### PR TITLE
Fix: skip NA values in intensities in transform_ibaq

### DIFF
--- a/quantmsio/operate/tools.py
+++ b/quantmsio/operate/tools.py
@@ -284,7 +284,7 @@ def transform_ibaq(df: pd.DataFrame) -> pd.DataFrame:
     # Check for NA in the "intensities" column
     if df["intensities"].isna().any():
         logging.warning(
-            "[transform_ibaq]: The 'intensities' column contain NaN values."
+            "[transform_ibaq]: The 'intensities' column contains NaN values."
         )
         df.dropna(subset=["intensities"], inplace=True)
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add NA value handling in `transform_ibaq` function

- Drop rows with NaN intensities before transformation

- Add warning log for NA detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Input DataFrame"] --> B["Check for NA values"]
  B --> C["Log warning if NA found"]
  C --> D["Drop NA rows"]
  D --> E["Continue transformation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tools.py</strong><dd><code>Add NA handling in transform_ibaq</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

quantmsio/operate/tools.py

<ul><li>Add NA value detection and warning logging<br> <li> Drop rows with NaN values in intensities column<br> <li> Prevent errors during DataFrame transformation</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms.io/pull/116/files#diff-05c29420816285e435c66766c1306a5e96c02fa947aeed094b5a18276e8af09e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

