### PR TITLE
Update MaxQuant class.

### DIFF
--- a/quantmsio/core/maxquant/maxquant.py
+++ b/quantmsio/core/maxquant/maxquant.py
@@ -1460,7 +1460,6 @@ class MaxQuant:
 
             best_match_row = None
             best_similarity = 0.0
-            best_tissue_candidate = None
 
             # Try matching each candidate part against SDRF tissues
             for tissue_candidate in tissue_candidates:
@@ -1468,7 +1467,7 @@ class MaxQuant:
                 if not tissue_normalized or len(tissue_normalized) < 3:
                     continue
 
-                for idx, row in sdrf_df.iterrows():
+                for _, row in sdrf_df.iterrows():
                     sdrf_tissue = row.get("characteristics[organism part]", "")
                     if pd.notna(sdrf_tissue):
                         sdrf_tissue_normalized = self._normalize_tissue_name(
@@ -1481,7 +1480,6 @@ class MaxQuant:
                         if similarity > best_similarity:
                             best_similarity = similarity
                             best_match_row = row
-                            best_tissue_candidate = tissue_candidate
 
             if best_match_row is not None and best_similarity > 0.5:
                 first_sdrf_sample = best_match_row["source name"]
@@ -1497,8 +1495,12 @@ class MaxQuant:
                 }
 
                 return virtual_record
-        except Exception:
-            pass
+        except (KeyError, AttributeError, ValueError) as e:
+            logger.debug(f"Tissue-based matching failed for {maxquant_sample}: {e}")
+        except Exception as e:
+            logger.warning(
+                f"Unexpected error in tissue matching for {maxquant_sample}: {e}"
+            )
 
         return None
 


### PR DESCRIPTION
### **User description**
## Improve MaxQuant Sample Matching with SDRF

### Problem
MaxQuant column names often fail to match SDRF sample IDs due to:
- Numerical format inconsistencies (e.g., "Sample-1" vs "Sample-01")
- Ambiguous SDRF record selection when multiple records have equal token matches
- Hardcoded tissue name normalizations limiting flexibility

### Solution
1. **Numerical normalization**: Strip leading zeros from numbers in both MaxQuant column names and SDRF tokens (e.g., "01" -> "1")
2. **Prioritize exact matches**: When multiple SDRF records have equal token match scores, prefer records with exact `source_name` matches
3. **Fuzzy tissue matching**: Replace hardcoded tissue mappings with fuzzy matching against SDRF `characteristics[organism part]`


___

### **PR Type**
Enhancement


___

### **Description**
- Normalize numbers by removing leading zeros in token matching

- Prioritize exact source_name matches when token scores are equal

- Add tissue-based fuzzy matching fallback for low-confidence matches

- Improve SDRF record selection with tissue similarity scoring


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MaxQuant Sample Name"] --> B["Tokenize & Normalize Numbers"]
  B --> C["Token-Based Matching"]
  C --> D{"Match Count > 0?"}
  D -->|Yes| E["Prefer Exact source_name"]
  D -->|No| F["Tissue-Based Fuzzy Matching"]
  E --> G["Return Best Record"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maxquant.py</strong><dd><code>Numerical normalization and tissue-based matching enhancement</code></dd></summary>
<hr>

quantmsio/core/maxquant/maxquant.py

<ul><li>Implement numerical normalization in <br><code>_preprocess_sdrf_for_optimization()</code> to strip leading zeros from digit <br>tokens<br> <li> Add numerical normalization in <code>_tokenize_intensity_suffix()</code> for <br>consistent token processing<br> <li> Enhance <code>_find_best_matching_record()</code> with exact source_name matching <br>priority and tissue-based fallback<br> <li> Add three new methods: <code>_try_tissue_based_matching()</code>, <br><code>_calculate_tissue_similarity()</code>, and <code>_normalize_tissue_name()</code> for fuzzy <br>tissue matching<br> <li> Update <code>_get_sample_accession_by_maxquant_name()</code> to pass <br>maxquant_sample parameter and handle -1 match count from tissue <br>matching</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms.io/pull/125/files#diff-8ddc745871856171e785652ff70c2c16f60028ce4a819ec510e60c28e3078e5c">+154/-6</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

