### PR TITLE
feat: Collections and Collection Indexes spec

### DIFF
--- a/docs/spec/collection-indexes.md
+++ b/docs/spec/collection-indexes.md
@@ -4,7 +4,7 @@ An **index** is a materialized, pre-computed data structure that enables fast se
 
 ## Why Indexes?
 
-Consider a collection with 72 datasets totaling 1.18 TB of PSM data. Without an index, searching for a peptide means reading all 1.18 TB:
+Consider a large collection with dozens of datasets totaling hundreds of gigabytes or more of PSM data. Without an index, searching for a peptide means scanning every file:
 
 ```python
 # Without index: scans ALL parquet files (~minutes)
@@ -60,7 +60,7 @@ Each row in the peptide index represents one (peptide, peptidoform, dataset) com
 
 ```python
 # Using the collection API
-coll = qpx.open_collection("/data/msnet/")
+coll = qpx.open_collection("/data/my_collection/")
 
 # Search by exact sequence
 results = coll.index("peptide").search("PEPTIDEK")
@@ -104,7 +104,7 @@ Indexes are built from the collection's QPX datasets using a batch process:
 
 ```python
 # Build the peptide index for the entire collection
-coll = qpx.open_collection("/data/msnet/")
+coll = qpx.open_collection("/data/my_collection/")
 coll.build_index("peptide")
 ```
 
@@ -171,9 +171,9 @@ Indexes are lightweight compared to the source data:
 
 | Component | Size | Notes |
 |-----------|------|-------|
-| Source PSM data | ~1.18 TB | The actual data |
-| Peptide index | ~0.6 GB | ~0.05% of source |
-| Protein index (future) | ~0.1 GB | Estimated |
+| Source PSM data | Varies (GBs to TBs) | The actual data |
+| Peptide index | ~0.05% of source | Typically a few hundred MB for TB-scale collections |
+| Protein index (future) | ~0.01% of source | Estimated |
 
 ## Conventions
 

--- a/docs/spec/collection-indexes.md
+++ b/docs/spec/collection-indexes.md
@@ -1,10 +1,10 @@
 # Collection Indexes
 
-An **index** is a materialized, pre-computed data structure that enables fast search across all datasets in a [collection](collection.md). Unlike the collection itself (which is programmatic), indexes are **persisted as Parquet files** because the alternative -- scanning terabytes of PSM data for every query -- is impractical.
+An **index** is a materialized, pre-computed data structure that enables fast search across all datasets in a [collection](collection.md). Unlike the collection itself (which is programmatic), indexes are **persisted as Parquet files** because the alternative -- scanning the full collection for every query -- is impractical at scale.
 
 ## Why Indexes?
 
-Consider a large collection with dozens of datasets totaling hundreds of gigabytes or more of PSM data. Without an index, searching for a peptide means scanning every file:
+Consider a collection with dozens of datasets. Without an index, searching for a peptide means scanning every PSM file; finding a differentially expressed protein means opening every DE view. With an index, the query reads only a small, targeted partition:
 
 ```python
 # Without index: scans ALL parquet files (~minutes)
@@ -14,34 +14,32 @@ coll.sql("SELECT * FROM psm WHERE sequence = 'PEPTIDEK'")
 coll.index("peptide").search("PEPTIDEK")
 ```
 
-An index trades **one-time build cost** (hours) for **instant queries** (milliseconds). Think of it as a library catalog: the catalog is small and fast to search, and it tells you which book (dataset/file) to open.
+An index trades **one-time build cost** (minutes to hours) for **instant queries** (milliseconds). Think of it as a library catalog: the catalog is small and fast to search, and it tells you which book (dataset) to open.
 
 ## Index Types
 
-QPX defines a standard structure for indexes. The initial spec includes one index type, with the framework designed to support future types.
+QPX defines a standard framework for collection indexes. Each index type materializes data from a specific QPX view into a Hive-partitioned Parquet structure optimized for its search pattern.
 
 ### Peptide Index
 
-Maps peptide sequences to the datasets and files that contain them.
+Maps peptide sequences to the datasets that contain them. Built from `psm.parquet` across all datasets.
 
-**Stored at**: `{collection_root}/_index/peptide/`
-
-**Partitioned by**: First two amino acids of the sequence (Hive-style), yielding ~400 partitions (`AA`, `AC`, `AD`, ..., `YW`, `YY`). Each partition is typically 1-5 MB compressed.
+**Source view**: PSM  
+**Stored at**: `_index/peptide/`  
+**Partitioned by**: First two amino acids of the sequence (~400 partitions)
 
 ```text
-_index/
-└── peptide/
-    ├── sequence_prefix=AA/data.parquet
-    ├── sequence_prefix=AC/data.parquet
-    ├── sequence_prefix=AD/data.parquet
-    ├── ...
-    ├── sequence_prefix=PE/data.parquet    ← "PEPTIDEK" lives here
-    └── sequence_prefix=YY/data.parquet
+_index/peptide/
+├── sequence_prefix=AA/data.parquet
+├── sequence_prefix=AC/data.parquet
+├── ...
+├── sequence_prefix=PE/data.parquet    # "PEPTIDEK" lives here
+└── sequence_prefix=YY/data.parquet
 ```
 
 #### Schema
 
-Each row in the peptide index represents one (peptide, peptidoform, dataset) combination:
+Each row represents one (peptide, peptidoform, dataset) combination:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -53,22 +51,13 @@ Each row in the peptide index represents one (peptide, peptidoform, dataset) com
 | `best_pep` | float64 | Best (lowest) posterior error probability across all PSMs |
 | `protein_accessions` | array[string] | All proteins this peptide maps to in this dataset |
 
