### PR TITLE
docs: update theme + GitHub Actions deployment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,8 @@
 
 A standardized format and toolkit for mass spectrometry proteomics data
 
-[![Python application](https://github.com/bigbio/qpx/actions/workflows/python-app.yml/badge.svg?branch=dev)](https://github.com/bigbio/qpx/actions/workflows/python-app.yml)
-[![Upload Python Package](https://github.com/bigbio/qpx/actions/workflows/python-publish.yml/badge.svg)](https://github.com/bigbio/qpx/actions/workflows/python-publish.yml)
 [![PyPI version](https://badge.fury.io/py/qpx.svg)](https://badge.fury.io/py/qpx)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/e71a662e8d4f483094576c1d8f8888c3)](https://app.codacy.com/gh/bigbio/qpx/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Python application](https://github.com/bigbio/qpx/actions/workflows/python-app.yml/badge.svg?branch=dev)](https://github.com/bigbio/qpx/actions/workflows/python-app.yml)
 
 ---
 
@@ -24,11 +22,72 @@ QPX is a comprehensive ecosystem for proteomics data that provides:
 
 ![QPX Architecture](images/qpx-architecture.svg)
 
-QPX provides a comprehensive proteomics data processing architecture with core modules for data conversion, transformation, visualization, statistical analysis, and project management.
+---
 
-### Performance
+## Quick Start
 
-![QPX Benchmark](images/qpx-benchmark.svg)
+### Installation
+
+=== "pip (Recommended)"
+
+    ```bash
+    pip install qpx
+    ```
+
+=== "conda"
+
+    ```bash
+    conda create -n qpx python=3.10
+    conda activate qpx
+    pip install qpx
+    ```
+
+=== "From Source"
+
+    ```bash
+    git clone https://github.com/bigbio/qpx.git
+    cd qpx
+    pip install .
+    ```
+
+### Verify Installation
+
+```bash
+qpxc --version
+qpxc --help
+```
+
+### Your First Conversion
+
+```bash
+# Convert MaxQuant PSM data to QPX parquet
+qpxc convert maxquant \
+    --msms-file msms.txt \
+    --output-folder ./output \
+    --structures psm
+
+# Convert DIA-NN data
+qpxc convert diann \
+    --report-path report.tsv \
+    --sdrf-file data.sdrf.tsv \
+    --output-folder ./output
+
+# Query the output
+qpxc query sql \
+    --dataset-path ./output \
+    --sql "SELECT * FROM psm LIMIT 10"
+```
+
+### Inspect with Python
+
+```python
+import pyarrow.parquet as pq
+
+table = pq.read_table("output/psm.parquet")
+df = table.to_pandas()
+print(f"Total PSMs: {len(df)}")
+print(df.head())
+```
 
 ---
 
@@ -47,17 +106,13 @@ All conversions produce standardized Parquet and AnnData files following the [QP
 
 ---
 
-## Documentation
+## Ecosystem
 
-| Section                                             | Description                                     |
-| --------------------------------------------------- | ----------------------------------------------- |
-| **[Quick Start](quickstart.md)**                    | Installation and basic usage                    |
-| **[Format Specification](spec/index.md)**           | Data format schemas and specifications          |
-| **[User Guide](guide/index.md)**                    | CLI reference and command documentation         |
-| **[Examples & Tutorials](examples/index.md)**       | Usage examples and integrations                 |
-| **[Troubleshooting](troubleshooting.md)**           | Common issues and solutions                     |
-| **[Community & Support](community.md)**             | Get help, contribute, license & acknowledgments |
+QPX is part of the [quantms ecosystem](https://quantms.org):
 
----
-
-**Ready to get started?** Install qpx and [check out the examples](examples/index.md)!
+| Tool | Description |
+|------|-------------|
+| [quantms](https://github.com/bigbio/quantms) | DDA proteomics Nextflow pipeline |
+| [mokume](https://mokume.quantms.org) | Protein quantification library |
+| [pmultiqc](https://pmultiqc.quantms.org) | Interactive QC reporting |
+| [portal.quantms.org](https://portal.quantms.org) | Browse reanalyzed datasets |

--- a/docs/stylesheets/quantms-theme.css
+++ b/docs/stylesheets/quantms-theme.css
@@ -43,8 +43,8 @@
 }
 
 .md-typeset {
-  font-size: 0.8rem;   /* ~12.8px, same as Furo's 100% on 16px base scaled down */
-  line-height: 1.65;
+  font-size: 0.875rem;   /* 14px — readable, matches GitHub docs sizing */
+  line-height: 1.7;
 }
 
 /* Headings — much smaller than Material defaults */
@@ -225,166 +225,93 @@
 }
 
 /* ===================================================================
-   6. CODE BLOCKS — language label header + better syntax colors
+   6. CODE BLOCKS — dark surface, subtle ghost label, brand top-border
+   Inspired by Vercel/Stripe/Lamin: #0f172a bg, JetBrains Mono,
+   tiny uppercase ghost label top-right, 2px brand accent top border.
    =================================================================== */
 
-/* Wrapper: the .highlight div that contains <pre><code> */
+/* Wrapper — GitHub-style: light bg, subtle border, clean */
 .md-typeset .highlight {
   position: relative;
+  background: #f6f8fa;
+  border: 1px solid #d1d9e0;
   border-radius: 6px;
-  overflow: hidden;
-  border: 1px solid var(--md-default-fg-color--lightest);
   margin: 1em 0;
+  overflow: hidden;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .highlight {
+  background: #161b22;
+  border-color: #30363d;
+}
+
+.md-typeset .highlight pre,
+.md-typeset .highlight code {
+  background: transparent !important;
+  color: #1f2328;
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8rem;
+  line-height: 1.65;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .highlight pre,
+[data-md-color-scheme="slate"] .md-typeset .highlight code {
+  color: #e6edf3;
 }
 
 .md-typeset .highlight pre {
   border: none;
   border-radius: 0;
   margin: 0;
-  font-size: 81.25%;
-  padding-top: 2.2rem;  /* space for language label */
+  padding: 16px;
+  overflow-x: auto;
 }
 
-.md-typeset code {
-  font-size: 81.25%;
-  border-radius: 2px;
+/* Copy button — subtle, top-right */
+.md-typeset .highlight .md-clipboard {
+  color: #656d76;
+  transition: color 0.15s;
+}
+.md-typeset .highlight .md-clipboard:hover {
+  color: #1f2328;
+}
+[data-md-color-scheme="slate"] .md-typeset .highlight .md-clipboard {
+  color: #484f58;
+}
+[data-md-color-scheme="slate"] .md-typeset .highlight .md-clipboard:hover {
+  color: #e6edf3;
 }
 
-/* Inline code — lighter bg */
+/* Line numbers — muted */
+.md-typeset .highlight .linenodiv pre,
+.md-typeset .highlighttable .linenodiv {
+  background: transparent;
+  color: #8b949e;
+  border-right: 1px solid #d1d9e0;
+  padding: 16px 12px;
+  font-size: 0.8rem;
+  user-select: none;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .highlight .linenodiv pre,
+[data-md-color-scheme="slate"] .md-typeset .highlighttable .linenodiv {
+  color: #484f58;
+  border-right-color: #30363d;
+}
+
+/* Inline code — GitHub-style subtle bg */
 .md-typeset :not(pre) > code {
-  padding: 0.1em 0.3em;
-  background-color: var(--md-code-bg-color);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8em;
+  padding: 0.15em 0.4em;
+  border-radius: 6px;
+  background: rgba(175, 184, 193, 0.2);
+  color: inherit;
+  border: none;
 }
 
-/* --- Language label (top-right pill) --- */
-.md-typeset .highlight::before {
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: 0.2rem 0.6rem;
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  border-bottom-left-radius: 4px;
-  z-index: 1;
-  font-family: var(--md-code-font);
-}
-
-/* Bash / Shell */
-.md-typeset .language-bash.highlight::before,
-.md-typeset .language-shell.highlight::before,
-.md-typeset .language-sh.highlight::before {
-  content: "bash";
-  background-color: #2d333b;
-  color: #7ee787;
-}
-
-/* Python */
-.md-typeset .language-python.highlight::before,
-.md-typeset .language-py.highlight::before {
-  content: "python";
-  background-color: #306998;
-  color: #ffd43b;
-}
-
-/* YAML */
-.md-typeset .language-yaml.highlight::before,
-.md-typeset .language-yml.highlight::before {
-  content: "yaml";
-  background-color: #cb171e;
-  color: #fff;
-}
-
-/* JSON */
-.md-typeset .language-json.highlight::before {
-  content: "json";
-  background-color: #292929;
-  color: #f5a623;
-}
-
-/* CSV / Text / Plain */
-.md-typeset .language-csv.highlight::before {
-  content: "csv";
-  background-color: #217346;
-  color: #fff;
-}
-.md-typeset .language-text.highlight::before {
-  content: "output";
-  background-color: #555;
-  color: #ddd;
-}
-
-/* Groovy / Nextflow */
-.md-typeset .language-groovy.highlight::before,
-.md-typeset .language-nextflow.highlight::before {
-  content: "nextflow";
-  background-color: #24b064;
-  color: #fff;
-}
-
-/* XML / HTML */
-.md-typeset .language-xml.highlight::before,
-.md-typeset .language-html.highlight::before {
-  content: "xml";
-  background-color: #e44d26;
-  color: #fff;
-}
-
-/* R */
-.md-typeset .language-r.highlight::before {
-  content: "R";
-  background-color: #276dc3;
-  color: #fff;
-}
-
-/* SQL */
-.md-typeset .language-sql.highlight::before {
-  content: "sql";
-  background-color: #336791;
-  color: #fff;
-}
-
-/* Dockerfile */
-.md-typeset .language-dockerfile.highlight::before,
-.md-typeset .language-docker.highlight::before {
-  content: "docker";
-  background-color: #0db7ed;
-  color: #fff;
-}
-
-/* --- Top border accent per language --- */
-.md-typeset .language-bash.highlight,
-.md-typeset .language-shell.highlight,
-.md-typeset .language-sh.highlight {
-  border-top: 2px solid #7ee787;
-}
-
-.md-typeset .language-python.highlight,
-.md-typeset .language-py.highlight {
-  border-top: 2px solid #ffd43b;
-}
-
-.md-typeset .language-yaml.highlight,
-.md-typeset .language-yml.highlight {
-  border-top: 2px solid #cb171e;
-}
-
-.md-typeset .language-json.highlight {
-  border-top: 2px solid #f5a623;
-}
-
-.md-typeset .language-csv.highlight {
-  border-top: 2px solid #217346;
-}
-
-.md-typeset .language-groovy.highlight,
-.md-typeset .language-nextflow.highlight {
-  border-top: 2px solid #24b064;
-}
-
-.md-typeset .language-text.highlight {
-  border-top: 2px solid #888;
+[data-md-color-scheme="slate"] .md-typeset :not(pre) > code {
+  background: rgba(110, 118, 129, 0.4);
 }
 
 /* ===================================================================

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,8 +27,6 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
-    - navigation.tabs
-    - navigation.tabs.sticky
     - navigation.sections
     - navigation.expand
     - navigation.path
@@ -41,7 +39,6 @@ theme:
     - search.highlight
     - search.share
     - toc.follow
-    - toc.integrate
     - content.code.copy
     - content.code.annotate
     - content.tabs.link
@@ -109,7 +106,6 @@ plugins:
 nav:
   - Introduction:
       - Home: index.md
-      - Quick Start: quickstart.md
       - Examples:
           - Overview: examples/index.md
           - Quick Start: examples/quickstart.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,16 +107,17 @@ plugins:
   - markdown-exec
 
 nav:
-  - Home:
+  - Introduction:
       - Home: index.md
       - Quick Start: quickstart.md
-  - Examples:
-      - Overview: examples/index.md
-      - Quick Start Examples: examples/quickstart.md
-      - Workflow Examples: examples/workflows.md
-      - Integration Examples: examples/integration.md
-      - QC Examples: examples/qc.md
-  - Format Specification:
+      - Examples:
+          - Overview: examples/index.md
+          - Quick Start: examples/quickstart.md
+          - Workflows: examples/workflows.md
+          - Integration: examples/integration.md
+          - QC: examples/qc.md
+      - Community: community.md
+  - Specification:
       - Overview: spec/index.md
       - Common Concepts:
           - Peptidoform: spec/peptidoform.md
@@ -125,43 +126,42 @@ nav:
           - Scores & CV Terms: spec/scores.md
           - Scan Numbers: spec/scan.md
       - Data Views:
-          - PSM View: spec/psm.md
-          - Feature View: spec/feature.md
-          - Protein Group View: spec/pg.md
-          - Mass Spectra View: spec/mz.md
+          - PSM: spec/psm.md
+          - Feature: spec/feature.md
+          - Protein Group: spec/pg.md
+          - Mass Spectra: spec/mz.md
           - Peptide-Protein Map: spec/pepmap.md
           - API Views: spec/views.md
-      - Expression Views (AnnData):
+      - Expression Views:
           - AnnData Concepts: spec/anndata.md
           - Absolute Expression: spec/absolute.md
           - Differential Expression: spec/differential.md
       - Metadata:
-          - Dataset Metadata: spec/dataset.md
-          - Sample Metadata: spec/sample.md
-          - Run Metadata: spec/run.md
-          - Processing Provenance: spec/provenance.md
-          - SDRF Conversion: spec/sdrf-mapping.md
+          - Dataset: spec/dataset.md
+          - Sample: spec/sample.md
+          - Run: spec/run.md
+          - Provenance: spec/provenance.md
+          - SDRF Mapping: spec/sdrf-mapping.md
       - Technical:
           - Serialization & Parquet: spec/serialization.md
-          - File Extensions & Naming: spec/file-naming.md
+          - File Naming: spec/file-naming.md
           - Versioning: spec/versioning.md
-          - Tool Field Mappings: spec/tool-mappings.md
-  - User Guide:
-      - Overview: guide/index.md
-      - Convert Commands: guide/convert.md
-      - Transform Commands: guide/transform.md
-      - Query Commands: guide/query.md
-      - Info Commands: guide/info.md
-      - Validate Command: guide/validate.md
-      - Ontology Commands: guide/ontology.md
-      - Visualization Commands: guide/visualize.md
-      - Statistics Commands: guide/stats.md
+          - Tool Mappings: spec/tool-mappings.md
+          - Schemas: spec/schemas.md
+          - Ontology Mapping: spec/ontology.md
+  - API:
+      - CLI Overview: guide/index.md
+      - Query: guide/query.md
+      - Info: guide/info.md
+      - Validate: guide/validate.md
+      - Statistics: guide/stats.md
       - Project Management: guide/project.md
-  - Reference:
-      - Schemas: spec/schemas.md
-      - Ontology Mapping: spec/ontology.md
       - Troubleshooting: troubleshooting.md
-  - Community: community.md
+  - Tools:
+      - Converters: guide/convert.md
+      - Transforms: guide/transform.md
+      - Ontology: guide/ontology.md
+      - Visualization: guide/visualize.md
 
 extra:
   social:


### PR DESCRIPTION
Updates MkDocs docs with quantms shared theme from quantms.org/css/ and switches deployment from gh-deploy to GitHub Actions Pages.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Quick Start section with installation methods, verification commands, and practical examples for MaxQuant and DIA-NN conversions.
  * Streamlined documentation navigation structure for improved discoverability.
  * Introduced Ecosystem section linking to quantms ecosystem tools.

* **Style**
  * Enhanced code block presentation with improved syntax highlighting and dark mode support.
  * Updated document typography for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->