### PR TITLE
Enhance PDC2QPX with sample/run views and accession handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,17 @@ Commands:
 
 ### pdc2qpx
 
-One-shot download + conversion of a PDC/CPTAC study (requires `pip install qpx[pdc]`):
+One-shot download + conversion of PDC/CPTAC studies (requires `pip install qpx[pdc]`). `-a/--accession` takes a single ID, comma-separated IDs, or a CSV with a `pdc_study_id`/`pdc_id` column:
 
 ```bash
 # Entire QPX including full spectra (for quantms reanalysis)
-qpxc pdc2qpx \
-    --study PDC000109 \
+qpxc pdc2qpx -a PDC000109 \
     --download-dir ./downloads \
     --output-folder ./qpx/PDC000109 \
     --include-spectra --max-cpus 24
+
+# Many studies from a CSV (each -> ./qpx/<study>/)
+qpxc pdc2qpx -a cptac_lfq.csv --download-dir ./downloads --output-folder ./qpx
 ```
 
 ### Convert

--- a/docs/guide/pdc2qpx.md
+++ b/docs/guide/pdc2qpx.md
@@ -1,12 +1,13 @@
 # pdc2qpx
 
-One-shot download + conversion of a PDC/CPTAC study into a QPX dataset.
+One-shot download + conversion of PDC/CPTAC studies into QPX datasets.
 
-`pdc2qpx` orchestrates three steps in a single command:
+`pdc2qpx` orchestrates these steps in a single command:
 
-1. Download the study's CDAP `.psm` files (and, with `--include-spectra`, the mzML spectra) from PDC via [pridepy](https://github.com/bigbio/pridepy).
+1. Download each study's CDAP `.psm` files (and, with `--include-spectra`, the mzML spectra) from PDC via [pridepy](https://github.com/bigbio/pridepy).
 2. Convert the `.psm` files to QPX psm/feature/pg/dataset/ontology/provenance views (`CdapConverter`).
-3. Convert the mzML files to a full-spectra `mz.parquet`, linked to PSM/feature by `run_file_name` + `scan`.
+3. Build `sample`/`run` views from PDC GraphQL metadata (on by default) — this recovers the TMT/iTRAQ channel → biological-sample mapping that `.psm` files lack. Disable with `--no-metadata`.
+4. With `--include-spectra`, convert the mzML files to a full-spectra `mz.parquet`, linked to PSM/feature by `run_file_name` + `scan`.
 
 The download layer requires the optional `pdc` extra:
 
@@ -17,51 +18,54 @@ pip install qpx[pdc]
 ## Usage
 
 ```bash
-qpxc pdc2qpx --study PDC000109 --download-dir ./downloads --output-folder ./qpx/PDC000109 [OPTIONS]
+qpxc pdc2qpx -a PDC000109 --download-dir ./downloads --output-folder ./qpx/PDC000109 [OPTIONS]
 ```
+
+`-a/--accession` accepts a **single** ID, **comma-separated** IDs, or a **CSV** with a `pdc_study_id`/`pdc_id` column (the same input forms as `pridepy download-pdc-files -a`). With more than one study, each is written to `<output-folder>/<study>/` and a failed study (e.g. one with no CDAP `.psm`) is reported without aborting the rest — unless `--stop-on-error` is set.
 
 ## Parameters
 
 | Option | Description | Default |
 | ------ | ----------- | ------- |
-| `--study` | PDC study accession (e.g. `PDC000109`) | required |
+| `-a`, `--accession` | PDC study accession(s): single ID, comma-separated, or a CSV with `pdc_study_id`/`pdc_id` | required |
 | `--download-dir` | Directory for downloaded files (written under `<download-dir>/<study>/`) | required |
-| `--output-folder` | Directory for generated QPX parquet files | required |
+| `--output-folder` | QPX output dir. One study writes here; multiple studies write to `<output-folder>/<study>/` | required |
 | `--include-spectra` | Also download mzML and produce a full-spectra `<study>.mz.parquet` | off |
+| `--no-metadata` | Skip building `sample`/`run` views from PDC metadata | off (views built) |
 | `--ms-levels` | MS levels for the mz view (e.g. `2` or `1,2`) | all |
 | `--max-cpus` | Threads for the CDAP conversion | 24 |
 | `--max-memory` | Memory limit for the CDAP conversion | 16GB |
 | `--download-threads` | Parallel HTTP Range threads per file | 24 |
 | `--skip-download` | Use files already present under `<download-dir>/<study>/` | off |
+| `--stop-on-error` | With multiple studies, abort on the first failure | off (continue) |
 
 ## Examples
 
-### Base QPX (psm/feature/pg) only
-
-```bash
-qpxc pdc2qpx \
-    --study PDC000109 \
-    --download-dir ./downloads \
-    --output-folder ./qpx/PDC000109
-```
-
-### Entire QPX including full spectra
+### One study, entire QPX including full spectra
 
 For quantms-style reanalysis you need MS1 (precursor LFQ quantification) as well as MS2 (identification), so include all MS levels (the default when `--ms-levels` is omitted):
 
 ```bash
-qpxc pdc2qpx \
-    --study PDC000109 \
+qpxc pdc2qpx -a PDC000109 \
     --download-dir ./downloads \
     --output-folder ./qpx/PDC000109 \
     --include-spectra --max-cpus 24
 ```
 