-!!! note "What is NOT in the index"
-    The index does not store spectral data (m/z arrays, intensities), per-PSM details, or run-level information. It is a lightweight pointer -- "this peptide exists in this dataset with this confidence." To get full PSM details, query the dataset's `psm.parquet` directly.
-
 #### Querying
 
 ```python
-# Using the collection API
 coll = qpx.open_collection("/data/my_collection/")
 
 # Search by exact sequence
 results = coll.index("peptide").search("PEPTIDEK")
-# Returns DataFrame:
-#   project_accession | peptidoform           | charge_states | spectra_count | best_pep
-#   PXD000561         | PEPTIDEK              | [2, 3]        | 142           | 1.2e-15
-#   PXD000561         | PEP(Phospho)TIDEK     | [2]           | 8             | 3.4e-06
-#   PXD002137         | PEPTIDEK              | [2, 3, 4]     | 891           | 8.7e-22
 
 # Search by prefix (wildcard)
 results = coll.index("peptide").search_prefix("PEPTID")
@@ -77,63 +66,176 @@ results = coll.index("peptide").search_prefix("PEPTID")
 results = coll.index("peptide").search_peptidoform("PEP(Phospho)TIDEK")
 ```
 
-Under the hood, this translates to:
+#### Build Algorithm
 
 ```sql
--- DuckDB reads only the 'PE' partition (~1-5 MB), not the full index
-SELECT *
-FROM read_parquet('_index/peptide/sequence_prefix=PE/data.parquet')
-WHERE sequence = 'PEPTIDEK'
-```
-
-### Future Index Types
-
-The index framework is designed to be extensible. Potential future indexes:
-
-| Index | Partition key | Use case |
-|-------|--------------|----------|
-| **protein** | First 2 chars of accession | "Which datasets identified P04637 (TP53)?" |
-| **spectrum** | Binned precursor m/z | "Find spectra matching this m/z and charge" |
-| **modification** | Modification name | "Which datasets have phosphorylation data?" |
-
-Each would follow the same pattern: Hive-partitioned Parquet under `_index/{type}/`.
-
-## Building Indexes
-
-Indexes are built from the collection's QPX datasets using a batch process:
-
-```python
-# Build the peptide index for the entire collection
-coll = qpx.open_collection("/data/my_collection/")
-coll.build_index("peptide")
-```
-
-This:
-
-1. Reads `psm.parquet` from every dataset in the collection.
-2. Filters out decoy PSMs (`is_decoy = false`).
-3. Aggregates per (sequence, peptidoform, project_accession).
-4. Partitions by `sequence_prefix` (first 2 amino acids).
-5. Writes Hive-partitioned Parquet files to `_index/peptide/`.
-
-### Build Algorithm
-
-```sql
--- Pseudocode for the peptide index build
-INSERT INTO _index/peptide/
 SELECT
-    sequence,
-    peptidoform,
-    project_accession,
-    LIST(DISTINCT charge)                    AS charge_states,
-    COUNT(*)                                 AS spectra_count,
-    MIN(posterior_error_probability)          AS best_pep,
-    LIST(DISTINCT UNNEST(protein_accessions)) AS protein_accessions,
-    LEFT(sequence, 2)                        AS sequence_prefix
+    sequence, peptidoform, project_accession,
+    LIST(DISTINCT charge)                     AS charge_states,
+    COUNT(*)                                  AS spectra_count,
+    MIN(posterior_error_probability)           AS best_pep,
+    LIST(DISTINCT UNNEST(protein_accessions))  AS protein_accessions,
+    LEFT(sequence, 2)                         AS sequence_prefix
 FROM psm
 WHERE is_decoy = false
 GROUP BY sequence, peptidoform, project_accession
 ```
