### PR TITLE
Update muData representation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ A Python package for working with mass spectrometry data in the QPX format.
 - **Validate** datasets against the canonical QPX schema
 - **Ontology** management for PSI-MS and PRIDE CV terms
 
+### MuData Export (quantification results only)
+
+QPX datasets can be exported to [MuData](https://mudata.readthedocs.io/) — the multi-modal container from the scverse ecosystem. This export is available **only for quantification results** (precursor/protein intensities and, optionally, protein expression and differential expression results).
+
+![QPX MuData Structure](docs/images/mudata-architecture.svg)
+
+```python
+ds = Dataset("path/to/PXD000000/")
+mdata = ds.to_mudata()              # auto-detects label & available modalities
+mdata.write("PXD000000.h5mu")       # serialize to HDF5
+```
+
+> Requires the optional `mudata` dependency: `pip install "qpx[mudata]"`
+
 ### Performance
 
 ![QPX Benchmark](docs/images/qpx-benchmark.svg)

--- a/docs/images/mudata-architecture.svg
+++ b/docs/images/mudata-architecture.svg
@@ -1,0 +1,231 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 1080" font-family="'Helvetica Neue', Arial, sans-serif">
+  <defs>
+    <filter id="s" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-opacity="0.08"/>
+    </filter>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#94a3b8"/>
+    </marker>
+  </defs>
+
+  <rect width="1400" height="1080" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="700" y="50" text-anchor="middle" font-size="34" font-weight="700" fill="#1e293b" letter-spacing="2">QPX MuData Structure</text>
+  <text x="700" y="80" text-anchor="middle" font-size="16" fill="#64748b" letter-spacing="2">Multi-modal proteomics container (scverse ecosystem)</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- OUTER MuData container -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <rect x="40" y="100" width="1320" height="940" rx="16" fill="#fdf4ff" stroke="#d8b4fe" stroke-width="2.5" filter="url(#s)"/>
+  <text x="700" y="136" text-anchor="middle" font-size="22" font-weight="700" fill="#7e22ce">MuData  (PXD000000)</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- mod["precursors"] — top left -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <rect x="70" y="160" width="610" height="310" rx="12" fill="#eff6ff" stroke="#93c5fd" stroke-width="2" filter="url(#s)"/>
+  <text x="375" y="192" text-anchor="middle" font-size="18" font-weight="700" fill="#1e40af">mod["precursors"]</text>
+  <text x="375" y="212" text-anchor="middle" font-size="12" fill="#3b82f6">AnnData  —  from feature.parquet via DuckDB</text>
+
+  <!-- obs axis label (rows) -->
+  <text x="88" y="245" font-size="11" font-weight="700" fill="#dc2626" letter-spacing="1">obs (rows)</text>
+  <text x="88" y="260" font-size="12" fill="#64748b">= MS runs</text>
+
+  <!-- var axis label (columns) -->
+  <text x="230" y="245" font-size="11" font-weight="700" fill="#059669" letter-spacing="1">var (columns)</text>
+  <text x="230" y="260" font-size="12" fill="#64748b">= precursor IDs (peptidoform|charge)</text>
+
+  <!-- Matrix X -->
+  <rect x="88" y="272" width="574" height="120" rx="8" fill="#dbeafe" stroke="#93c5fd" stroke-width="1"/>
+  <text x="375" y="300" text-anchor="middle" font-size="16" font-weight="700" fill="#1e40af">X  (sparse CSR, float32)</text>
+  <text x="375" y="322" text-anchor="middle" font-size="13" fill="#3b82f6">Intensity matrix for selected label (LFQ / TMT / ...)</text>
+
+  <!-- Row labels -->
+  <text x="100" y="350" font-size="11" fill="#64748b">run_001.raw</text>
+  <text x="100" y="366" font-size="11" fill="#64748b">run_002.raw</text>
+  <text x="100" y="382" font-size="11" fill="#94a3b8">...</text>
+
+  <!-- Col labels -->
+  <text x="240" y="350" font-size="11" fill="#64748b">PEPTK|2</text>
+  <text x="320" y="350" font-size="11" fill="#64748b">SEQNC|3</text>
+  <text x="400" y="350" font-size="11" fill="#94a3b8">...</text>
+
+  <!-- obs metadata -->
+  <rect x="88" y="398" width="260" height="58" rx="6" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
+  <text x="100" y="418" font-size="12" font-weight="600" fill="#dc2626">obs metadata (per run)</text>
+  <text x="100" y="436" font-size="11" fill="#64748b">run_accession, sample_accession, label,</text>
+  <text x="100" y="450" font-size="11" fill="#64748b">biological_replicate, technical_replicate, fraction, instrument</text>
+
+  <!-- var metadata -->
+  <rect x="370" y="398" width="292" height="58" rx="6" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="382" y="418" font-size="12" font-weight="600" fill="#059669">var metadata (per precursor)</text>
+  <text x="382" y="436" font-size="11" fill="#64748b">precursor_id index</text>
+  <text x="382" y="450" font-size="11" fill="#64748b">(peptidoform|charge)</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- mod["proteins"] — top right -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <rect x="720" y="160" width="610" height="310" rx="12" fill="#eff6ff" stroke="#93c5fd" stroke-width="2" filter="url(#s)"/>
+  <text x="1025" y="192" text-anchor="middle" font-size="18" font-weight="700" fill="#1e40af">mod["proteins"]</text>
+  <text x="1025" y="212" text-anchor="middle" font-size="12" fill="#3b82f6">AnnData  —  from pg.parquet via DuckDB</text>
+
+  <!-- obs axis label -->
+  <text x="738" y="245" font-size="11" font-weight="700" fill="#dc2626" letter-spacing="1">obs (rows)</text>
+  <text x="738" y="260" font-size="12" fill="#64748b">= MS runs</text>
+
+  <!-- var axis label -->
+  <text x="880" y="245" font-size="11" font-weight="700" fill="#059669" letter-spacing="1">var (columns)</text>
+  <text x="880" y="260" font-size="12" fill="#64748b">= anchor proteins (UniProt accession)</text>
+
+  <!-- Matrix X -->
+  <rect x="738" y="272" width="574" height="120" rx="8" fill="#dbeafe" stroke="#93c5fd" stroke-width="1"/>
+  <text x="1025" y="300" text-anchor="middle" font-size="16" font-weight="700" fill="#1e40af">X  (sparse CSR, float32)</text>
+  <text x="1025" y="322" text-anchor="middle" font-size="13" fill="#3b82f6">Protein group intensity for selected label</text>
+
+  <!-- Row labels -->
+  <text x="750" y="350" font-size="11" fill="#64748b">run_001.raw</text>
+  <text x="750" y="366" font-size="11" fill="#64748b">run_002.raw</text>
+  <text x="750" y="382" font-size="11" fill="#94a3b8">...</text>
+
+  <!-- Col labels -->
+  <text x="880" y="350" font-size="11" fill="#64748b">P12345</text>
+  <text x="950" y="350" font-size="11" fill="#64748b">Q67890</text>
+  <text x="1020" y="350" font-size="11" fill="#94a3b8">...</text>
+
+  <!-- obs metadata -->
+  <rect x="738" y="398" width="260" height="58" rx="6" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
+  <text x="750" y="418" font-size="12" font-weight="600" fill="#dc2626">obs metadata (per run)</text>
+  <text x="750" y="436" font-size="11" fill="#64748b">run_accession, sample_accession, label,</text>
+  <text x="750" y="450" font-size="11" fill="#64748b">biological_replicate, technical_replicate, fraction, instrument</text>
+
+  <!-- var metadata -->
+  <rect x="1020" y="398" width="292" height="58" rx="6" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="1032" y="418" font-size="12" font-weight="600" fill="#059669">var metadata (per protein)</text>
+  <text x="1032" y="436" font-size="11" fill="#64748b">anchor_protein index,</text>
+  <text x="1032" y="450" font-size="11" fill="#64748b">gene_name</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- mod["expression"] — bottom left -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <rect x="70" y="495" width="610" height="340" rx="12" fill="#f0fdf4" stroke="#86efac" stroke-width="2" filter="url(#s)"/>
+  <text x="375" y="527" text-anchor="middle" font-size="18" font-weight="700" fill="#16a34a">mod["expression"]</text>
+  <text x="375" y="547" text-anchor="middle" font-size="12" fill="#16a34a">AnnData  —  from .pe.h5ad / .pe.zarr  (optional)</text>
+
+  <!-- obs axis label -->
+  <text x="88" y="578" font-size="11" font-weight="700" fill="#dc2626" letter-spacing="1">obs (rows)</text>
+  <text x="88" y="593" font-size="12" fill="#64748b">= SAMPLES (sample_accession)</text>
+
+  <!-- var axis label -->
+  <text x="300" y="578" font-size="11" font-weight="700" fill="#059669" letter-spacing="1">var (columns)</text>
+  <text x="300" y="593" font-size="12" fill="#64748b">= proteins (UniProt accession)</text>
+
+  <!-- Matrix X -->
+  <rect x="88" y="605" width="574" height="80" rx="8" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="375" y="632" text-anchor="middle" font-size="16" font-weight="700" fill="#16a34a">X  (primary quantification)</text>
+  <text x="375" y="652" text-anchor="middle" font-size="13" fill="#16a34a">ibaq_log, maxlfq, tmt_intensity, ...</text>
+
+  <!-- Row labels -->
+  <text x="100" y="673" font-size="11" fill="#64748b">sample_001</text>
+  <text x="100" y="687" font-size="11" fill="#64748b">sample_002</text>
+
+  <!-- Col labels -->
+  <text x="300" y="673" font-size="11" fill="#64748b">P12345</text>
+  <text x="370" y="673" font-size="11" fill="#64748b">Q67890</text>
+  <text x="440" y="673" font-size="11" fill="#94a3b8">...</text>
+
+  <!-- Layers -->
+  <rect x="88" y="698" width="574" height="58" rx="6" fill="#fef9c3" stroke="#fde047" stroke-width="1"/>
+  <text x="100" y="718" font-size="12" font-weight="600" fill="#a16207">layers (alternative quantifications)</text>
+  <text x="100" y="735" font-size="11" fill="#64748b">ibaq_raw, ibaq_ppb, copies_per_cell, concentration_nm, ...</text>
+
+  <!-- obs metadata -->
+  <rect x="88" y="766" width="260" height="55" rx="6" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
+  <text x="100" y="786" font-size="12" font-weight="600" fill="#dc2626">obs metadata (per sample)</text>
+  <text x="100" y="802" font-size="11" fill="#64748b">organism, tissue, disease, cell_type</text>
+
+  <!-- var metadata -->
+  <rect x="370" y="766" width="292" height="55" rx="6" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="382" y="786" font-size="12" font-weight="600" fill="#059669">var metadata (per protein)</text>
+  <text x="382" y="802" font-size="11" fill="#64748b">protein accession index</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- mod["differential"] — bottom right -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <rect x="720" y="495" width="610" height="340" rx="12" fill="#fff7ed" stroke="#fdba74" stroke-width="2" filter="url(#s)"/>
+  <text x="1025" y="527" text-anchor="middle" font-size="18" font-weight="700" fill="#c2410c">mod["differential"]</text>
+  <text x="1025" y="547" text-anchor="middle" font-size="12" fill="#c2410c">AnnData  —  from .de.h5ad / .de.zarr  (optional)</text>
+
+  <!-- obs axis label -->
+  <text x="738" y="578" font-size="11" font-weight="700" fill="#dc2626" letter-spacing="1">obs (rows)</text>
+  <text x="738" y="593" font-size="12" fill="#64748b">= CONTRASTS (e.g. cancer_vs_normal)</text>
+
+  <!-- var axis label -->
+  <text x="960" y="578" font-size="11" font-weight="700" fill="#059669" letter-spacing="1">var (columns)</text>
+  <text x="960" y="593" font-size="12" fill="#64748b">= proteins (UniProt accession)</text>
+
+  <!-- Matrix X -->
+  <rect x="738" y="605" width="574" height="80" rx="8" fill="#ffedd5" stroke="#fdba74" stroke-width="1"/>
+  <text x="1025" y="632" text-anchor="middle" font-size="16" font-weight="700" fill="#c2410c">X  =  log2FC</text>
+  <text x="1025" y="652" text-anchor="middle" font-size="13" fill="#c2410c">log2 fold change (contrasts x proteins)</text>
+
+  <!-- Row labels -->
+  <text x="750" y="673" font-size="11" fill="#64748b">cancer_vs_normal</text>
+  <text x="750" y="687" font-size="11" fill="#64748b">treated_vs_ctrl</text>
+
+  <!-- Col labels -->
+  <text x="960" y="673" font-size="11" fill="#64748b">P12345</text>
+  <text x="1030" y="673" font-size="11" fill="#64748b">Q67890</text>
+  <text x="1100" y="673" font-size="11" fill="#94a3b8">...</text>
+
+  <!-- Layers -->
+  <rect x="738" y="698" width="574" height="58" rx="6" fill="#fef9c3" stroke="#fde047" stroke-width="1"/>
+  <text x="750" y="718" font-size="12" font-weight="600" fill="#a16207">layers (statistical results)</text>
+  <text x="750" y="735" font-size="11" fill="#64748b">pvals_adj, scores, pvals, se</text>
+
+  <!-- obs metadata -->
+  <rect x="738" y="766" width="290" height="55" rx="6" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
+  <text x="750" y="786" font-size="12" font-weight="600" fill="#dc2626">obs (per contrast)</text>
+  <text x="750" y="802" font-size="11" fill="#64748b">contrast identifier index only</text>
+
+  <!-- var metadata -->
+  <rect x="1050" y="766" width="262" height="55" rx="6" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="1062" y="786" font-size="12" font-weight="600" fill="#059669">var metadata (per protein)</text>
+  <text x="1062" y="802" font-size="11" fill="#64748b">protein accession index</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- CROSS-MODALITY: varp["feature_mapping"] + uns -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <rect x="70" y="860" width="780" height="80" rx="10" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5" filter="url(#s)"/>
+  <text x="88" y="888" font-size="16" font-weight="700" fill="#7c3aed">varp["feature_mapping"]</text>
+  <text x="88" y="908" font-size="13" fill="#64748b">Symmetric boolean sparse CSR matrix over all var IDs (precursor IDs + protein IDs)</text>
+  <text x="88" y="926" font-size="13" fill="#64748b">Non-zero entry [i, j] = precursor i maps to protein j (and vice versa)</text>
+
+  <rect x="880" y="860" width="450" height="80" rx="10" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5" filter="url(#s)"/>
+  <text x="898" y="888" font-size="16" font-weight="700" fill="#7c3aed">uns (from dataset.parquet)</text>
+  <text x="898" y="908" font-size="13" fill="#64748b">project_accession, project_title, project_description,</text>
+  <text x="898" y="926" font-size="13" fill="#64748b">pubmed_id, software_name, software_version, creation_date</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- LEGEND at bottom -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <rect x="70" y="960" width="1260" height="65" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="4"/>
+  <text x="88" y="985" font-size="13" font-weight="600" fill="#64748b" letter-spacing="1">AXES SUMMARY</text>
+
+  <!-- Legend items -->
+  <rect x="250" y="972" width="14" height="14" rx="2" fill="#dc2626"/>
+  <text x="272" y="984" font-size="13" fill="#1e293b" font-weight="600">obs (rows):</text>
+  <text x="366" y="984" font-size="13" fill="#64748b">runs (precursors, proteins) | samples (expression) | contrasts (differential)</text>
+
+  <rect x="250" y="998" width="14" height="14" rx="2" fill="#059669"/>
+  <text x="272" y="1010" font-size="13" fill="#1e293b" font-weight="600">var (cols):</text>
+  <text x="362" y="1010" font-size="13" fill="#64748b">precursor IDs (precursors) | proteins (proteins, expression, differential)</text>
+
+  <rect x="880" y="972" width="14" height="14" rx="2" fill="#2563eb"/>
+  <text x="902" y="984" font-size="13" fill="#1e293b" font-weight="600">X:</text>
+  <text x="920" y="984" font-size="13" fill="#64748b">primary data matrix (intensity / expression / log2FC)</text>
+
+  <rect x="880" y="998" width="14" height="14" rx="2" fill="#a16207"/>
+  <text x="902" y="1010" font-size="13" fill="#1e293b" font-weight="600">layers:</text>
+  <text x="960" y="1010" font-size="13" fill="#64748b">alternative quantifications or statistical results</text>
+
+</svg>

--- a/docs/images/qpx-architecture.svg
+++ b/docs/images/qpx-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 920" font-family="'Helvetica Neue', Arial, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1000" font-family="'Helvetica Neue', Arial, sans-serif">
   <defs>
     <filter id="s" x="-2%" y="-2%" width="104%" height="108%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-opacity="0.08"/>
@@ -9,7 +9,7 @@
   </defs>
 
   <!-- White background -->
-  <rect width="1600" height="920" fill="#ffffff"/>
+  <rect width="1600" height="1000" fill="#ffffff"/>
 
   <!-- Title -->
   <text x="800" y="58" text-anchor="middle" font-size="38" font-weight="700" fill="#1e293b" letter-spacing="2">QPX</text>
@@ -124,12 +124,12 @@
   <text x="367" y="606" text-anchor="middle" font-size="13" font-weight="600" fill="white">pepmap.parquet</text>
 
   <rect x="460" y="586" width="185" height="30" rx="6" fill="#d97706" filter="url(#s)"/>
-  <text x="552" y="606" text-anchor="middle" font-size="13" font-weight="600" fill="white">differential.h5ad</text>
+  <text x="552" y="606" text-anchor="middle" font-size="13" font-weight="600" fill="white">*.de.h5ad</text>
 
   <rect x="660" y="586" width="155" height="30" rx="6" fill="#d97706" filter="url(#s)"/>
-  <text x="737" y="606" text-anchor="middle" font-size="13" font-weight="600" fill="white">ae.h5ad</text>
+  <text x="737" y="606" text-anchor="middle" font-size="13" font-weight="600" fill="white">*.pe.h5ad</text>
 
-  <text x="850" y="606" font-size="12" fill="#94a3b8">AnnData for DE &amp; absolute expression</text>
+  <text x="850" y="606" font-size="12" fill="#94a3b8">MuData for DE &amp; protein expression</text>
 
   <!-- ═══════════════════════════════════════════════════ -->
   <!-- ROW 4: TRANSFORMS + VIEWS (side by side) -->
@@ -193,9 +193,39 @@
   <rect x="780" y="790" width="740" height="52" rx="10" fill="#ecfeff" stroke="#67e8f9" stroke-width="1.5" filter="url(#s)"/>
   <text x="800" y="822" font-size="14" font-weight="700" fill="#0891b2" letter-spacing="1">INTEGRATIONS</text>
 
-  <text x="955" y="822" font-size="15" font-weight="500" fill="#1e293b">Python / Pandas</text>
-  <text x="1100" y="822" font-size="15" font-weight="500" fill="#1e293b">AnnData / Scanpy</text>
-  <text x="1260" y="822" font-size="15" font-weight="500" fill="#1e293b">R / Arrow</text>
-  <text x="1400" y="822" font-size="15" font-weight="500" fill="#1e293b">DuckDB SQL</text>
+  <text x="920" y="822" font-size="14" font-weight="500" fill="#1e293b">Python / Pandas</text>
+  <text x="1050" y="822" font-size="14" font-weight="500" fill="#1e293b">MuData / AnnData</text>
+  <text x="1190" y="822" font-size="14" font-weight="500" fill="#1e293b">Scanpy / Muon</text>
+  <text x="1310" y="822" font-size="14" font-weight="500" fill="#1e293b">R / Arrow</text>
+  <text x="1420" y="822" font-size="14" font-weight="500" fill="#1e293b">DuckDB SQL</text>
+
+  <!-- ═══════════════════════════════════════════════════ -->
+  <!-- ROW 6: MuData EXPORT -->
+  <!-- ═══════════════════════════════════════════════════ -->
+  <line x1="800" y1="842" x2="800" y2="870" stroke="#94a3b8" stroke-width="2" marker-end="url(#arr)"/>
+
+  <rect x="80" y="878" width="1440" height="100" rx="14" fill="#fdf4ff" stroke="#e879f9" stroke-width="2" filter="url(#s)"/>
+  <text x="800" y="908" text-anchor="middle" font-size="20" font-weight="700" fill="#7e22ce" letter-spacing="1">MuData EXPORT</text>
+  <text x="800" y="928" text-anchor="middle" font-size="13" fill="#a855f7">ds.to_mudata()  →  multi-modal scverse container  →  .h5mu / .zarr.mu</text>
+
+  <rect x="120" y="940" width="160" height="26" rx="5" fill="#a855f7"/>
+  <text x="200" y="958" text-anchor="middle" font-size="12" font-weight="600" fill="white">mod["precursors"]</text>
+
+  <rect x="300" y="940" width="150" height="26" rx="5" fill="#a855f7"/>
+  <text x="375" y="958" text-anchor="middle" font-size="12" font-weight="600" fill="white">mod["proteins"]</text>
+
+  <rect x="470" y="940" width="170" height="26" rx="5" fill="#a855f7"/>
+  <text x="555" y="958" text-anchor="middle" font-size="12" font-weight="600" fill="white">mod["expression"]</text>
+
+  <rect x="660" y="940" width="170" height="26" rx="5" fill="#a855f7"/>
+  <text x="745" y="958" text-anchor="middle" font-size="12" font-weight="600" fill="white">mod["differential"]</text>
+
+  <rect x="850" y="940" width="185" height="26" rx="5" fill="#7e22ce"/>
+  <text x="942" y="958" text-anchor="middle" font-size="12" font-weight="600" fill="white">varp["feature_mapping"]</text>
+
+  <rect x="1055" y="940" width="110" height="26" rx="5" fill="#7e22ce"/>
+  <text x="1110" y="958" text-anchor="middle" font-size="12" font-weight="600" fill="white">uns metadata</text>
+
+  <text x="1230" y="958" font-size="12" fill="#94a3b8">scverse / scanpy / muon</text>
 
 </svg>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for MuData export functionality, explaining how to export QPX datasets to MuData format with support for quantification results (intensities and optional expression data). Includes installation instructions for the optional `mudata` extra.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->