+### Many studies from a CSV
+
+Each study is written to `./qpx/<study>/`; studies without CDAP `.psm` are skipped and reported at the end.
+
+```bash
+qpxc pdc2qpx -a cptac_lfq.csv \
+    --download-dir ./downloads \
+    --output-folder ./qpx --max-cpus 24
+```
+
 ### Re-run on already-downloaded files
 
 ```bash
-qpxc pdc2qpx \
-    --study PDC000109 \
+qpxc pdc2qpx -a PDC000109 \
     --download-dir ./downloads \
     --output-folder ./qpx/PDC000109 \
     --include-spectra --skip-download
@@ -69,14 +73,16 @@ qpxc pdc2qpx \
 
 ## Output
 
-Under `--output-folder`, prefixed with the study accession:
+Per study, prefixed with the study accession (under `--output-folder` for a single study, or `<output-folder>/<study>/` for many):
 
 - `<study>.psm.parquet`, `<study>.feature.parquet`, `<study>.pg.parquet`
+- `<study>.sample.parquet`, `<study>.run.parquet` (unless `--no-metadata`) — biological sample metadata and the channel → sample mapping from PDC
 - `<study>.dataset.parquet`, `<study>.ontology.parquet`, `<study>.provenance.parquet`
 - `<study>.mz.parquet` (only with `--include-spectra`) — full spectra, joinable to PSM/feature by `run_file_name` + `scan`
 
 ## Notes
 
-- Only CPTAC studies that publish CDAP `.psm` files can produce the base QPX views; `--include-spectra` additionally requires mzML to be available on PDC for that study.
+- Only PDC studies that publish CDAP `.psm` files can produce the base QPX views; `--include-spectra` additionally requires mzML to be available on PDC for that study.
+- `sample`/`run` views come from PDC GraphQL metadata (`studyExperimentalDesign` + `biospecimenPerStudy` + `fileMetadata`), not from the `.psm` files. A metadata fetch failure is logged and skipped without breaking the rest of the conversion.
 - Downloads go through pridepy's PDC layer (signed CloudFront URLs, md5 validation, automatic 403 URL re-signing).
 - See [Converters](convert.md) for the underlying `qpxc convert cdap` and `qpxc convert mz` commands.

--- a/docs/spec/converter-coverage.md
+++ b/docs/spec/converter-coverage.md
@@ -11,13 +11,16 @@ This page lists which QPX data views each converter produces. Use it to see at a
 | **DIA-NN** | No | Yes | Yes | No | If SDRF | If SDRF | Yes | If SDRF | No | No |
 | **Spectronaut** | No | Yes | Yes | No | If SDRF | If SDRF | Yes | Yes | Yes | No |
 | **quantms** | Yes | Yes | Yes | No | If SDRF | If SDRF | Yes | Yes | No | No |
-| **CDAP** | Yes | Yes | Yes | No | No | No | Yes | Yes | Yes | No |
+| **CDAP** | Yes | Yes | Yes | No | If PDC | If PDC | Yes | Yes | Yes | No |
 | **mzIdentML** | Yes | No | No | Yes | If SDRF | If SDRF | Yes | Yes | Yes | No |
 | **SDRF** | No | No | No | No | Yes | Yes | No | Optional | No | No |
 
 - **Yes** — the converter produces this view.
 - **No** — the converter does not produce this view (e.g. DIA-NN has no PSM view; mzIdentML has no Feature/PG).
 - **If SDRF** — the view is produced only when an SDRF file is provided (sample and run metadata). SDRF is optional for all converters.
+- **If PDC** — CPTAC/PDC studies ship no SDRF, and CDAP `.psm` files carry no sample metadata. When run through `qpxc pdc2qpx` (default), the sample/run views are built from PDC GraphQL metadata, which also recovers the TMT/iTRAQ channel → biological-sample mapping. Disable with `--no-metadata`.
+
+> The `mz` (full-spectra) view is produced by the standalone `qpxc convert mz` command, or automatically by `qpxc pdc2qpx --include-spectra`; it is not emitted by the per-tool converters above.
 
 ## CLI commands
 

--- a/qpx/cli/pdc2qpx.py
+++ b/qpx/cli/pdc2qpx.py
@@ -30,6 +30,12 @@ import click
     help="Also download mzML and produce a full-spectra <study>.mz.parquet",
 )
 @click.option(
+    "--no-metadata",
+    is_flag=True,
+    default=False,
+    help="Skip building sample/run views from PDC metadata (built by default)",
+)
+@click.option(
     "--ms-levels",
     default=None,
     help="MS levels for the mz view (e.g. '2' or '1,2'). Default: all levels.",
@@ -54,6 +60,7 @@ def pdc2qpx_cmd(
     download_dir: Path,
     output_folder: Path,
     include_spectra: bool,
+    no_metadata: bool,
     ms_levels: Optional[str],
     max_cpus: int,
     max_memory: str,
@@ -95,6 +102,7 @@ def pdc2qpx_cmd(
         download_dir=download_dir,
         output_folder=output_folder,
         include_spectra=include_spectra,
+        include_metadata=not no_metadata,
         ms_levels=levels,
         max_cpus=max_cpus,
         max_memory=max_memory,

--- a/qpx/cli/pdc2qpx.py
+++ b/qpx/cli/pdc2qpx.py
@@ -10,7 +10,12 @@ import click
 
 
 @click.command("pdc2qpx")
-@click.option("--study", required=True, help="PDC study accession (e.g. PDC000109)")
+@click.option(
+    "-a",
+    "--accession",
+    required=True,
+    help="PDC study accession(s): a single ID, comma-separated IDs, or a CSV with a pdc_study_id/pdc_id column",
+)
 @click.option(
     "--download-dir",
     required=True,
@@ -21,7 +26,7 @@ import click
     "--output-folder",
     required=True,
     type=click.Path(file_okay=False, path_type=Path),
-    help="Directory for generated QPX parquet files",
+    help="QPX output dir. One study writes here; multiple studies write to <output-folder>/<study>/",
 )
 @click.option(
     "--include-spectra",
@@ -54,9 +59,15 @@ import click
     default=False,
     help="Use files already present under <download-dir>/<study>/ (skip downloading)",
 )
+@click.option(
+    "--stop-on-error",
+    is_flag=True,
+    default=False,
+    help="With multiple studies, abort on the first failure (default: continue and report)",
+)
 @click.option("--verbose", is_flag=True, help="Enable verbose logging")
 def pdc2qpx_cmd(
-    study: str,
+    accession: str,
     download_dir: Path,
     output_folder: Path,
     include_spectra: bool,
@@ -66,50 +77,63 @@ def pdc2qpx_cmd(
     max_memory: str,
     download_threads: int,
     skip_download: bool,
+    stop_on_error: bool,
     verbose: bool,
 ):
-    """Download a PDC/CPTAC study and convert it to a QPX dataset.
+    """Download PDC/CPTAC studies and convert them to QPX datasets.
 
-    Downloads the CDAP ``.psm`` files (and, with ``--include-spectra``, the mzML
-    spectra) for one PDC study, then converts them: ``.psm`` to psm/feature/pg/...
-    views and mzML to a full-spectra ``mz.parquet``. Requires the ``pdc`` extra
-    (``pip install qpx[pdc]``) for the pridepy download layer.
+    ``--accession`` accepts a single ID, comma-separated IDs, or a CSV with a
+    ``pdc_study_id``/``pdc_id`` column (same input forms as ``pridepy``). Each
+    study's CDAP ``.psm`` (and, with ``--include-spectra``, mzML) is converted to
+    psm/feature/pg/sample/run/... views. With several studies the batch
+    continues past a failed study (e.g. one with no ``.psm``) unless
+    ``--stop-on-error`` is set. Requires the ``pdc`` extra (``pip install
+    qpx[pdc]``) for the pridepy download/parse layer.
 
     \b
     Examples:
-        # Base QPX (psm/feature/pg) only
-        qpxc pdc2qpx \\
-            --study PDC000109 \\
-            --download-dir ./downloads \\
-            --output-folder ./qpx/PDC000109
+        # One study (full spectra for quantms reanalysis)
+        qpxc pdc2qpx -a PDC000109 \\
+            --download-dir ./downloads --output-folder ./qpx/PDC000109 \\
+            --include-spectra
 
-        # Entire QPX including full spectra (for quantms reanalysis)
-        qpxc pdc2qpx \\
-            --study PDC000109 \\
-            --download-dir ./downloads \\
-            --output-folder ./qpx/PDC000109 \\
-            --include-spectra --max-cpus 24
+        # Many studies from a CSV (each -> ./qpx/<study>/)
+        qpxc pdc2qpx -a cptac_lfq.csv \\
+            --download-dir ./downloads --output-folder ./qpx --max-cpus 24
     """
     if verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
     levels = [int(x.strip()) for x in ms_levels.split(",")] if ms_levels else None
 
-    from qpx.pipeline.pdc2qpx import run_pdc2qpx
+    try:
+        from pridepy.pdc.client import parse_accessions
+    except ImportError:
+        raise ImportError("pridepy is required for pdc2qpx. Install it with: pip install qpx[pdc]") from None
 
-    outputs = run_pdc2qpx(
-        study=study,
-        download_dir=download_dir,
-        output_folder=output_folder,
-        include_spectra=include_spectra,
-        include_metadata=not no_metadata,
-        ms_levels=levels,
-        max_cpus=max_cpus,
-        max_memory=max_memory,
-        download_threads=download_threads,
-        skip_download=skip_download,
-    )
+    studies = parse_accessions(accession)
+    from qpx.pipeline.pdc2qpx import run_pdc2qpx, run_pdc2qpx_batch
 
-    click.echo(f"pdc2qpx complete for {study}. Output: {output_folder}")
-    if "mz" in outputs:
-        click.echo(f"Full spectra: {outputs['mz']}")
+    common = {
+        "include_spectra": include_spectra,
+        "include_metadata": not no_metadata,
+        "ms_levels": levels,
+        "max_cpus": max_cpus,
+        "max_memory": max_memory,
+        "download_threads": download_threads,
+        "skip_download": skip_download,
+    }
+
+    if len(studies) == 1:
+        outputs = run_pdc2qpx(studies[0], download_dir, output_folder, **common)
+        click.echo(f"pdc2qpx complete for {studies[0]}. Output: {output_folder}")
+        if "mz" in outputs:
+            click.echo(f"Full spectra: {outputs['mz']}")
+        return
+
+    results = run_pdc2qpx_batch(studies, download_dir, output_folder, continue_on_error=not stop_on_error, **common)
+    n_ok = sum(1 for record in results.values() if record["status"] == "ok")
+    click.echo(f"\npdc2qpx: {n_ok}/{len(results)} studies ok (output under {output_folder}/<study>/)")
+    for study, record in results.items():
+        suffix = f" ({record['error']})" if record["error"] else ""
+        click.echo(f"  {record['status']:6s} {study}{suffix}")

--- a/qpx/cli/pdc2qpx.py
+++ b/qpx/cli/pdc2qpx.py
@@ -106,13 +106,9 @@ def pdc2qpx_cmd(
 
     levels = [int(x.strip()) for x in ms_levels.split(",")] if ms_levels else None
 
-    try:
-        from pridepy.pdc.client import parse_accessions
-    except ImportError:
-        raise ImportError("pridepy is required for pdc2qpx. Install it with: pip install qpx[pdc]") from None
+    from qpx.pipeline.pdc2qpx import parse_accessions, run_pdc2qpx, run_pdc2qpx_batch
 
     studies = parse_accessions(accession)
-    from qpx.pipeline.pdc2qpx import run_pdc2qpx, run_pdc2qpx_batch
 
     common = {
         "include_spectra": include_spectra,

--- a/qpx/converters/cdap/converter.py
+++ b/qpx/converters/cdap/converter.py
@@ -12,7 +12,7 @@ from qpx.converters.cdap.pg_adapter import CdapPgAdapter
 from qpx.converters.cdap.psm_adapter import CdapPsmAdapter
 from qpx.converters.mappings import get_tool_meta
 from qpx.converters.orchestrator import BaseOrchestrator
-from qpx.core.constants import FEATURE, ONTOLOGY, PG, PSM, RUN, SAMPLE
+from qpx.core.constants import FEATURE, ONTOLOGY, PG, PSM
 from qpx.core.engine import create_converter_connection
 from qpx.core.scores import field_ontology_entries, score_ontology_entries
 
@@ -205,7 +205,9 @@ class CdapConverter(BaseOrchestrator):
                 "tool_uri": None,
                 "parameters": None,
                 "config": None,
-                "output_views": records + [SAMPLE, RUN, ONTOLOGY],
+                # CDAP itself produces psm/feature/pg + ontology; sample/run come
+                # from PDC metadata in pdc2qpx, not from this converter.
+                "output_views": records + [ONTOLOGY],
             },
         ]
         super()._write_provenance(output_folder, prefix, prov_records)

--- a/qpx/converters/cdap/pdc_sample_run.py
+++ b/qpx/converters/cdap/pdc_sample_run.py
@@ -75,18 +75,26 @@ def _plex_channel_map(plex: dict) -> list[tuple[str, str, str]]:
 
     canonical = ITRAQ4_CHANNEL_FIELDS if experiment_type.startswith("iTRAQ") else TMT_CHANNEL_FIELDS
     present = [field for field in canonical if plex.get(field)]
-    if len(present) != len(cdap_labels):
+
+    expected_labels = list(cdap_labels)
+    # TMT11 pilots may also carry the legacy TMTXX 132N/C channels; CDAP appends
+    # them for TMT11 (see CdapBaseAdapter._detect_channels), so mirror that here
+    # instead of skipping the whole plex on the resulting count mismatch.
+    if experiment_type == "TMT11" and (plex.get("tmt_132n") or plex.get("tmt_132c")):
+        expected_labels.extend(CHANNEL_DEFS["TMTXX"])
+
+    if len(present) != len(expected_labels):
         logger.warning(
             "Plex %s: %d PDC channels but %d CDAP labels for %s; skipping its channels",
             plex.get("study_run_metadata_submitter_id"),
             len(present),
-            len(cdap_labels),
+            len(expected_labels),
             experiment_type,
         )
         return []
 
     mapping: list[tuple[str, str, str]] = []
-    for field, cdap_label in zip(present, cdap_labels):
+    for field, cdap_label in zip(present, expected_labels):
         entry = plex[field][0]
         mapping.append((cdap_label, entry["aliquot_id"], entry.get("aliquot_submitter_id") or entry["aliquot_id"]))
     return mapping
@@ -112,6 +120,42 @@ def _sample_record(aliquot_id: str, aliquot_submitter_id: str, biospecimen: dict
         "individual": meta.get("case_submitter_id"),
         "sample_type": meta.get("sample_type"),
     }
+
+
+def _write_sample_run(
+    sample_path: Path,
+    run_path: Path,
+    sample_records: list[dict],
+    run_records: list[dict],
+    compression: str,
+) -> None:
+    """Write the sample/run parquet via temp files + atomic rename.
+
+    A writer emits no file for an empty batch (a run with no mappable channels),
+    so only rename temps that were actually written. Temp files are removed on
+    any failure, so a crash never clobbers a previously-good parquet from an
+    earlier run.
+    """
+    sample_tmp = sample_path.with_name(sample_path.name + ".tmp")
+    run_tmp = run_path.with_name(run_path.name + ".tmp")
+    try:
+        with SampleWriter(
+            sample_tmp,
+            creator="pdc",
+            extra_columns=_SAMPLE_EXTRA_COLUMNS,
+            compression=compression,
+        ) as writer:
+            writer.write_batch(sample_records)
+        with RunWriter(run_tmp, creator="pdc", compression=compression) as writer:
+            writer.write_batch(run_records)
+        if sample_tmp.exists():
+            sample_tmp.replace(sample_path)
+        if run_tmp.exists():
+            run_tmp.replace(run_path)
+    finally:
+        for tmp in (sample_tmp, run_tmp):
+            if tmp.exists():
+                tmp.unlink()
 
 
 def build_sample_run_from_pdc(
@@ -193,17 +237,7 @@ def build_sample_run_from_pdc(
 
     sample_path = output_folder / f"{prefix}.sample.parquet"
     run_path = output_folder / f"{prefix}.run.parquet"
-
-    with SampleWriter(
-        sample_path,
-        creator="pdc",
-        extra_columns=_SAMPLE_EXTRA_COLUMNS,
-        compression=compression,
-    ) as writer:
-        writer.write_batch(list(sample_records.values()))
-
-    with RunWriter(run_path, creator="pdc", compression=compression) as writer:
-        writer.write_batch(run_records)
+    _write_sample_run(sample_path, run_path, list(sample_records.values()), run_records, compression)
 
     logger.info(
         "Wrote %d samples and %d runs from PDC metadata for %s",

--- a/qpx/converters/cdap/pdc_sample_run.py
+++ b/qpx/converters/cdap/pdc_sample_run.py
@@ -1,0 +1,214 @@
+"""Build CPTAC/PDC ``sample.parquet`` and ``run.parquet`` from PDC metadata.
+
+CDAP ``.psm`` files carry the run (``FileName``) but no biological sample
+metadata, and for isobaric (TMT/iTRAQ) studies no channel -> sample mapping.
+For 79% of CPTAC studies the reporter intensities in ``feature.parquet`` are
+therefore uninterpretable on their own. The missing link lives only in the PDC
+GraphQL API and is recovered here:
+
+    run_file_name --fileMetadata--> plex (study_run_metadata)
+    plex          --studyExperimentalDesign--> {channel: aliquot}
+    aliquot_id    --biospecimenPerStudy--> {organism, tissue, disease, case}
+
+The reporter channels are emitted in the **same CDAP label format**
+(``TMT10-126``, ``iTRAQ114``, ``LFQ`` for label-free) so that each
+``run.samples[].label`` joins directly to a ``feature.parquet`` intensity label.
+
+This builder lives at the ``pdc2qpx`` layer (it needs network), not inside the
+offline :class:`~qpx.converters.cdap.converter.CdapConverter`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from qpx.converters.cdap.constants import CHANNEL_DEFS
+from qpx.pdc.metadata import (
+    DEFAULT_METADATA_THREADS,
+    ITRAQ4_CHANNEL_FIELDS,
+    TMT_CHANNEL_FIELDS,
+    fetch_biospecimen,
+    fetch_experimental_design,
+    map_runs_to_plex,
+)
+from qpx.writers.run import RunWriter
+from qpx.writers.sample import SampleWriter
+
+logger = logging.getLogger(__name__)
+
+_LFQ_LABEL = "LFQ"
+_SAMPLE_EXTRA_COLUMNS = ["sample_type"]
+_DEFAULT_ORGANISM = "Homo sapiens"
+_NOT_REPORTED = "Not Reported"
+
+
+def _is_reference(aliquot_submitter_id: Optional[str]) -> bool:
+    """Return True for pooled internal-reference channels (no real case)."""
+    text = (aliquot_submitter_id or "").lower()
+    return "reference" in text or "pooled" in text
+
+
+def _plex_channel_map(plex: dict) -> list[tuple[str, str, str]]:
+    """Map one plex to ``[(cdap_label, aliquot_id, aliquot_submitter_id)]``.
+
+    Aligns the plex's non-empty PDC channel fields (canonical mass order) with
+    the CDAP channel labels for its ``experiment_type``. Label-free plexes yield
+    a single ``LFQ`` channel. Returns ``[]`` (with a warning) for experiment
+    types CDAP does not model (e.g. TMT16) or on a count mismatch, so a wrong
+    mapping is never emitted.
+    """
+    if plex.get("label_free"):
+        entry = plex["label_free"][0]
+        return [(_LFQ_LABEL, entry["aliquot_id"], entry.get("aliquot_submitter_id") or entry["aliquot_id"])]
+
+    experiment_type = plex.get("experiment_type")
+    cdap_labels = CHANNEL_DEFS.get(experiment_type)
+    if not cdap_labels:
+        logger.warning(
+            "Plex %s has experiment_type %r not modelled by CDAP; skipping its channels",
+            plex.get("study_run_metadata_submitter_id"),
+            experiment_type,
+        )
+        return []
+
+    canonical = ITRAQ4_CHANNEL_FIELDS if experiment_type.startswith("iTRAQ") else TMT_CHANNEL_FIELDS
+    present = [field for field in canonical if plex.get(field)]
+    if len(present) != len(cdap_labels):
+        logger.warning(
+            "Plex %s: %d PDC channels but %d CDAP labels for %s; skipping its channels",
+            plex.get("study_run_metadata_submitter_id"),
+            len(present),
+            len(cdap_labels),
+            experiment_type,
+        )
+        return []
+
+    mapping: list[tuple[str, str, str]] = []
+    for field, cdap_label in zip(present, cdap_labels):
+        entry = plex[field][0]
+        mapping.append((cdap_label, entry["aliquot_id"], entry.get("aliquot_submitter_id") or entry["aliquot_id"]))
+    return mapping
+
+
+def _sample_record(aliquot_id: str, aliquot_submitter_id: str, biospecimen: dict[str, dict]) -> dict:
+    """Build one ``sample.parquet`` record from a biospecimen aliquot."""
+    if _is_reference(aliquot_submitter_id):
+        return {
+            "sample_accession": aliquot_submitter_id,
+            "organism": _DEFAULT_ORGANISM,
+            "organism_part": _NOT_REPORTED,
+            "disease": None,
+            "individual": None,
+            "sample_type": "Internal Reference",
+        }
+    meta = biospecimen.get(aliquot_id) or {}
+    return {
+        "sample_accession": aliquot_submitter_id,
+        "organism": meta.get("taxon") or _DEFAULT_ORGANISM,
+        "organism_part": meta.get("primary_site") or _NOT_REPORTED,
+        "disease": meta.get("disease_type"),
+        "individual": meta.get("case_submitter_id"),
+        "sample_type": meta.get("sample_type"),
+    }
+
+
+def build_sample_run_from_pdc(
+    pdc_study_id: str,
+    output_folder: str | Path,
+    prefix: str,
+    *,
+    compression: str = "zstd",
+    threads: int = DEFAULT_METADATA_THREADS,
+) -> Optional[dict[str, Path]]:
+    """Build ``<prefix>.sample.parquet`` and ``<prefix>.run.parquet`` from PDC.
+
+    Returns ``{"sample": path, "run": path}`` on success or ``None`` when the
+    run -> plex map is empty (study has no harmonized metadata / no raw files).
+    Network errors propagate; the caller (pdc2qpx) wraps this in a warn-skip
+    guard so metadata failure never breaks the main conversion.
+    """
+    output_folder = Path(output_folder)
+
+    design = fetch_experimental_design(pdc_study_id)
+    biospecimen = fetch_biospecimen(pdc_study_id)
+    run_to_plex = map_runs_to_plex(pdc_study_id, threads=threads)
+
+    if not run_to_plex:
+        logger.warning("No run->plex mapping for %s; skipping sample/run views", pdc_study_id)
+        return None
+
+    # plex submitter id -> channel mapping
+    plex_channels = {
+        plex["study_run_metadata_submitter_id"]: _plex_channel_map(plex)
+        for plex in design
+        if plex.get("study_run_metadata_submitter_id")
+    }
+
+    # Sample rows: one per referenced aliquot, keyed by aliquot_submitter_id.
+    sample_records: dict[str, dict] = {}
+    for channels in plex_channels.values():
+        for _label, aliquot_id, aliquot_submitter_id in channels:
+            if aliquot_submitter_id not in sample_records:
+                sample_records[aliquot_submitter_id] = _sample_record(aliquot_id, aliquot_submitter_id, biospecimen)
+
+    # Run rows: one per run file, samples = its plex's channels.
+    run_records: list[dict] = []
+    runs_without_channels = 0
+    for run_file_name, info in sorted(run_to_plex.items()):
+        channels = plex_channels.get(info["plex"], [])
+        if not channels:
+            runs_without_channels += 1
+        samples = [
+            {
+                "sample_accession": aliquot_submitter_id,
+                "label": label,
+                "biological_replicate": None,
+                "technical_replicate": None,
+            }
+            for label, _aliquot_id, aliquot_submitter_id in channels
+        ]
+        run_records.append(
+            {
+                "run_accession": run_file_name,
+                "run_file_name": run_file_name,
+                "file_name": info.get("file_name"),
+                "samples": samples,
+                "fraction": str(info["fraction"]) if info.get("fraction") is not None else None,
+                "instrument": info.get("instrument"),
+                "enzymes": None,
+                "dissociation_method": None,
+                "modification_parameters": None,
+            }
+        )
+
+    if runs_without_channels:
+        logger.warning(
+            "%d/%d runs in %s have no channel mapping (unsupported experiment type or missing plex)",
+            runs_without_channels,
+            len(run_records),
+            pdc_study_id,
+        )
+
+    sample_path = output_folder / f"{prefix}.sample.parquet"
+    run_path = output_folder / f"{prefix}.run.parquet"
+
+    with SampleWriter(
+        sample_path,
+        creator="pdc",
+        extra_columns=_SAMPLE_EXTRA_COLUMNS,
+        compression=compression,
+    ) as writer:
+        writer.write_batch(list(sample_records.values()))
+
+    with RunWriter(run_path, creator="pdc", compression=compression) as writer:
+        writer.write_batch(run_records)
+
+    logger.info(
+        "Wrote %d samples and %d runs from PDC metadata for %s",
+        len(sample_records),
+        len(run_records),
+        pdc_study_id,
+    )
+    return {"sample": sample_path, "run": run_path}

--- a/qpx/converters/quantms/feature_adapter.py
+++ b/qpx/converters/quantms/feature_adapter.py
@@ -63,6 +63,8 @@ class QuantmsFeatureAdapter(BaseConverter):
         """Initialize adapter with an empty peptide-protein map."""
         super().__init__(**kwargs)
         self._pep_protein_map: dict[str, str] = {}
+        # Plex-aware TMT channel labels; convert() refines channel 10 for TMT10 runs.
+        self._tmt_channel_map: dict[int, str] = self._TMT_CHANNEL_MAP
 
     def convert(
         self,
@@ -112,6 +114,7 @@ class QuantmsFeatureAdapter(BaseConverter):
             )
         else:
             # Isobaric path uses the original dict-based approach
+            self._tmt_channel_map = self._resolve_tmt_channel_map()
             psm_lookup = self._build_psm_lookup(ms_runs)
             protein_qvalue_map = self._build_protein_qvalue_map()
             protein_gene_map = self._build_protein_gene_map()
@@ -705,7 +708,7 @@ class QuantmsFeatureAdapter(BaseConverter):
         7: "TMT129C",
         8: "TMT130N",
         9: "TMT130C",
-        10: "TMT131N",
+        10: "TMT131N",  # TMT10plex uses "TMT131" here; _resolve_tmt_channel_map handles it
         11: "TMT131C",
         # TMT16plex extensions
         12: "TMT132N",
@@ -741,6 +744,22 @@ class QuantmsFeatureAdapter(BaseConverter):
         except Exception:
             self.logger.debug("Failed to detect labeling type from msstats channels", exc_info=True)
         return "LFQ"
+
+    def _resolve_tmt_channel_map(self) -> dict[int, str]:
+        """Return the channel-index -> reporter-label map for this run's plex.
+
+        ``_TMT_CHANNEL_MAP`` follows the TMT11+ convention, where channel 10 is
+        ``TMT131N`` (paired with ``TMT131C`` at channel 11). A TMT10plex run has
+        no ``131C``, so its 10th reporter is the standard ``TMT131`` -- matching
+        the CDAP converter (``CHANNEL_DEFS["TMT10"]``) and OpenMS/SDRF. Detect the
+        plex from the max numeric channel and relabel channel 10 for a TMT10 run.
+        Non-numeric (already-labelled) channels leave the map unchanged.
+        """
+        channel_map = dict(self._TMT_CHANNEL_MAP)
+        max_channel = self._conn.execute('SELECT MAX(TRY_CAST("Channel" AS INTEGER)) FROM msstats').fetchone()[0]
+        if max_channel == 10:
+            channel_map[10] = "TMT131"
+        return channel_map
 
     def _build_psm_lookup(self, ms_runs: dict[int, str]) -> dict[tuple, dict]:
         """Build a lookup from (run_file_name, peptidoform, charge) -> PSM info.
@@ -1177,7 +1196,7 @@ class QuantmsFeatureAdapter(BaseConverter):
         _sub = re.sub
         _from_proforma = from_proforma
         _safe_float = safe_float
-        _tmt_map = self._TMT_CHANNEL_MAP
+        _tmt_map = self._tmt_channel_map
         mods_meta = self._modifications_meta
         is_tmt = experiment_type == "TMT"
         _proforma_cache: dict[tuple[str, str], list | None] = {}

--- a/qpx/pdc/__init__.py
+++ b/qpx/pdc/__init__.py
@@ -1,0 +1,7 @@
+"""PDC (Proteomic Data Commons) metadata access for QPX.
+
+Self-contained GraphQL helpers used by the CDAP sample/run builder to recover
+the channel -> aliquot -> biological-sample mapping that CDAP ``.psm`` files do
+not carry. Network access only; no pridepy dependency (pridepy remains the
+download layer for ``pdc2qpx``).
+"""

--- a/qpx/pdc/metadata.py
+++ b/qpx/pdc/metadata.py
@@ -1,0 +1,195 @@
+"""Minimal PDC GraphQL client for sample/run metadata.
+
+CDAP ``.psm`` files identify the run (``FileName``) but carry no biological
+sample metadata and, for isobaric studies, no channel -> sample mapping. That
+mapping lives only in the PDC GraphQL API. This module exposes the three
+queries needed to rebuild it, plus a threaded helper to map each run file to
+its plex (``study_run_metadata``):
+
+    run_file_name --fileMetadata--> study_run_metadata_submitter_id (plex)
+    plex          --studyExperimentalDesign--> {channel: aliquot}
+    aliquot_id    --biospecimenPerStudy--> {organism, tissue, disease, ...}
+
+All queries pass ``acceptDUA: true`` (the harmonized metadata is open access).
+Read-only; no pridepy dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+from qpx.core.http import safe_urlopen
+
+logger = logging.getLogger(__name__)
+
+PDC_API = "https://pdc.cancer.gov/graphql"
+_USER_AGENT = "qpx-pdc2qpx"
+_TIMEOUT_SECONDS = 120
+# Global rule: PDC file-metadata lookups fan out at 24 threads by default.
+DEFAULT_METADATA_THREADS = 24
+
+# Reporter-ion channel fields in canonical mass-ascending order. The same order
+# CDAP's CHANNEL_DEFS use, so a plex's non-empty channels align positionally
+# with the CDAP channel labels (see pdc_sample_run.py).
+TMT_CHANNEL_FIELDS: tuple[str, ...] = (
+    "tmt_126",
+    "tmt_127n",
+    "tmt_127c",
+    "tmt_128n",
+    "tmt_128c",
+    "tmt_129n",
+    "tmt_129c",
+    "tmt_130n",
+    "tmt_130c",
+    "tmt_131",
+    "tmt_131c",
+    "tmt_132n",
+    "tmt_132c",
+    "tmt_133n",
+    "tmt_133c",
+    "tmt_134n",
+    "tmt_134c",
+    "tmt_135n",
+)
+ITRAQ4_CHANNEL_FIELDS: tuple[str, ...] = ("itraq_114", "itraq_115", "itraq_116", "itraq_117")
+ALL_CHANNEL_FIELDS: tuple[str, ...] = ("label_free",) + TMT_CHANNEL_FIELDS + ITRAQ4_CHANNEL_FIELDS
+
+
+def post_graphql(query: str, variables: Optional[dict] = None, *, api_url: str = PDC_API) -> dict:
+    """POST a GraphQL query to PDC and return the ``data`` object.
+
+    Raises ``RuntimeError`` if the response carries ``errors``.
+    """
+    payload = {"query": query, "variables": variables or {}}
+    request = urllib.request.Request(
+        api_url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", "User-Agent": _USER_AGENT},
+    )
+    with safe_urlopen(request, timeout=_TIMEOUT_SECONDS) as response:
+        body = json.load(response)
+    if body.get("errors"):
+        raise RuntimeError(f"PDC GraphQL returned errors: {body['errors']}")
+    return body.get("data") or {}
+
+
+_FILES_PER_STUDY_QUERY = """
+query StudyFiles($studyId: String!) {
+  filesPerStudy(pdc_study_id: $studyId, acceptDUA: true) {
+    file_id
+    file_name
+    data_category
+  }
+}
+"""
+
+_FILE_METADATA_QUERY = """
+query FileMeta($fileId: String!) {
+  fileMetadata(file_id: $fileId, acceptDUA: true) {
+    file_name
+    study_run_metadata_submitter_id
+    fraction_number
+    instrument
+  }
+}
+"""
+
+_CHANNEL_SELECTION = "\n".join(f"    {field} {{ aliquot_id aliquot_submitter_id }}" for field in ALL_CHANNEL_FIELDS)
+_EXPERIMENTAL_DESIGN_QUERY = f"""
+query Design($studyId: String!) {{
+  studyExperimentalDesign(pdc_study_id: $studyId, acceptDUA: true) {{
+    study_run_metadata_submitter_id
+    experiment_type
+{_CHANNEL_SELECTION}
+  }}
+}}
+"""
+
+_BIOSPECIMEN_QUERY = """
+query Biospecimen($studyId: String!) {
+  biospecimenPerStudy(pdc_study_id: $studyId, acceptDUA: true) {
+    aliquot_id
+    aliquot_submitter_id
+    sample_submitter_id
+    sample_type
+    disease_type
+    primary_site
+    case_submitter_id
+    taxon
+  }
+}
+"""
+
+
+def fetch_study_files(pdc_study_id: str) -> list[dict]:
+    """Return all files for a study (``file_id``, ``file_name``, ``data_category``)."""
+    data = post_graphql(_FILES_PER_STUDY_QUERY, {"studyId": pdc_study_id})
+    return data.get("filesPerStudy") or []
+
+
+def fetch_experimental_design(pdc_study_id: str) -> list[dict]:
+    """Return the per-plex experimental design (channel -> aliquot mapping)."""
+    data = post_graphql(_EXPERIMENTAL_DESIGN_QUERY, {"studyId": pdc_study_id})
+    return data.get("studyExperimentalDesign") or []
+
+
+def fetch_biospecimen(pdc_study_id: str) -> dict[str, dict]:
+    """Return ``{aliquot_id: biospecimen_record}`` for a study."""
+    data = post_graphql(_BIOSPECIMEN_QUERY, {"studyId": pdc_study_id})
+    rows = data.get("biospecimenPerStudy") or []
+    return {row["aliquot_id"]: row for row in rows if row.get("aliquot_id")}
+
+
+def fetch_file_metadata(file_id: str) -> Optional[dict]:
+    """Return the first ``fileMetadata`` record for a file id, or ``None``."""
+    data = post_graphql(_FILE_METADATA_QUERY, {"fileId": file_id})
+    records = data.get("fileMetadata") or []
+    return records[0] if records else None
+
+
+def _strip_raw_extension(file_name: str) -> str:
+    """Drop a trailing vendor/raw extension to match CDAP ``run_file_name``."""
+    stem = str(file_name).strip()
+    for ext in (".raw", ".RAW", ".mzML", ".mzml", ".mzML.gz", ".mgf", ".d"):
+        if stem.endswith(ext):
+            return stem[: -len(ext)]
+    return stem
+
+
+def map_runs_to_plex(pdc_study_id: str, *, threads: int = DEFAULT_METADATA_THREADS) -> dict[str, dict]:
+    """Map each raw run file to its plex via ``fileMetadata``.
+
+    PDC has no per-study bulk ``fileMetadata`` query, so each raw file is looked
+    up individually. Lookups fan out across *threads* workers (metadata-only,
+    fast). Returns ``{run_file_name: {plex, file_name, fraction, instrument}}``
+    keyed by the extension-stripped file name (matching CDAP ``run_file_name``).
+    """
+    raw_files = [f for f in fetch_study_files(pdc_study_id) if f.get("data_category") == "Raw Mass Spectra"]
+    if not raw_files:
+        logger.warning("No raw spectra files found for %s; run->plex map will be empty", pdc_study_id)
+        return {}
+
+    def _lookup(entry: dict) -> Optional[tuple[str, dict]]:
+        meta = fetch_file_metadata(entry["file_id"])
+        if not meta or not meta.get("study_run_metadata_submitter_id"):
+            return None
+        original_name = meta.get("file_name") or entry.get("file_name") or ""
+        run_file_name = _strip_raw_extension(original_name)
+        return run_file_name, {
+            "plex": meta["study_run_metadata_submitter_id"],
+            "file_name": original_name or None,
+            "fraction": meta.get("fraction_number"),
+            "instrument": meta.get("instrument"),
+        }
+
+    run_to_plex: dict[str, dict] = {}
+    with ThreadPoolExecutor(max_workers=max(1, threads)) as pool:
+        for result in pool.map(_lookup, raw_files):
+            if result is not None:
+                run_to_plex[result[0]] = result[1]
+    logger.info("Mapped %d/%d raw run files to plexes for %s", len(run_to_plex), len(raw_files), pdc_study_id)
+    return run_to_plex

--- a/qpx/pdc/metadata.py
+++ b/qpx/pdc/metadata.py
@@ -152,9 +152,15 @@ def fetch_file_metadata(file_id: str) -> Optional[dict]:
 
 
 def _strip_raw_extension(file_name: str) -> str:
-    """Drop a trailing vendor/raw extension to match CDAP ``run_file_name``."""
+    """Drop a trailing raw extension to match CDAP ``run_file_name``.
+
+    The extension set must stay identical to
+    ``CdapBaseAdapter.strip_run_extension`` (converters/cdap/base_adapter.py);
+    otherwise a ``.mzML.gz`` or ``.d`` run would strip to a different stem here
+    and break the join between ``run.parquet`` and the psm/feature views.
+    """
     stem = str(file_name).strip()
-    for ext in (".raw", ".RAW", ".mzML", ".mzml", ".mzML.gz", ".mgf", ".d"):
+    for ext in (".raw", ".RAW", ".mzML", ".mzml", ".mgf"):
         if stem.endswith(ext):
             return stem[: -len(ext)]
     return stem

--- a/qpx/pipeline/pdc2qpx.py
+++ b/qpx/pipeline/pdc2qpx.py
@@ -163,3 +163,53 @@ def run_pdc2qpx(
 
     logger.info("pdc2qpx complete for %s -> %s", study, output_folder)
     return outputs
+
+
+def run_pdc2qpx_batch(
+    studies: list[str],
+    download_dir: Path,
+    output_root: Path,
+    *,
+    include_spectra: bool = False,
+    include_metadata: bool = True,
+    ms_levels: Optional[list[int]] = None,
+    max_cpus: int = 24,
+    max_memory: str = "16GB",
+    download_threads: int = 24,
+    skip_download: bool = False,
+    continue_on_error: bool = True,
+) -> dict[str, dict]:
+    """Run :func:`run_pdc2qpx` for each study into ``output_root/<study>/``.
+
+    Returns ``{study: {"status": "ok"|"failed", "outputs": dict|None,
+    "error": str|None}}``. With *continue_on_error* (default) a study's expected
+    failure (missing/non-CDAP ``.psm``, network) is recorded and the batch
+    continues; set it ``False`` to abort on the first failure.
+    """
+    output_root = Path(output_root)
+    results: dict[str, dict] = {}
+    for index, study in enumerate(studies, start=1):
+        logger.info("pdc2qpx %d/%d: %s", index, len(studies), study)
+        try:
+            outputs = run_pdc2qpx(
+                study,
+                download_dir,
+                output_root / study,
+                include_spectra=include_spectra,
+                include_metadata=include_metadata,
+                ms_levels=ms_levels,
+                max_cpus=max_cpus,
+                max_memory=max_memory,
+                download_threads=download_threads,
+                skip_download=skip_download,
+            )
+            results[study] = {"status": "ok", "outputs": outputs, "error": None}
+        except (OSError, RuntimeError, ValueError, KeyError, TypeError) as exc:
+            if not continue_on_error:
+                raise
+            logger.warning("pdc2qpx: study %s failed: %s", study, exc)
+            results[study] = {"status": "failed", "outputs": None, "error": str(exc)}
+
+    n_ok = sum(1 for record in results.values() if record["status"] == "ok")
+    logger.info("pdc2qpx batch complete: %d/%d studies ok", n_ok, len(studies))
+    return results

--- a/qpx/pipeline/pdc2qpx.py
+++ b/qpx/pipeline/pdc2qpx.py
@@ -165,6 +165,34 @@ def run_pdc2qpx(
     return outputs
 
 
+def parse_accessions(accession: str) -> list[str]:
+    """Resolve PDC study accessions from a single ``-a`` argument.
+
+    Accepts a single ID, comma/newline-separated IDs, or a path to a CSV with a
+    ``pdc_study_id``/``pdc_id`` column. Mirrors the input forms of pridepy's
+    ``parse_accessions`` so ``pdc2qpx`` and ``pridepy download-pdc-files`` take
+    the same ``-a`` argument -- but keeps parsing dependency-free (pridepy is an
+    optional extra). Blank lines and ``#`` comments are ignored; order is
+    preserved and duplicates dropped.
+    """
+    source = Path(accession).expanduser()
+    if source.is_file() and source.suffix.lower() == ".csv":
+        import csv
+
+        with source.open(encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            column = next((c for c in ("pdc_study_id", "pdc_id") if c in (reader.fieldnames or [])), None)
+            if column is None:
+                raise ValueError(f"CSV must contain a pdc_study_id or pdc_id column: {source}")
+            raw = [str(row.get(column) or "") for row in reader]
+    else:
+        raw = accession.replace(",", "\n").split()
+    cleaned = [item.strip() for item in raw if item.strip() and not item.strip().startswith("#")]
+    if not cleaned:
+        raise ValueError(f"No PDC study accession found in: {accession!r}")
+    return list(dict.fromkeys(cleaned))
+
+
 def run_pdc2qpx_batch(
     studies: list[str],
     download_dir: Path,

--- a/qpx/pipeline/pdc2qpx.py
+++ b/qpx/pipeline/pdc2qpx.py
@@ -57,7 +57,7 @@ def _assert_cdap_psm(study_dir: Path) -> None:
             f"No .psm files found in {study_dir}. pdc2qpx needs CDAP .psm output; this PDC study may not provide harmonized PSMs."
         )
     with open(psm_files[0], encoding="utf-8") as handle:
-        header = handle.readline().rstrip("\n").split("\t")
+        header = handle.readline().rstrip("\r\n").split("\t")
     missing = [col for col in _CDAP_SIGNATURE_COLUMNS if col not in header]
     if missing:
         raise ValueError(
@@ -72,6 +72,7 @@ def run_pdc2qpx(
     output_folder: Path,
     *,
     include_spectra: bool = False,
+    include_metadata: bool = True,
     ms_levels: Optional[list[int]] = None,
     max_cpus: int = 24,
     max_memory: str = "16GB",
@@ -87,6 +88,10 @@ def run_pdc2qpx(
         output_folder: Directory for generated QPX parquet files.
         include_spectra: Also download mzML and produce a full-spectra
             ``<study>.mz.parquet``.
+        include_metadata: Build ``<study>.sample.parquet`` and
+            ``<study>.run.parquet`` from PDC GraphQL metadata (channel ->
+            biological-sample mapping). On by default; metadata failures are
+            logged and skipped without breaking the conversion.
         ms_levels: MS levels for the mz view (``None`` = all). Precursor-level
             LFQ reanalysis needs MS1 as well as MS2.
         max_cpus: Threads for the CDAP conversion.
@@ -124,7 +129,25 @@ def run_pdc2qpx(
     )
     outputs: dict[str, Path] = {"base": output_folder}
 
-    # 2. Optional full-spectra mz.parquet from mzML files.
+    # 2. Optional sample/run views from PDC metadata (channel -> sample mapping).
+    if include_metadata:
+        try:
+            from qpx.converters.cdap.pdc_sample_run import build_sample_run_from_pdc
+
+            built = build_sample_run_from_pdc(study, output_folder, prefix=study, threads=download_threads)
+            if built:
+                outputs.update(built)
+        except (OSError, RuntimeError, ValueError, KeyError, TypeError) as exc:
+            # Best-effort: network (OSError/URLError), GraphQL (RuntimeError), or
+            # data-shape failures must not break the main conversion.
+            logger.warning("PDC metadata sample/run build skipped for %s: %s", study, exc)
+            for suffix in (".sample.parquet", ".run.parquet"):
+                partial = output_folder / f"{study}{suffix}"
+                if partial.exists():
+                    partial.unlink()
+                    logger.debug("Removed partial %s", partial)
+
+    # 3. Optional full-spectra mz.parquet from mzML files.
     if include_spectra:
         if not skip_download:
             _download(study, "mzml", download_dir, download_threads)

--- a/qpx/pipeline/pdc2qpx.py
+++ b/qpx/pipeline/pdc2qpx.py
@@ -139,13 +139,10 @@ def run_pdc2qpx(
                 outputs.update(built)
         except (OSError, RuntimeError, ValueError, KeyError, TypeError) as exc:
             # Best-effort: network (OSError/URLError), GraphQL (RuntimeError), or
-            # data-shape failures must not break the main conversion.
+            # data-shape failures must not break the main conversion. The builder
+            # writes via temp files + atomic rename, so a failure here never
+            # clobbers a previously-good sample/run parquet.
             logger.warning("PDC metadata sample/run build skipped for %s: %s", study, exc)
-            for suffix in (".sample.parquet", ".run.parquet"):
-                partial = output_folder / f"{study}{suffix}"
-                if partial.exists():
-                    partial.unlink()
-                    logger.debug("Removed partial %s", partial)
 
     # 3. Optional full-spectra mz.parquet from mzML files.
     if include_spectra:

--- a/tests/converters/test_cdap_converter.py
+++ b/tests/converters/test_cdap_converter.py
@@ -240,6 +240,14 @@ class TestCdapMetadata:
         table = pq.read_table(str(path))
         assert table.num_rows > 0
 
+    def test_provenance_does_not_claim_sample_run(self, converted_output):
+        """CDAP does not write sample/run, so provenance must not claim them."""
+        path = converted_output / f"{_PREFIX}.provenance.parquet"
+        table = pq.read_table(str(path))
+        all_views = {view for views in table.column("output_views").to_pylist() for view in (views or [])}
+        assert "sample" not in all_views
+        assert "run" not in all_views
+
     def test_dataset_exists(self, converted_output):
         path = converted_output / f"{_PREFIX}.dataset.parquet"
         assert path.exists()

--- a/tests/converters/test_pdc2qpx.py
+++ b/tests/converters/test_pdc2qpx.py
@@ -52,7 +52,7 @@ def test_pdc2qpx_base(tmp_path):
     download_dir = _stage_study(tmp_path, study)
     out = tmp_path / "qpx"
 
-    result = run_pdc2qpx(study, download_dir, out, skip_download=True)
+    result = run_pdc2qpx(study, download_dir, out, skip_download=True, include_metadata=False)
 
     assert "mz" not in result
     feature = out / f"{study}.feature.parquet"
@@ -67,7 +67,7 @@ def test_pdc2qpx_with_spectra(tmp_path):
     download_dir = _stage_study(tmp_path, study, with_mzml=True)
     out = tmp_path / "qpx"
 
-    result = run_pdc2qpx(study, download_dir, out, include_spectra=True, skip_download=True)
+    result = run_pdc2qpx(study, download_dir, out, include_spectra=True, skip_download=True, include_metadata=False)
 
     assert result["mz"] == out / f"{study}.mz.parquet"
     mz = pq.read_table(str(result["mz"]))
@@ -95,3 +95,16 @@ def test_pdc2qpx_non_cdap_psm_raises(tmp_path):
 
     with pytest.raises(ValueError, match="not a CDAP-format"):
         run_pdc2qpx(study, tmp_path / "downloads", tmp_path / "qpx", skip_download=True)
+
+
+def test_assert_cdap_psm_accepts_crlf(tmp_path):
+    """A valid CDAP .psm with Windows CRLF line endings passes pre-check."""
+    from qpx.pipeline.pdc2qpx import _assert_cdap_psm
+
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    header = "FileName\tScanNum\tPeptideSequence\tProtein\tCharge\r\n"
+    row = "run1.raw\t100\tPEPTIDE\tNP_000001.1\t2\r\n"
+    (study_dir / "valid_crlf.psm").write_bytes((header + row).encode("utf-8"))
+
+    _assert_cdap_psm(study_dir)

--- a/tests/converters/test_pdc2qpx.py
+++ b/tests/converters/test_pdc2qpx.py
@@ -182,3 +182,49 @@ def test_pdc2qpx_cli_comma_accessions_runs_batch(tmp_path):
     assert "2/2 studies ok" in result.output
     assert (out / "PDC_A" / "PDC_A.feature.parquet").exists()
     assert (out / "PDC_B" / "PDC_B.feature.parquet").exists()
+
+
+def test_parse_accessions(tmp_path):
+    from qpx.pipeline.pdc2qpx import parse_accessions
+
+    # single / comma+whitespace / dedup / ignore comments
+    assert parse_accessions("PDC000109") == ["PDC000109"]
+    assert parse_accessions("PDC1, PDC2 PDC1 #c") == ["PDC1", "PDC2"]
+    # CSV with a pdc_study_id column
+    csvf = tmp_path / "list.csv"
+    csvf.write_text("pdc_study_id,quant_method\nPDC5,TMT10\nPDC6,Label Free\n", encoding="utf-8")
+    assert parse_accessions(str(csvf)) == ["PDC5", "PDC6"]
+
+
+def test_pdc2qpx_cli_does_not_require_pridepy_when_skipping(tmp_path, monkeypatch):
+    """The parse + skip-download + no-metadata path must work without the pridepy extra.
+
+    Regression guard: pridepy is an optional extra (absent in CI), so accession
+    parsing and the offline conversion path must not import it.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_pridepy(name, *args, **kwargs):
+        if name == "pridepy" or name.startswith("pridepy."):
+            raise ImportError("pridepy blocked for this test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_pridepy)
+
+    from click.testing import CliRunner
+
+    from qpx.cli.pdc2qpx import pdc2qpx_cmd
+
+    download_dir = tmp_path / "downloads"
+    _stage_psm_only(download_dir, "PDC_X")
+    out = tmp_path / "qpx"
+
+    result = CliRunner().invoke(
+        pdc2qpx_cmd,
+        ["-a", "PDC_X", "--download-dir", str(download_dir), "--output-folder", str(out), "--skip-download", "--no-metadata"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (out / "PDC_X.feature.parquet").exists()

--- a/tests/converters/test_pdc2qpx.py
+++ b/tests/converters/test_pdc2qpx.py
@@ -108,3 +108,77 @@ def test_assert_cdap_psm_accepts_crlf(tmp_path):
     (study_dir / "valid_crlf.psm").write_bytes((header + row).encode("utf-8"))
 
     _assert_cdap_psm(study_dir)
+
+
+def _stage_psm_only(download_dir, study):
+    """Stage download_dir/<study>/ with the fixture .psm files."""
+    study_dir = download_dir / study
+    study_dir.mkdir(parents=True)
+    for psm in _FIXTURE_CDAP.glob("*.psm"):
+        shutil.copy(psm, study_dir / psm.name)
+
+
+def test_run_pdc2qpx_batch_isolates_failures(tmp_path):
+    """One bad study (no .psm) is recorded as failed; the batch still finishes."""
+    from qpx.pipeline.pdc2qpx import run_pdc2qpx_batch
+
+    download_dir = tmp_path / "downloads"
+    _stage_psm_only(download_dir, "PDC_GOOD")
+    (download_dir / "PDC_BAD").mkdir(parents=True)  # empty -> no .psm
+    out_root = tmp_path / "qpx"
+
+    results = run_pdc2qpx_batch(["PDC_GOOD", "PDC_BAD"], download_dir, out_root, skip_download=True, include_metadata=False)
+
+    assert results["PDC_GOOD"]["status"] == "ok"
+    assert results["PDC_BAD"]["status"] == "failed"
+    assert results["PDC_BAD"]["error"]
+    assert (out_root / "PDC_GOOD" / "PDC_GOOD.feature.parquet").exists()
+    assert sum(1 for r in results.values() if r["status"] == "ok") == 1
+
+
+def test_run_pdc2qpx_batch_stop_on_error(tmp_path):
+    """With continue_on_error=False the first failure propagates."""
+    from qpx.pipeline.pdc2qpx import run_pdc2qpx_batch
+
+    download_dir = tmp_path / "downloads"
+    (download_dir / "PDC_BAD").mkdir(parents=True)
+    with pytest.raises(FileNotFoundError):
+        run_pdc2qpx_batch(
+            ["PDC_BAD"],
+            download_dir,
+            tmp_path / "qpx",
+            skip_download=True,
+            include_metadata=False,
+            continue_on_error=False,
+        )
+
+
+def test_pdc2qpx_cli_comma_accessions_runs_batch(tmp_path):
+    """`-a PDC_A,PDC_B` resolves to multiple studies and writes one folder each."""
+    from click.testing import CliRunner
+
+    from qpx.cli.pdc2qpx import pdc2qpx_cmd
+
+    download_dir = tmp_path / "downloads"
+    _stage_psm_only(download_dir, "PDC_A")
+    _stage_psm_only(download_dir, "PDC_B")
+    out = tmp_path / "qpx"
+
+    result = CliRunner().invoke(
+        pdc2qpx_cmd,
+        [
+            "-a",
+            "PDC_A,PDC_B",
+            "--download-dir",
+            str(download_dir),
+            "--output-folder",
+            str(out),
+            "--skip-download",
+            "--no-metadata",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "2/2 studies ok" in result.output
+    assert (out / "PDC_A" / "PDC_A.feature.parquet").exists()
+    assert (out / "PDC_B" / "PDC_B.feature.parquet").exists()

--- a/tests/converters/test_pdc_sample_run.py
+++ b/tests/converters/test_pdc_sample_run.py
@@ -1,0 +1,158 @@
+"""Tests for the PDC-metadata sample/run builder (qpx.converters.cdap.pdc_sample_run).
+
+The three PDC GraphQL calls (experimental design, biospecimen, run->plex) are
+mocked, so these run fully offline. They lock the channel->sample mapping, the
+CDAP label format, the reference-channel and label-free branches, and the
+sample.parquet / run.parquet schema compliance.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pyarrow.parquet as pq
+
+from qpx.pdc.metadata import TMT_CHANNEL_FIELDS
+
+_BUILDER = "qpx.converters.cdap.pdc_sample_run"
+
+
+def _tmt10_plex(plex_id, aliquots):
+    """Build a TMT10 plex dict with 10 (aliquot_id, aliquot_submitter_id) channels."""
+    plex = {"study_run_metadata_submitter_id": plex_id, "experiment_type": "TMT10", "label_free": None}
+    for field, (aid, asid) in zip(TMT_CHANNEL_FIELDS[:10], aliquots):
+        plex[field] = [{"aliquot_id": aid, "aliquot_submitter_id": asid}]
+    return plex
+
+
+def _biospecimen(aliquots, **overrides):
+    """Build {aliquot_id: record} for the given (aliquot_id, aliquot_submitter_id) list."""
+    base = {
+        "taxon": "Homo sapiens",
+        "primary_site": "Breast",
+        "disease_type": "Breast Invasive Carcinoma",
+        "sample_type": "Primary Tumor",
+        "case_submitter_id": "11BR047",
+    }
+    base.update(overrides)
+    out = {}
+    for aid, asid in aliquots:
+        out[aid] = {"aliquot_id": aid, "aliquot_submitter_id": asid, **base}
+    return out
+
+
+def _build(tmp_path, design, biospecimen, run_to_plex, study="PDC_TEST"):
+    from qpx.converters.cdap.pdc_sample_run import build_sample_run_from_pdc
+
+    with (
+        patch(f"{_BUILDER}.fetch_experimental_design", return_value=design),
+        patch(f"{_BUILDER}.fetch_biospecimen", return_value=biospecimen),
+        patch(f"{_BUILDER}.map_runs_to_plex", return_value=run_to_plex),
+    ):
+        return build_sample_run_from_pdc(study, tmp_path, prefix=study)
+
+
+def test_tmt10_builds_sample_run_with_channel_mapping(tmp_path):
+    aliquots = [(f"al{i}", f"sub{i}") for i in range(9)] + [("alRef", "Internal Reference - Pooled Sample")]
+    plex_id = "01CPTAC_Proteome_20160911"
+    design = [_tmt10_plex(plex_id, aliquots)]
+    biospecimen = _biospecimen(aliquots[:9])  # reference deliberately absent from biospecimen
+    run_to_plex = {
+        "run_f01": {"plex": plex_id, "file_name": "run_f01.raw", "fraction": "1", "instrument": "Orbitrap Fusion"},
+        "run_f02": {"plex": plex_id, "file_name": "run_f02.raw", "fraction": "2", "instrument": "Orbitrap Fusion"},
+    }
+
+    result = _build(tmp_path, design, biospecimen, run_to_plex)
+    assert result is not None
+
+    run_tbl = pq.read_table(str(result["run"]))
+    assert run_tbl.num_rows == 2  # one row per run file
+    rows = {r["run_file_name"]: r for r in run_tbl.to_pylist()}
+    samples = rows["run_f01"]["samples"]
+    labels = [s["label"] for s in samples]
+    # CDAP TMT10 label format, all 10 channels, mass-ascending
+    assert labels == [
+        "TMT10-126",
+        "TMT10-127N",
+        "TMT10-127C",
+        "TMT10-128N",
+        "TMT10-128C",
+        "TMT10-129N",
+        "TMT10-129C",
+        "TMT10-130N",
+        "TMT10-130C",
+        "TMT10-131",
+    ]
+    # 131 channel maps to the pooled reference
+    assert samples[-1]["sample_accession"] == "Internal Reference - Pooled Sample"
+    assert rows["run_f01"]["fraction"] == "1"
+    assert rows["run_f01"]["instrument"] == "Orbitrap Fusion"
+
+    sample_tbl = pq.read_table(str(result["sample"]))
+    srows = {r["sample_accession"]: r for r in sample_tbl.to_pylist()}
+    # every run.samples.sample_accession resolves to a sample row
+    assert set(s["sample_accession"] for s in samples) <= set(srows)
+    assert srows["sub0"]["organism"] == "Homo sapiens"
+    assert srows["sub0"]["organism_part"] == "Breast"
+    assert srows["sub0"]["disease"] == "Breast Invasive Carcinoma"
+    assert srows["sub0"]["sample_type"] == "Primary Tumor"
+    # reference channel special-cased (absent from biospecimen)
+    ref = srows["Internal Reference - Pooled Sample"]
+    assert ref["organism"] == "Homo sapiens"
+    assert ref["organism_part"] == "Not Reported"
+    assert ref["sample_type"] == "Internal Reference"
+
+
+def test_label_free_single_lfq_channel(tmp_path):
+    plex_id = "PLEX_LF"
+    design = [
+        {
+            "study_run_metadata_submitter_id": plex_id,
+            "experiment_type": "Label Free",
+            "label_free": [{"aliquot_id": "alLF", "aliquot_submitter_id": "subLF"}],
+        }
+    ]
+    biospecimen = _biospecimen([("alLF", "subLF")], primary_site="Lung", disease_type="Lung Adenocarcinoma")
+    run_to_plex = {"lf_run": {"plex": plex_id, "file_name": "lf_run.raw", "fraction": None, "instrument": "QE"}}
+
+    result = _build(tmp_path, design, biospecimen, run_to_plex)
+    run_tbl = pq.read_table(str(result["run"]))
+    samples = run_tbl.to_pylist()[0]["samples"]
+    assert len(samples) == 1
+    assert samples[0]["label"] == "LFQ"
+    assert samples[0]["sample_accession"] == "subLF"
+
+    sample_tbl = pq.read_table(str(result["sample"]))
+    srows = {r["sample_accession"]: r for r in sample_tbl.to_pylist()}
+    assert srows["subLF"]["organism_part"] == "Lung"
+
+
+def test_unsupported_experiment_type_skips_channels(tmp_path):
+    """TMT16 is not modelled by CDAP; its runs get no channel mapping (empty samples)."""
+    plex_id = "PLEX_TMT16"
+    design = [{"study_run_metadata_submitter_id": plex_id, "experiment_type": "TMT16", "label_free": None}]
+    run_to_plex = {"t16_run": {"plex": plex_id, "file_name": "t16_run.raw", "fraction": "1", "instrument": "Lumos"}}
+
+    result = _build(tmp_path, design, {}, run_to_plex)
+    run_tbl = pq.read_table(str(result["run"]))
+    assert run_tbl.to_pylist()[0]["samples"] == []
+
+
+def test_channel_count_mismatch_skips_plex(tmp_path):
+    """A plex declaring TMT10 but missing a channel must not emit a wrong mapping."""
+    plex_id = "PLEX_BAD"
+    aliquots = [(f"al{i}", f"sub{i}") for i in range(10)]
+    plex = _tmt10_plex(plex_id, aliquots)
+    del plex["tmt_131"]  # only 9 channels now
+    run_to_plex = {"bad_run": {"plex": plex_id, "file_name": "bad_run.raw", "fraction": "1", "instrument": "X"}}
+
+    result = _build(tmp_path, [plex], _biospecimen(aliquots), run_to_plex)
+    run_tbl = pq.read_table(str(result["run"]))
+    assert run_tbl.to_pylist()[0]["samples"] == []
+
+
+def test_empty_run_to_plex_returns_none(tmp_path):
+    result = _build(tmp_path, [], {}, {})
+    assert result is None
+    assert not (tmp_path / "PDC_TEST.run.parquet").exists()
+    assert not (tmp_path / "PDC_TEST.sample.parquet").exists()

--- a/tests/converters/test_pdc_sample_run.py
+++ b/tests/converters/test_pdc_sample_run.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pyarrow.parquet as pq
+import pytest
 
 from qpx.pdc.metadata import TMT_CHANNEL_FIELDS
 
@@ -156,3 +157,66 @@ def test_empty_run_to_plex_returns_none(tmp_path):
     assert result is None
     assert not (tmp_path / "PDC_TEST.run.parquet").exists()
     assert not (tmp_path / "PDC_TEST.sample.parquet").exists()
+
+
+def _tmt11_plex(plex_id, aliquots, *, with_tmtxx=False):
+    """Build a TMT11 plex; ``with_tmtxx`` also populates the legacy 132N/C channels."""
+    n_channels = 13 if with_tmtxx else 11
+    plex = {"study_run_metadata_submitter_id": plex_id, "experiment_type": "TMT11", "label_free": None}
+    for field, (aid, asid) in zip(TMT_CHANNEL_FIELDS[:n_channels], aliquots):
+        plex[field] = [{"aliquot_id": aid, "aliquot_submitter_id": asid}]
+    return plex
+
+
+def test_tmt11_with_tmtxx_extra_channels_maps_all(tmp_path):
+    """A TMT11 plex that also carries TMTXX 132N/C maps all 13 channels, not skips.
+
+    CDAP appends the legacy TMTXX channels for TMT11 studies, so the metadata
+    builder must too -- otherwise these 15 known pilot studies get empty samples.
+    """
+    aliquots = [(f"al{i}", f"sub{i}") for i in range(13)]
+    plex_id = "01CPTAC_TMT11_TMTXX"
+    design = [_tmt11_plex(plex_id, aliquots, with_tmtxx=True)]
+    run_to_plex = {"t11_run": {"plex": plex_id, "file_name": "t11_run.raw", "fraction": "1", "instrument": "Lumos"}}
+
+    result = _build(tmp_path, design, _biospecimen(aliquots), run_to_plex)
+    labels = [s["label"] for s in pq.read_table(str(result["run"])).to_pylist()[0]["samples"]]
+    assert len(labels) == 13
+    assert labels[0] == "TMT11-126C"
+    assert labels[-2:] == ["TMTXX-132N", "TMTXX-132C"]
+
+
+def test_build_failure_preserves_existing_outputs(tmp_path):
+    """A build failure must not clobber a previously-good sample/run parquet."""
+    from qpx.converters.cdap.pdc_sample_run import build_sample_run_from_pdc
+
+    good_sample = tmp_path / "PDC_TEST.sample.parquet"
+    good_run = tmp_path / "PDC_TEST.run.parquet"
+    good_sample.write_bytes(b"PRIOR-GOOD-SAMPLE")
+    good_run.write_bytes(b"PRIOR-GOOD-RUN")
+
+    with (
+        patch(f"{_BUILDER}.fetch_experimental_design", return_value=[]),
+        patch(f"{_BUILDER}.fetch_biospecimen", return_value={}),
+        patch(f"{_BUILDER}.map_runs_to_plex", side_effect=RuntimeError("network down")),
+    ):
+        with pytest.raises(RuntimeError):
+            build_sample_run_from_pdc("PDC_TEST", tmp_path, prefix="PDC_TEST")
+
+    assert good_sample.read_bytes() == b"PRIOR-GOOD-SAMPLE"
+    assert good_run.read_bytes() == b"PRIOR-GOOD-RUN"
+    assert not (tmp_path / "PDC_TEST.sample.parquet.tmp").exists()
+    assert not (tmp_path / "PDC_TEST.run.parquet.tmp").exists()
+
+
+def test_strip_raw_extension_matches_cdap():
+    """metadata._strip_raw_extension must strip the exact same set as CDAP, so a
+    PDC-derived run_file_name matches the CDAP stem (else run<->feature joins break)."""
+    from qpx.converters.cdap.base_adapter import CdapBaseAdapter
+    from qpx.pdc.metadata import _strip_raw_extension
+
+    for name in ("run_f01.raw", "run_f01.mzML", "run_f01.mgf", "run_f01.mzML.gz", "run_f01.d", "run_f01"):
+        assert _strip_raw_extension(name) == CdapBaseAdapter.strip_run_extension(name)
+    # .mzML.gz / .d are intentionally left intact (CDAP does not strip them either)
+    assert _strip_raw_extension("run_f01.mzML.gz") == "run_f01.mzML.gz"
+    assert _strip_raw_extension("run_f01.d") == "run_f01.d"

--- a/tests/converters/test_quantms_tmt_channels.py
+++ b/tests/converters/test_quantms_tmt_channels.py
@@ -1,0 +1,81 @@
+"""Plex-aware TMT channel labelling in the quantms feature adapter.
+
+TMT10plex's 10th reporter is the standard ``131``; TMT11+ renames it ``131N`` to
+pair with the added ``131C``. These lock that the feature adapter emits
+``TMT131`` for a TMT10plex run (matching the CDAP converter and OpenMS/SDRF) and
+``TMT131N``/``TMT131C`` for TMT11 -- so numeric-channel MSstats no longer mislabels
+channel 10 as ``TMT131N`` on a TMT10 study.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from qpx.converters.base import resolve_columns
+from qpx.converters.quantms.feature_adapter import _FEATURE_MAP, QuantmsFeatureAdapter
+
+
+def _adapter_with_channels(channels) -> QuantmsFeatureAdapter:
+    """Build an adapter whose in-memory msstats table holds the given numeric channels."""
+    adapter = QuantmsFeatureAdapter()
+    values = ", ".join(f"({c})" for c in channels)
+    adapter._conn.execute(f"CREATE TABLE msstats AS SELECT * FROM (VALUES {values}) AS t(Channel)")
+    return adapter
+
+
+def test_tmt10_channel_10_is_131():
+    """A 10-channel run labels channel 10 as the standard TMT131, not TMT131N."""
+    channel_map = _adapter_with_channels(range(1, 11))._resolve_tmt_channel_map()
+    assert channel_map[1] == "TMT126"
+    assert channel_map[10] == "TMT131"  # not TMT131N -- TMT10plex has no 131C
+
+
+def test_tmt11_channel_10_is_131n_and_11_is_131c():
+    """An 11-channel run keeps the TMT11 naming: channel 10 = TMT131N, 11 = TMT131C."""
+    channel_map = _adapter_with_channels(range(1, 12))._resolve_tmt_channel_map()
+    assert channel_map[10] == "TMT131N"
+    assert channel_map[11] == "TMT131C"
+
+
+def test_non_numeric_channels_leave_map_unchanged():
+    """String channels (already labelled upstream) must not trigger the TMT10 relabel."""
+    adapter = QuantmsFeatureAdapter()
+    adapter._conn.execute("CREATE TABLE msstats AS SELECT * FROM (VALUES ('TMT131')) AS t(Channel)")
+    assert adapter._resolve_tmt_channel_map()[10] == "TMT131N"
+
+
+def test_tmt10_feature_labels_end_to_end():
+    """A one-feature TMT10 batch yields TMT126..TMT131 with channel 10 = TMT131."""
+    adapter = _adapter_with_channels(range(1, 11))
+    adapter._tmt_channel_map = adapter._resolve_tmt_channel_map()
+    adapter._modifications_meta = {}
+    adapter._enzyme_name = None
+
+    df = pd.DataFrame(
+        {
+            "PeptideSequence": ["PEPTIDE"] * 10,
+            "ProteinName": ["P12345"] * 10,
+            "Reference": ["run1.raw"] * 10,
+            "Charge": [2] * 10,
+            "Channel": list(range(1, 11)),
+            "Intensity": [float(i) for i in range(1, 11)],
+            "RetentionTime": [10.0] * 10,
+        }
+    )
+    col_map = resolve_columns(_FEATURE_MAP, set(df.columns))
+    records = adapter._transform_batch_isobaric(df, col_map, {}, {}, {}, "TMT")
+
+    assert len(records) == 1
+    labels = [entry["label"] for entry in records[0]["intensities"]]
+    assert labels == [
+        "TMT126",
+        "TMT127N",
+        "TMT127C",
+        "TMT128N",
+        "TMT128C",
+        "TMT129N",
+        "TMT129C",
+        "TMT130N",
+        "TMT130C",
+        "TMT131",
+    ]


### PR DESCRIPTION
This pull request significantly enhances the `pdc2qpx` command to support batch processing of PDC/CPTAC studies, adds robust sample/run metadata extraction from PDC GraphQL APIs, and improves documentation and CLI usability. The changes ensure that biological sample metadata and channel mappings are recovered for downstream analysis, and that the command can handle multiple studies in a single run, reporting failures without aborting the batch by default.

**Key changes:**

### CLI and Batch Processing Enhancements
- The `pdc2qpx` CLI now accepts a new `-a/--accession` option, supporting single IDs, comma-separated IDs, or a CSV file for batch conversion. It adds options for skipping metadata extraction (`--no-metadata`) and controlling batch failure behavior (`--stop-on-error`). The command logic is refactored to process multiple studies, reporting results for each and continuing past failures unless instructed otherwise. [[1]](diffhunk://#diff-850480c9c08a18662827730ada2bcdd20a743049b95fa78ea66160c4fda73275L13-R18) [[2]](diffhunk://#diff-850480c9c08a18662827730ada2bcdd20a743049b95fa78ea66160c4fda73275L24-R42) [[3]](diffhunk://#diff-850480c9c08a18662827730ada2bcdd20a743049b95fa78ea66160c4fda73275R62-R135)

### Metadata Extraction and Sample/Run View Generation
- Introduces a new module (`qpx/converters/cdap/pdc_sample_run.py`) that builds `sample.parquet` and `run.parquet` files for each study by querying PDC GraphQL APIs. This recovers the channel-to-sample mapping missing from CDAP `.psm` files, enabling correct interpretation of reporter intensities in downstream analyses.
- Updates converter logic to clarify that `sample` and `run` views are produced from PDC metadata at the `pdc2qpx` layer, not by the CDAP converter itself. [[1]](diffhunk://#diff-2bb05bf11023ca823b52b4bb331b324acc68a06b9f9814faedab780435e661bbL15-R15) [[2]](diffhunk://#diff-2bb05bf11023ca823b52b4bb331b324acc68a06b9f9814faedab780435e661bbL208-R210)

### Documentation Updates
- Substantially revises the `README.md` and user guide for `pdc2qpx` to describe new CLI options, batch processing, input formats, and the origin of `sample`/`run` views. Adds usage examples for both single-study and multi-study runs, and clarifies output structure and error handling. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L180-R190) [[2]](diffhunk://#diff-01de84485e5b1a9ded87445e5f7d71946f4f21f6ad77ad229114e6ae95592d82L3-R10) [[3]](diffhunk://#diff-01de84485e5b1a9ded87445e5f7d71946f4f21f6ad77ad229114e6ae95592d82L20-R86)
- Updates the converter coverage specification to document that CDAP sample/run views are available "If PDC" and explains their provenance from PDC GraphQL metadata rather than SDRF files.

### Internal Structure and Metadata Layer
- Adds a new `qpx/pdc/__init__.py` module to encapsulate PDC GraphQL helpers, decoupling metadata retrieval from pridepy and clarifying the download/metadata separation.