+
+### Protein Index
+
+Maps protein accessions to the datasets that identified or quantified them. Built from `pg.parquet` across all datasets.
+
+**Source view**: Protein Group (PG)  
+**Stored at**: `_index/protein/`  
+**Partitioned by**: First two characters of the anchor protein accession (~300-400 partitions for UniProt-style accessions)
+
+```text
+_index/protein/
+├── accession_prefix=A0/data.parquet
+├── accession_prefix=P0/data.parquet   # "P04637" (TP53) lives here
+├── accession_prefix=Q9/data.parquet
+└── ...
+```
+
+#### Schema
+
+Each row represents one (protein, dataset) combination:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `anchor_protein` | string | Representative protein accession for the group |
+| `protein_accessions` | array[string] | All accessions in the protein group |
+| `project_accession` | string | Dataset identifier |
+| `gg_names` | array[string] | Gene names associated with the protein group |
+| `global_qvalue` | float64 | Protein-level global q-value |
+| `num_peptides` | int32 | Number of distinct peptides supporting the protein group |
+| `num_runs` | int32 | Number of MS runs where the protein was quantified |
+
+#### Querying
+
+```python
+# Find all datasets that identified TP53
+results = coll.index("protein").search("P04637")
+
+# Search by gene name (requires scanning gene name column within partitions)
+results = coll.index("protein").search_gene("TP53")
+
+# Find all datasets with a protein family (prefix search)
+results = coll.index("protein").search_prefix("P046")
+```
+
+#### Build Algorithm
+
+```sql
+SELECT
+    anchor_protein, protein_accessions, project_accession,
+    gg_names, global_qvalue,
+    num_peptides, num_unique_peptides,
+    COUNT(DISTINCT run_file_name) AS num_runs,
+    LEFT(anchor_protein, 2)       AS accession_prefix
+FROM pg
+GROUP BY anchor_protein, protein_accessions, project_accession,
+         gg_names, global_qvalue, num_peptides, num_unique_peptides
+```
+
+### Differential Expression Index
+
+Maps proteins to their differential expression results across studies. Built from differential expression (DE) views. Enables meta-analysis queries like "which proteins are consistently up-regulated in cancer studies?"
+
+**Source view**: Differential Expression (DE)  
+**Stored at**: `_index/de/`  
+**Partitioned by**: First two characters of the protein accession
+
+```text
+_index/de/
+├── accession_prefix=A0/data.parquet
+├── accession_prefix=P0/data.parquet
+└── ...
+```
+
+#### Schema
+
+Each row represents one (protein, contrast, dataset) combination:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `protein_accession` | string | Protein accession |
+| `gene_name` | string, null | Gene name |
+| `project_accession` | string | Dataset identifier |
+| `contrast` | string | Comparison label (e.g., "disease_vs_control") |
+| `log2_fold_change` | float64 | Log2 fold change |
+| `adj_pvalue` | float64 | Adjusted p-value (BH or similar) |
+| `regulation` | string | "up", "down", or "ns" (not significant) |
+| `organisms` | array[string] | Organisms in this study (from sample metadata) |
+
+#### Querying
+
+```python
+# Which studies show TP53 as differentially expressed?
+results = coll.index("de").search("P04637")
+#   project_accession | contrast              | log2fc | adj_pvalue | regulation
+#   PXD000561         | tumor_vs_normal       | 2.3    | 1.2e-08    | up
+#   PXD002137         | treatment_vs_control  | -0.8   | 0.03       | down
+
+# Meta-analysis: proteins consistently up-regulated across 3+ studies
+results = coll.index("de").search_consistent(
+    min_studies=3,
+    direction="up",
+    adj_pvalue_cutoff=0.05,
+)
+
+# Find all DE results for a gene
+results = coll.index("de").search_gene("BRCA1")
+```
+
+#### Build Algorithm
+
+```sql
+SELECT
+    protein_accession, gene_name, project_accession,
+    contrast, log2_fold_change, adj_pvalue,
+    CASE
+        WHEN adj_pvalue < 0.05 AND log2_fold_change > 0 THEN 'up'
+        WHEN adj_pvalue < 0.05 AND log2_fold_change < 0 THEN 'down'
+        ELSE 'ns'
+    END AS regulation,
+    organisms,
+    LEFT(protein_accession, 2) AS accession_prefix
+FROM de
+JOIN sample USING (project_accession)
+```
+
+### Future Index Types
+
+The framework supports additional index types following the same pattern:
+
+| Index | Source view | Partition key | Use case |
+|-------|-----------|--------------|----------|
+| **spectrum** | MZ | Binned precursor m/z | "Find spectra matching this m/z and charge" |
+| **modification** | PSM/Feature | Modification name | "Which datasets have phosphorylation data?" |
+| **sample** | Sample | Organism/tissue | "Find all liver tissue datasets" |
+
+## Building Indexes
+
+```python
+coll = qpx.open_collection("/data/my_collection/")
+
+# Build a specific index
+coll.build_index("peptide")
+coll.build_index("protein")
+coll.build_index("de")
+
+# Build all available indexes
+coll.build_all_indexes()
+```
+
+The build process for each index:
+
+1. Reads the source view from every dataset in the collection.
+2. Applies index-specific filters (e.g., `is_decoy = false` for peptide index).
+3. Aggregates per the index schema's grouping key.
+4. Partitions by the index's partition column.
+5. Writes Hive-partitioned Parquet files to `_index/{type}/`.
 
 ### Rebuilding
 
@@ -154,9 +256,10 @@ Each index stores a metadata file at `_index/{type}/_metadata.json`:
 ```json
 {
     "index_type": "peptide",
+    "source_view": "psm",
     "qpx_version": "1.0",
     "built_at": "2026-04-08T14:30:00Z",
-    "datasets_included": ["PXD000561", "PXD002137", "..."],
+    "datasets_included": ["PXD000561", "PXD002137"],
     "total_entries": 14400000,
     "partitions": 400,
     "compression": "zstd"
@@ -169,17 +272,18 @@ The `datasets_included` list enables staleness detection: if the current collect
 
 Indexes are lightweight compared to the source data:
 
-| Component | Size | Notes |
-|-----------|------|-------|
-| Source PSM data | Varies (GBs to TBs) | The actual data |
-| Peptide index | ~0.05% of source | Typically a few hundred MB for TB-scale collections |
-| Protein index (future) | ~0.01% of source | Estimated |
+| Index type | Typical size | Notes |
+|-----------|-------------|-------|
+| Peptide | ~0.05% of PSM data | Aggregates millions of PSMs into unique peptide-dataset pairs |
+| Protein | ~0.01% of PG data | One row per protein group per dataset |
+| DE | ~0.02% of DE data | One row per protein per contrast per dataset |
 
 ## Conventions
 
 - Indexes live under `_index/` at the collection root.
 - The `_` prefix signals "infrastructure, not a dataset" -- collection discovery skips it.
-- Each index type gets its own subdirectory: `_index/peptide/`, `_index/protein/`, etc.
+- Each index type gets its own subdirectory: `_index/peptide/`, `_index/protein/`, `_index/de/`.
 - Partition column names use the `{field}_prefix` naming pattern.
 - Index Parquet files use ZSTD compression.
 - Index metadata is stored as `_metadata.json` (not Parquet) for easy inspection.
+- Each index declares its `source_view` in metadata, linking it to the QPX view it materializes.

--- a/docs/spec/collection-indexes.md
+++ b/docs/spec/collection-indexes.md
@@ -24,9 +24,11 @@ QPX defines a standard framework for collection indexes. Each index type materia
 
 Maps peptide sequences to the datasets that contain them. Built from `psm.parquet` across all datasets.
 
-**Source view**: PSM  
-**Stored at**: `_index/peptide/`  
-**Partitioned by**: First two amino acids of the sequence (~400 partitions)
+| | |
+|---|---|
+| **Source view** | PSM |
+| **Stored at** | `_index/peptide/` |
+| **Partitioned by** | First two amino acids of the sequence (~400 partitions) |
 
 ```text
 _index/peptide/
@@ -85,9 +87,11 @@ GROUP BY sequence, peptidoform, project_accession
 
 Maps protein accessions to the datasets that identified or quantified them. Built from `pg.parquet` across all datasets.
 
-**Source view**: Protein Group (PG)  
-**Stored at**: `_index/protein/`  
-**Partitioned by**: First two characters of the anchor protein accession (~300-400 partitions for UniProt-style accessions)
+| | |
+|---|---|
+| **Source view** | Protein Group (PG) |
+| **Stored at** | `_index/protein/` |
+| **Partitioned by** | First two characters of the anchor protein accession (~300-400 partitions) |
 
 ```text
 _index/protein/
@@ -130,21 +134,23 @@ results = coll.index("protein").search_prefix("P046")
 SELECT
     anchor_protein, protein_accessions, project_accession,
     gg_names, global_qvalue,
-    num_peptides, num_unique_peptides,
+    num_peptides,
     COUNT(DISTINCT run_file_name) AS num_runs,
     LEFT(anchor_protein, 2)       AS accession_prefix
 FROM pg
 GROUP BY anchor_protein, protein_accessions, project_accession,
-         gg_names, global_qvalue, num_peptides, num_unique_peptides
+         gg_names, global_qvalue, num_peptides
 ```
 
 ### Differential Expression Index
 
 Maps proteins to their differential expression results across studies. Built from differential expression (DE) views. Enables meta-analysis queries like "which proteins are consistently up-regulated in cancer studies?"
 
-**Source view**: Differential Expression (DE)  
-**Stored at**: `_index/de/`  
-**Partitioned by**: First two characters of the protein accession
+| | |
+|---|---|
+| **Source view** | Differential Expression (DE) |
+| **Stored at** | `_index/de/` |
+| **Partitioned by** | First two characters of the protein accession |
 
 ```text
 _index/de/
@@ -199,10 +205,14 @@ SELECT
         WHEN adj_pvalue < 0.05 AND log2_fold_change < 0 THEN 'down'
         ELSE 'ns'
     END AS regulation,
-    organisms,
+    s.organisms,
     LEFT(protein_accession, 2) AS accession_prefix
 FROM de
-JOIN sample USING (project_accession)
+JOIN (
+    SELECT project_accession, LIST(DISTINCT organism) AS organisms
+    FROM sample
+    GROUP BY project_accession
+) s USING (project_accession)
 ```
 
 ### Future Index Types

--- a/docs/spec/collection-indexes.md
+++ b/docs/spec/collection-indexes.md
@@ -1,0 +1,185 @@
+# Collection Indexes
+
+An **index** is a materialized, pre-computed data structure that enables fast search across all datasets in a [collection](collection.md). Unlike the collection itself (which is programmatic), indexes are **persisted as Parquet files** because the alternative -- scanning terabytes of PSM data for every query -- is impractical.
+
+## Why Indexes?
+
+Consider a collection with 72 datasets totaling 1.18 TB of PSM data. Without an index, searching for a peptide means reading all 1.18 TB:
+
+```python
+# Without index: scans ALL parquet files (~minutes)
+coll.sql("SELECT * FROM psm WHERE sequence = 'PEPTIDEK'")
+
+# With index: reads only the relevant partition (~milliseconds)
+coll.index("peptide").search("PEPTIDEK")
+```
+
+An index trades **one-time build cost** (hours) for **instant queries** (milliseconds). Think of it as a library catalog: the catalog is small and fast to search, and it tells you which book (dataset/file) to open.
+
+## Index Types
+
+QPX defines a standard structure for indexes. The initial spec includes one index type, with the framework designed to support future types.
+
+### Peptide Index
+
+Maps peptide sequences to the datasets and files that contain them.
+
+**Stored at**: `{collection_root}/_index/peptide/`
+
+**Partitioned by**: First two amino acids of the sequence (Hive-style), yielding ~400 partitions (`AA`, `AC`, `AD`, ..., `YW`, `YY`). Each partition is typically 1-5 MB compressed.
+
+```text
+_index/
+└── peptide/
+    ├── sequence_prefix=AA/data.parquet
+    ├── sequence_prefix=AC/data.parquet
+    ├── sequence_prefix=AD/data.parquet
+    ├── ...
+    ├── sequence_prefix=PE/data.parquet    ← "PEPTIDEK" lives here
+    └── sequence_prefix=YY/data.parquet
+```
+
+#### Schema
+
+Each row in the peptide index represents one (peptide, peptidoform, dataset) combination:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sequence` | string | Unmodified peptide amino acid sequence |
+| `peptidoform` | string | Peptide with modifications in ProForma notation |
+| `project_accession` | string | Dataset identifier (e.g., `PXD000561`) |
+| `charge_states` | array[int16] | Distinct precursor charge states observed |
+| `spectra_count` | int32 | Number of PSMs for this peptide in this dataset |
+| `best_pep` | float64 | Best (lowest) posterior error probability across all PSMs |
+| `protein_accessions` | array[string] | All proteins this peptide maps to in this dataset |
+
+!!! note "What is NOT in the index"
+    The index does not store spectral data (m/z arrays, intensities), per-PSM details, or run-level information. It is a lightweight pointer -- "this peptide exists in this dataset with this confidence." To get full PSM details, query the dataset's `psm.parquet` directly.
+
+#### Querying
+
+```python
+# Using the collection API
+coll = qpx.open_collection("/data/msnet/")
+
+# Search by exact sequence
+results = coll.index("peptide").search("PEPTIDEK")
+# Returns DataFrame:
+#   project_accession | peptidoform           | charge_states | spectra_count | best_pep
+#   PXD000561         | PEPTIDEK              | [2, 3]        | 142           | 1.2e-15
+#   PXD000561         | PEP(Phospho)TIDEK     | [2]           | 8             | 3.4e-06
+#   PXD002137         | PEPTIDEK              | [2, 3, 4]     | 891           | 8.7e-22
+
+# Search by prefix (wildcard)
+results = coll.index("peptide").search_prefix("PEPTID")
+
+# Search by peptidoform (with modifications)
+results = coll.index("peptide").search_peptidoform("PEP(Phospho)TIDEK")
+```
+
+Under the hood, this translates to:
+
+```sql
+-- DuckDB reads only the 'PE' partition (~1-5 MB), not the full index
+SELECT *
+FROM read_parquet('_index/peptide/sequence_prefix=PE/data.parquet')
+WHERE sequence = 'PEPTIDEK'
+```
+
+### Future Index Types
+
+The index framework is designed to be extensible. Potential future indexes:
+
+| Index | Partition key | Use case |
+|-------|--------------|----------|
+| **protein** | First 2 chars of accession | "Which datasets identified P04637 (TP53)?" |
+| **spectrum** | Binned precursor m/z | "Find spectra matching this m/z and charge" |
+| **modification** | Modification name | "Which datasets have phosphorylation data?" |
+
+Each would follow the same pattern: Hive-partitioned Parquet under `_index/{type}/`.
+
+## Building Indexes
+
+Indexes are built from the collection's QPX datasets using a batch process:
+
+```python
+# Build the peptide index for the entire collection
+coll = qpx.open_collection("/data/msnet/")
+coll.build_index("peptide")
+```
+
+This:
+
+1. Reads `psm.parquet` from every dataset in the collection.
+2. Filters out decoy PSMs (`is_decoy = false`).
+3. Aggregates per (sequence, peptidoform, project_accession).
+4. Partitions by `sequence_prefix` (first 2 amino acids).
+5. Writes Hive-partitioned Parquet files to `_index/peptide/`.
+
+### Build Algorithm
+
+```sql
+-- Pseudocode for the peptide index build
+INSERT INTO _index/peptide/
+SELECT
+    sequence,
+    peptidoform,
+    project_accession,
+    LIST(DISTINCT charge)                    AS charge_states,
+    COUNT(*)                                 AS spectra_count,
+    MIN(posterior_error_probability)          AS best_pep,
+    LIST(DISTINCT UNNEST(protein_accessions)) AS protein_accessions,
+    LEFT(sequence, 2)                        AS sequence_prefix
+FROM psm
+WHERE is_decoy = false
+GROUP BY sequence, peptidoform, project_accession
+```
+
+### Rebuilding
+
+Indexes can go stale when datasets are added or removed. The rebuild process is idempotent -- it drops the existing index and recreates it from scratch:
+
+```python
+# Rebuild after adding new datasets
+coll.build_index("peptide", force=True)
+
+# Check if index is stale (compares dataset list vs index metadata)
+coll.index("peptide").is_stale()
+```
+
+### Index Metadata
+
+Each index stores a metadata file at `_index/{type}/_metadata.json`:
+
+```json
+{
+    "index_type": "peptide",
+    "qpx_version": "1.0",
+    "built_at": "2026-04-08T14:30:00Z",
+    "datasets_included": ["PXD000561", "PXD002137", "..."],
+    "total_entries": 14400000,
+    "partitions": 400,
+    "compression": "zstd"
+}
+```
+
+The `datasets_included` list enables staleness detection: if the current collection has datasets not in this list, the index is stale.
+
+## Storage
+
+Indexes are lightweight compared to the source data:
+
+| Component | Size | Notes |
+|-----------|------|-------|
+| Source PSM data | ~1.18 TB | The actual data |
+| Peptide index | ~0.6 GB | ~0.05% of source |
+| Protein index (future) | ~0.1 GB | Estimated |
+
+## Conventions
+
+- Indexes live under `_index/` at the collection root.
+- The `_` prefix signals "infrastructure, not a dataset" -- collection discovery skips it.
+- Each index type gets its own subdirectory: `_index/peptide/`, `_index/protein/`, etc.
+- Partition column names use the `{field}_prefix` naming pattern.
+- Index Parquet files use ZSTD compression.
+- Index metadata is stored as `_metadata.json` (not Parquet) for easy inspection.

--- a/docs/spec/collection.md
+++ b/docs/spec/collection.md
@@ -10,6 +10,7 @@ Collections are **programmatic, not persisted**. There is no `collection.parquet
 - **Lab-scale analysis**: A research group stores all their QPX-converted experiments under a shared directory. Cross-dataset queries find which experiments identified a protein of interest.
 - **AI/ML training**: Researchers discover and download datasets matching specific criteria (organism, size, instrument) to build training corpora for machine learning models.
 - **Multi-cohort studies**: Datasets from different cohorts or conditions are grouped into a collection for comparative analysis without merging into a single dataset.
+- **Cross-study differential expression**: Compare protein expression changes across multiple independent studies to identify consistently regulated proteins in a disease or condition.
 
 ## Directory Convention
 
@@ -22,7 +23,10 @@ my_collection/                          # Collection root
 │   ├── PXD000561.sample.parquet
 │   ├── PXD000561.run.parquet
 │   ├── PXD000561.sdrf.tsv
-│   └── psm/                           # Hive-partitioned PSMs
+│   ├── PXD000561.pg.parquet            # Protein groups
+│   ├── PXD000561.ae.h5ad               # Absolute expression
+│   ├── PXD000561.de.h5ad               # Differential expression
+│   └── psm/                            # Hive-partitioned PSMs
 │       ├── run_file_name=run_01/
 │       │   └── part-0.parquet
 │       └── run_file_name=run_02/
@@ -33,8 +37,11 @@ my_collection/                          # Collection root
 │   └── ...
 │
 └── _index/                             # Collection indexes (optional)
-    └── peptide/
-        ├── sequence_prefix=AA/data.parquet
+    ├── peptide/
+    │   ├── sequence_prefix=AA/data.parquet
+    │   └── ...
+    └── protein/
+        ├── accession_prefix=P0/data.parquet
         └── ...
 ```
 
@@ -62,11 +69,16 @@ coll = qpx.open_collection(
 # List discovered datasets
 print(coll.datasets)
 # ['PXD000561', 'PXD002137', 'PXD012636', ...]
+
+# Limit which structures are loaded (saves memory for large collections)
+coll = qpx.open_collection("/data/my_collection/", structures=["dataset", "sample", "pg"])
 ```
 
 ## Cross-Dataset Queries
 
-Collections register all datasets in a single DuckDB engine, enabling SQL queries across datasets:
+Collections register all datasets in a single DuckDB engine, enabling SQL queries across any QPX structure:
+
+### Identification Queries
 
 ```python
 # How many PSMs per project?
@@ -86,6 +98,47 @@ coll.sql("""
 """)
 ```
 
+### Protein-Level Queries
+
+```python
+# Which datasets identified TP53?
+coll.sql("""
+    SELECT project_accession, anchor_protein, global_qvalue
+    FROM pg
+    WHERE anchor_protein = 'P04637'
+    ORDER BY global_qvalue ASC
+""")
+
+# Compare protein group counts across datasets
+coll.sql("""
+    SELECT project_accession,
+           COUNT(*) AS protein_groups,
+           COUNT(*) FILTER (WHERE global_qvalue < 0.01) AS pg_at_1pct_fdr
+    FROM pg
+    GROUP BY project_accession
+""")
+```
+
+### Expression Queries
+
+Collections that include expression views (`.ae.h5ad`, `.de.h5ad`) support cross-study expression analysis:
+
+```python
+# Find proteins differentially expressed in multiple studies
+# (requires DE views to be available in the collection datasets)
+coll.sql("""
+    SELECT protein_accession,
+           COUNT(DISTINCT project_accession) AS num_studies,
+           AVG(log2_fold_change) AS mean_log2fc,
+           LIST(project_accession) AS studies
+    FROM de
+    WHERE adj_pvalue < 0.05
+    GROUP BY protein_accession
+    HAVING num_studies >= 3
+    ORDER BY num_studies DESC
+""")
+```
+
 ### Derived Collection Summary
 
 The collection summary is computed on demand from existing QPX structures, not stored:
@@ -95,9 +148,9 @@ The collection summary is computed on demand from existing QPX structures, not s
 summary = coll.summary()
 
 # Returns a DataFrame with one row per dataset:
-#   project_accession | organisms          | instruments       | num_runs | num_psms
-#   PXD000561         | [Homo sapiens]     | [Q Exactive HF]  | 24       | 4,200,000
-#   PXD012636         | [Homo sapiens, ... | [Orbitrap Fusion] | 48       | 12,300,000
+#   project_accession | organisms          | instruments       | num_runs | structures
+#   PXD000561         | [Homo sapiens]     | [Q Exactive HF]  | 24       | [psm, feature, pg, ae]
+#   PXD012636         | [Homo sapiens, ... | [Orbitrap Fusion] | 48       | [psm, feature, pg]
 ```
 
 This is equivalent to:
@@ -131,7 +184,7 @@ coll.sql("""
 Users download individual datasets from a collection:
 
 ```bash
-# Download one project
+# Download one project (all structures)
 aws s3 sync s3://bucket/my_collection/PXD000561/ ./PXD000561/
 
 # Download all human datasets (using the summary to filter first)
@@ -158,3 +211,4 @@ Collections can optionally include **materialized indexes** for fast search acro
 - **No manifest file**: The collection is discovered from the filesystem. If a dataset is added or removed, the collection reflects the change on next open.
 - **No cross-dataset joins on partitioned columns**: Hive partition columns (e.g., `run_file_name`) are local to each dataset. Cross-dataset queries that filter on partition columns work, but the partition column values may overlap across datasets.
 - **Memory**: Opening a large collection registers all datasets in DuckDB. For collections with hundreds of datasets, consider using `structures=["dataset", "sample"]` to limit which views are loaded.
+- **Expression views**: Cross-dataset expression queries require that the same comparison/contrast design was used across studies. The collection does not normalize expression values between datasets.

--- a/docs/spec/collection.md
+++ b/docs/spec/collection.md
@@ -1,0 +1,159 @@
+# Collections
+
+A **collection** is a group of QPX datasets stored under a common path. Collections enable cross-dataset operations -- browsing available datasets, querying across all of them, and building materialized indexes for fast search.
+
+Collections are **programmatic, not persisted**. There is no `collection.parquet` file. The collection is defined by a directory convention: any subfolder that contains a `*.dataset.parquet` file is recognized as a QPX dataset within the collection.
+
+## Use Cases
+
+- **Public repositories**: A reanalysis collection like MSNet contains 72 QPX datasets under one S3 prefix. Users browse the collection to find datasets by organism or instrument, then download individual projects.
+- **Lab-scale analysis**: A research group stores all their QPX-converted experiments under a shared directory. Cross-dataset queries find which experiments identified a protein of interest.
+- **AI/ML training**: Researchers discover and download datasets matching specific criteria (organism, size, instrument) to build training corpora.
+
+## Directory Convention
+
+A collection is any directory where immediate subfolders contain QPX datasets:
+
+```text
+msnet/                                  # Collection root
+├── PXD000561/                          # QPX dataset
+│   ├── PXD000561.dataset.parquet
+│   ├── PXD000561.sample.parquet
+│   ├── PXD000561.run.parquet
+│   ├── PXD000561.sdrf.tsv
+│   └── psm/                           # Hive-partitioned PSMs
+│       ├── run_file_name=run_01/
+│       │   └── part-0.parquet
+│       └── run_file_name=run_02/
+│           └── part-0.parquet
+│
+├── PXD002137/                          # Another QPX dataset
+│   ├── PXD002137.dataset.parquet
+│   └── ...
+│
+└── _index/                             # Collection indexes (optional)
+    └── peptide/
+        ├── sequence_prefix=AA/data.parquet
+        └── ...
+```
+
+### Discovery Rules
+
+1. Scan immediate subfolders of the collection root.
+2. A subfolder is a **dataset** if it contains at least one `*.dataset.parquet` file.
+3. Subfolders starting with `_` (e.g., `_index/`) are **reserved** for collection infrastructure and are not treated as datasets.
+4. Nested collections (collections inside collections) are not supported.
+
+## Opening a Collection
+
+```python
+import qpx
+
+# Local directory
+coll = qpx.open_collection("/data/msnet/")
+
+# S3
+coll = qpx.open_collection(
+    "s3://bucket/msnet/",
+    s3_config={"region": "us-east-1", "anonymous": True},
+)
+
+# List discovered datasets
+print(coll.datasets)
+# ['PXD000561', 'PXD002137', 'PXD012636', ...]
+```
+
+## Cross-Dataset Queries
+
+Collections register all datasets in a single DuckDB engine, enabling SQL queries across datasets:
+
+```python
+# How many PSMs per project?
+coll.sql("""
+    SELECT project_accession, COUNT(*) AS num_psms
+    FROM psm
+    GROUP BY project_accession
+    ORDER BY num_psms DESC
+""")
+
+# Find a peptide across all projects
+coll.sql("""
+    SELECT project_accession, peptidoform, charge, COUNT(*) AS spectra
+    FROM psm
+    WHERE sequence = 'PEPTIDEK'
+    GROUP BY project_accession, peptidoform, charge
+""")
+```
+
+### Derived Collection Summary
+
+The collection summary is computed on demand from existing QPX structures, not stored:
+
+```python
+# Aggregated view — derived from dataset.parquet + sample.parquet + run.parquet
+summary = coll.summary()
+
+# Returns a DataFrame with one row per dataset:
+#   project_accession | organisms          | instruments       | num_runs | num_psms
+#   PXD000561         | [Homo sapiens]     | [Q Exactive HF]  | 24       | 4,200,000
+#   PXD012636         | [Homo sapiens, ... | [Orbitrap Fusion] | 48       | 12,300,000
+```
+
+This is equivalent to:
+
+```sql
+SELECT d.project_accession,
+       LIST(DISTINCT s.organism) AS organisms,
+       COUNT(DISTINCT r.run_file_name) AS num_runs
+FROM dataset d
+JOIN sample s USING (project_accession)
+JOIN run r USING (project_accession)
+GROUP BY d.project_accession
+```
+
+### Species Search
+
+Because organism information lives in `sample.parquet`, species search works without any additional infrastructure:
+
+```python
+# Find all mouse datasets
+coll.sql("""
+    SELECT DISTINCT d.project_accession, d.project_title
+    FROM dataset d
+    JOIN sample s USING (project_accession)
+    WHERE list_contains(s.organism, 'Mus musculus')
+""")
+```
+
+## Bulk Download
+
+Users download individual datasets from a collection:
+
+```bash
+# Download one project
+aws s3 sync s3://bucket/msnet/PXD000561/ ./PXD000561/
+
+# Download all human datasets (using the summary to filter first)
+for project in $(python3 -c "
+import qpx
+coll = qpx.open_collection('s3://bucket/msnet/', s3_config={'anonymous': True})
+for row in coll.sql(\"\"\"
+    SELECT d.project_accession FROM dataset d
+    JOIN sample s USING (project_accession)
+    WHERE list_contains(s.organism, 'Homo sapiens')
+\"\"\").fetchall():
+    print(row[0])
+"); do
+    aws s3 sync "s3://bucket/msnet/$project/" "./$project/"
+done
+```
+
+## Indexes
+
+Collections can optionally include **materialized indexes** for fast search across datasets. See [Collection Indexes](collection-indexes.md) for details.
+
+## Limitations
+
+- **No manifest file**: The collection is discovered from the filesystem. If a dataset is added or removed, the collection reflects the change on next open.
+- **No cross-dataset joins on partitioned columns**: Hive partition columns (e.g., `run_file_name`) are local to each dataset. Cross-dataset queries that filter on partition columns work, but the partition column values may overlap across datasets.
+- **Memory**: Opening a large collection registers all datasets in DuckDB. For collections with hundreds of datasets, consider using `structures=["dataset", "sample"]` to limit which views are loaded.

--- a/docs/spec/collection.md
+++ b/docs/spec/collection.md
@@ -153,7 +153,7 @@ summary = coll.summary()
 #   PXD012636         | [Homo sapiens, ... | [Orbitrap Fusion] | 48       | [psm, feature, pg]
 ```
 
-This is equivalent to:
+This is equivalent to (partial example showing key aggregations):
 
 ```sql
 SELECT d.project_accession,

--- a/docs/spec/collection.md
+++ b/docs/spec/collection.md
@@ -6,16 +6,17 @@ Collections are **programmatic, not persisted**. There is no `collection.parquet
 
 ## Use Cases
 
-- **Public repositories**: A reanalysis collection like MSNet contains 72 QPX datasets under one S3 prefix. Users browse the collection to find datasets by organism or instrument, then download individual projects.
+- **Public repositories**: A large-scale reanalysis effort produces QPX datasets for dozens or hundreds of public proteomics projects. Users browse the collection to find datasets by organism or instrument, then download individual projects.
 - **Lab-scale analysis**: A research group stores all their QPX-converted experiments under a shared directory. Cross-dataset queries find which experiments identified a protein of interest.
-- **AI/ML training**: Researchers discover and download datasets matching specific criteria (organism, size, instrument) to build training corpora.
+- **AI/ML training**: Researchers discover and download datasets matching specific criteria (organism, size, instrument) to build training corpora for machine learning models.
+- **Multi-cohort studies**: Datasets from different cohorts or conditions are grouped into a collection for comparative analysis without merging into a single dataset.
 
 ## Directory Convention
 
 A collection is any directory where immediate subfolders contain QPX datasets:
 
 ```text
-msnet/                                  # Collection root
+my_collection/                          # Collection root
 ├── PXD000561/                          # QPX dataset
 │   ├── PXD000561.dataset.parquet
 │   ├── PXD000561.sample.parquet
@@ -50,11 +51,11 @@ msnet/                                  # Collection root
 import qpx
 
 # Local directory
-coll = qpx.open_collection("/data/msnet/")
+coll = qpx.open_collection("/data/my_collection/")
 
 # S3
 coll = qpx.open_collection(
-    "s3://bucket/msnet/",
+    "s3://bucket/my_collection/",
     s3_config={"region": "us-east-1", "anonymous": True},
 )
 
@@ -131,12 +132,12 @@ Users download individual datasets from a collection:
 
 ```bash
 # Download one project
-aws s3 sync s3://bucket/msnet/PXD000561/ ./PXD000561/
+aws s3 sync s3://bucket/my_collection/PXD000561/ ./PXD000561/
 
 # Download all human datasets (using the summary to filter first)
 for project in $(python3 -c "
 import qpx
-coll = qpx.open_collection('s3://bucket/msnet/', s3_config={'anonymous': True})
+coll = qpx.open_collection('s3://bucket/my_collection/', s3_config={'anonymous': True})
 for row in coll.sql(\"\"\"
     SELECT d.project_accession FROM dataset d
     JOIN sample s USING (project_accession)
@@ -144,7 +145,7 @@ for row in coll.sql(\"\"\"
 \"\"\").fetchall():
     print(row[0])
 "); do
-    aws s3 sync "s3://bucket/msnet/$project/" "./$project/"
+    aws s3 sync "s3://bucket/my_collection/$project/" "./$project/"
 done
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,9 @@ nav:
           - Run Metadata: spec/run.md
           - Processing Provenance: spec/provenance.md
           - SDRF Conversion: spec/sdrf-mapping.md
+      - Collections:
+          - Collections: spec/collection.md
+          - Collection Indexes: spec/collection-indexes.md
       - Technical:
           - Serialization & Parquet: spec/serialization.md
           - File Extensions & Naming: spec/file-naming.md


### PR DESCRIPTION
## Summary

- Add **Collections** spec — programmatic, discovery-based grouping of QPX datasets under a common path (e.g., an S3 prefix with 72 reanalysis projects)
- Add **Collection Indexes** spec — materialized search structures (peptide index) for fast cross-dataset queries without scanning terabytes of PSM data

## Motivation

Large-scale QPX collections like MSNet (~1.18 TB, 72 projects) need two capabilities beyond individual dataset access:

1. **Browse/filter datasets** by organism, instrument, size — answered by cross-dataset queries on existing `dataset.parquet` + `sample.parquet` (no new persistence needed)
2. **Search for specific peptides** across all datasets — requires a materialized index because scanning 1.18 TB per query is impractical

## Design Decisions

- **Collections are programmatic**, not persisted. The collection is defined by a directory convention (subfolders with `*.dataset.parquet`). No manifest file to go stale.
- **Indexes are persisted** as Hive-partitioned Parquet under `_index/`. The `_` prefix excludes them from dataset discovery.
- **Peptide index** partitions by first 2 amino acids (~400 partitions, ~0.6 GB total for a 1.18 TB collection). Searching "PEPTIDEK" reads only the `PE` partition (~1-5 MB).
- **Extensible framework** for future index types (protein, spectrum, modification) following the same pattern.

## New Files

- `docs/spec/collection.md` — Collections spec
- `docs/spec/collection-indexes.md` — Collection Indexes spec
- `mkdocs.yml` — Added Collections section to navigation

## Test plan

- [ ] Verify mkdocs builds with new pages (`mkdocs serve`)
- [ ] Review spec for consistency with existing QPX conventions
- [ ] Validate that the peptide index schema aligns with PSM view fields
- [ ] Review `open_collection` / `build_index` API design

Generated with [Claude Code](https://claude.com/claude-code)