### PR TITLE
Run 'ruff format' on codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ QPX datasets can be exported to [MuData](https://mudata.readthedocs.io/) — the
 
 ```python
 ds = Dataset("path/to/PXD000000/")
-mdata = ds.to_mudata()              # auto-detects label & available modalities
-mdata.write("PXD000000.h5mu")       # serialize to HDF5
+mdata = ds.to_mudata()  # auto-detects label & available modalities
+mdata.write("PXD000000.h5mu")  # serialize to HDF5
 ```
 
 > Requires the optional `mudata` dependency: `pip install "qpx[mudata]"`

--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -6,89 +6,94 @@ Convert various mass spectrometry data formats to the QPX standard format.
 import click
 import textwrap
 
+
 def get_click_type_display(param):
     param_type = param.type
     type_str = str(param_type)
-    if 'Path' in type_str:
-        if hasattr(param_type, 'dir_okay') and not param_type.dir_okay:
-            return 'FILE'
-        elif hasattr(param_type, 'file_okay') and not param_type.file_okay:
-            return 'DIRECTORY'
+    if "Path" in type_str:
+        if hasattr(param_type, "dir_okay") and not param_type.dir_okay:
+            return "FILE"
+        elif hasattr(param_type, "file_okay") and not param_type.file_okay:
+            return "DIRECTORY"
         else:
-            return 'PATH'
+            return "PATH"
     elif isinstance(param_type, click.types.FloatParamType):
-        return 'FLOAT'
+        return "FLOAT"
     elif isinstance(param_type, click.types.IntParamType):
-        return 'INTEGER'
+        return "INTEGER"
     elif param.is_flag:
-        return 'FLAG'
+        return "FLAG"
     else:
-        return 'TEXT'
+        return "TEXT"
+
 
 def generate_params_table(command):
-    table = '<table>\n<thead>\n<tr>\n'
-    table += '<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n'
-    table += '</tr>\n</thead>\n<tbody>\n'
+    table = "<table>\n<thead>\n<tr>\n"
+    table += "<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n"
+    table += "</tr>\n</thead>\n<tbody>\n"
     for param in command.params:
-        if isinstance(param, click.Option) and param.name not in ['help']:
+        if isinstance(param, click.Option) and param.name not in ["help"]:
             param_names = param.opts
             param_name = param_names[0] if param_names else f"--{param.name}"
             param_type = get_click_type_display(param)
-            required = 'Yes' if param.required else 'No'
+            required = "Yes" if param.required else "No"
 
             # Extract default value from help text if it contains "(default: ...)"
-            description = param.help or ''
+            description = param.help or ""
             default_from_help = None
-            if '(default:' in description.lower():
+            if "(default:" in description.lower():
                 import re
-                match = re.search(r'\(default:\s*([^)]+)\)', description, re.IGNORECASE)
+
+                match = re.search(r"\(default:\s*([^)]+)\)", description, re.IGNORECASE)
                 if match:
                     default_from_help = match.group(1).strip()
 
             # Determine default value display
             if default_from_help:
                 default = default_from_help
-            elif param.default is not None and str(param.default) != 'Sentinel.UNSET':
+            elif param.default is not None and str(param.default) != "Sentinel.UNSET":
                 if param.is_flag:
-                    default = '-'
+                    default = "-"
                 elif isinstance(param.default, (int, float)):
                     default = str(param.default)
                 elif isinstance(param.default, str):
-                    default = f'<code>{param.default}</code>'
+                    default = f"<code>{param.default}</code>"
                 else:
                     default = str(param.default)
             else:
-                default = '-'
+                default = "-"
 
-            table += f'<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n'
-    table += '</tbody>\n</table>'
+            table += f"<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n"
+    table += "</tbody>\n</table>"
     return table
+
 
 def generate_description(command):
     if command.help:
         help_text = command.help
-        if 'Example' in help_text:
-            description = help_text.split('Example')[0].strip()
+        if "Example" in help_text:
+            description = help_text.split("Example")[0].strip()
         else:
             description = help_text.strip()
-        lines = description.split('\n')
+        lines = description.split("\n")
         if len(lines) > 1:
-            description = '\n'.join(lines[1:]).strip()
-            return f'<p>{description}</p>'
-    return ''
+            description = "\n".join(lines[1:]).strip()
+            return f"<p>{description}</p>"
+    return ""
 
-def generate_example(command, default_text=''):
-    if command.help and 'Example' in command.help:
-        example_section = command.help.split('Example')[1]
-        if ':' in example_section:
-            example_section = example_section.split(':', 1)[1]
+
+def generate_example(command, default_text=""):
+    if command.help and "Example" in command.help:
+        example_section = command.help.split("Example")[1]
+        if ":" in example_section:
+            example_section = example_section.split(":", 1)[1]
         example_section = textwrap.dedent(example_section).strip()
-        output = ''
+        output = ""
         if default_text:
-            output += f'<p>{default_text}</p>\n'
+            output += f"<p>{default_text}</p>\n"
         output += f'<pre><code class="language-bash">{example_section}</code></pre>'
         return output
-    return ''
+    return ""
 ```
 
 ## Overview
@@ -115,6 +120,7 @@ Convert QuantMS mzTab output to QPX format.
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_quantms_cmd
+
 print(generate_description(convert_quantms_cmd))
 ```
 
@@ -122,6 +128,7 @@ print(generate_description(convert_quantms_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_quantms_cmd
+
 print(generate_params_table(convert_quantms_cmd))
 ```
 
@@ -131,7 +138,8 @@ print(generate_params_table(convert_quantms_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_quantms_cmd
-print(generate_example(convert_quantms_cmd, 'Convert QuantMS data with default settings:'))
+
+print(generate_example(convert_quantms_cmd, "Convert QuantMS data with default settings:"))
 ```
 
 #### PSM Data Only {#quantms-example-psm}
@@ -207,6 +215,7 @@ Convert DIA-NN report files to QPX format.
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_diann_cmd
+
 print(generate_description(convert_diann_cmd))
 ```
 
@@ -214,6 +223,7 @@ print(generate_description(convert_diann_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_diann_cmd
+
 print(generate_params_table(convert_diann_cmd))
 ```
 
@@ -223,7 +233,8 @@ print(generate_params_table(convert_diann_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_diann_cmd
-print(generate_example(convert_diann_cmd, 'Convert a DIA-NN report with default settings:'))
+
+print(generate_example(convert_diann_cmd, "Convert a DIA-NN report with default settings:"))
 ```
 
 #### Advanced Example with Partitioning {#diann-example-partitioning}
@@ -297,6 +308,7 @@ Convert Spectronaut report files to QPX format.
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_spectronaut_cmd
+
 print(generate_description(convert_spectronaut_cmd))
 ```
 
@@ -304,6 +316,7 @@ print(generate_description(convert_spectronaut_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_spectronaut_cmd
+
 print(generate_params_table(convert_spectronaut_cmd))
 ```
 
@@ -313,7 +326,8 @@ print(generate_params_table(convert_spectronaut_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_spectronaut_cmd
-print(generate_example(convert_spectronaut_cmd, 'Convert Spectronaut data with default settings:'))
+
+print(generate_example(convert_spectronaut_cmd, "Convert Spectronaut data with default settings:"))
 ```
 
 #### With SDRF Metadata {#spectronaut-example-sdrf}
@@ -394,6 +408,7 @@ Convert MaxQuant output to QPX format.
 
 ```python exec="1" session="doc_utils" html="1"
 from qpx.cli.convert import convert_maxquant_cmd
+
 print(generate_description(convert_maxquant_cmd))
 ```
 
@@ -401,6 +416,7 @@ print(generate_description(convert_maxquant_cmd))
 
 ```python exec="1" session="doc_utils" html="1"
 from qpx.cli.convert import convert_maxquant_cmd
+
 print(generate_params_table(convert_maxquant_cmd))
 ```
 
@@ -410,7 +426,8 @@ print(generate_params_table(convert_maxquant_cmd))
 
 ```python exec="1" session="doc_utils" html="1"
 from qpx.cli.convert import convert_maxquant_cmd
-print(generate_example(convert_maxquant_cmd, 'Convert MaxQuant data with default settings:'))
+
+print(generate_example(convert_maxquant_cmd, "Convert MaxQuant data with default settings:"))
 ```
 
 #### PSM Data Only {#maxquant-example-psm}
@@ -488,6 +505,7 @@ Convert FragPipe output to QPX format.
 
 ```python exec="1" session="doc_utils" html="1"
 from qpx.cli.convert import convert_fragpipe_cmd
+
 print(generate_description(convert_fragpipe_cmd))
 ```
 
@@ -495,6 +513,7 @@ print(generate_description(convert_fragpipe_cmd))
 
 ```python exec="1" session="doc_utils" html="1"
 from qpx.cli.convert import convert_fragpipe_cmd
+
 print(generate_params_table(convert_fragpipe_cmd))
 ```
 
@@ -504,7 +523,8 @@ print(generate_params_table(convert_fragpipe_cmd))
 
 ```python exec="1" session="doc_utils" html="1"
 from qpx.cli.convert import convert_fragpipe_cmd
-print(generate_example(convert_fragpipe_cmd, 'Convert FragPipe PSM data with default settings:'))
+
+print(generate_example(convert_fragpipe_cmd, "Convert FragPipe PSM data with default settings:"))
 ```
 
 #### With Custom Settings {#fragpipe-example-custom}
@@ -533,6 +553,7 @@ Convert mzIdentML (.mzid) files to QPX PSM parquet format.
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_mzidentml_cmd
+
 print(generate_description(convert_mzidentml_cmd))
 ```
 
@@ -540,6 +561,7 @@ print(generate_description(convert_mzidentml_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_mzidentml_cmd
+
 print(generate_params_table(convert_mzidentml_cmd))
 ```
 
@@ -549,7 +571,8 @@ print(generate_params_table(convert_mzidentml_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_mzidentml_cmd
-print(generate_example(convert_mzidentml_cmd, 'Convert an mzIdentML file with default settings:'))
+
+print(generate_example(convert_mzidentml_cmd, "Convert an mzIdentML file with default settings:"))
 ```
 
 #### With Spectral Data from Single mzML {#mzidentml-example-spectral}
@@ -634,6 +657,7 @@ Convert SDRF metadata files to QPX sample and run parquet format.
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_sdrf_cmd
+
 print(generate_description(convert_sdrf_cmd))
 ```
 
@@ -641,6 +665,7 @@ print(generate_description(convert_sdrf_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_sdrf_cmd
+
 print(generate_params_table(convert_sdrf_cmd))
 ```
 
@@ -650,7 +675,8 @@ print(generate_params_table(convert_sdrf_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.convert import convert_sdrf_cmd
-print(generate_example(convert_sdrf_cmd, 'Convert SDRF metadata with default settings:'))
+
+print(generate_example(convert_sdrf_cmd, "Convert SDRF metadata with default settings:"))
 ```
 
 ### Output Files {#sdrf-output}

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -164,10 +164,7 @@ with qpx.open_dataset("./output") as ds:
         print(f"{name}: {result.summary}")
 
     # Query with SQL
-    top_proteins = ds.sql(
-        "SELECT anchor_protein, COUNT(*) AS n "
-        "FROM feature GROUP BY 1 ORDER BY n DESC LIMIT 10"
-    )
+    top_proteins = ds.sql("SELECT anchor_protein, COUNT(*) AS n FROM feature GROUP BY 1 ORDER BY n DESC LIMIT 10")
     print(top_proteins)
 
     # Access data views as DataFrames

--- a/docs/guide/info.md
+++ b/docs/guide/info.md
@@ -6,86 +6,91 @@ Inspect QPX datasets — view summaries, schemas, and Parquet metadata.
 import click
 import textwrap
 
+
 def get_click_type_display(param):
     param_type = param.type
     type_str = str(param_type)
-    if 'Path' in type_str:
-        if hasattr(param_type, 'dir_okay') and not param_type.dir_okay:
-            return 'FILE'
-        elif hasattr(param_type, 'file_okay') and not param_type.file_okay:
-            return 'DIRECTORY'
+    if "Path" in type_str:
+        if hasattr(param_type, "dir_okay") and not param_type.dir_okay:
+            return "FILE"
+        elif hasattr(param_type, "file_okay") and not param_type.file_okay:
+            return "DIRECTORY"
         else:
-            return 'PATH'
+            return "PATH"
     elif isinstance(param_type, click.types.FloatParamType):
-        return 'FLOAT'
+        return "FLOAT"
     elif isinstance(param_type, click.types.IntParamType):
-        return 'INTEGER'
+        return "INTEGER"
     elif param.is_flag:
-        return 'FLAG'
+        return "FLAG"
     elif isinstance(param_type, click.Choice):
-        return 'CHOICE'
+        return "CHOICE"
     else:
-        return 'TEXT'
+        return "TEXT"
+
 
 def generate_params_table(command):
-    table = '<table>\n<thead>\n<tr>\n'
-    table += '<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n'
-    table += '</tr>\n</thead>\n<tbody>\n'
+    table = "<table>\n<thead>\n<tr>\n"
+    table += "<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n"
+    table += "</tr>\n</thead>\n<tbody>\n"
     for param in command.params:
-        if isinstance(param, click.Option) and param.name not in ['help']:
+        if isinstance(param, click.Option) and param.name not in ["help"]:
             param_names = param.opts
             param_name = param_names[0] if param_names else f"--{param.name}"
             param_type = get_click_type_display(param)
-            required = 'Yes' if param.required else 'No'
-            description = param.help or ''
+            required = "Yes" if param.required else "No"
+            description = param.help or ""
             default_from_help = None
-            if '(default:' in description.lower():
+            if "(default:" in description.lower():
                 import re
-                match = re.search(r'\(default:\s*([^)]+)\)', description, re.IGNORECASE)
+
+                match = re.search(r"\(default:\s*([^)]+)\)", description, re.IGNORECASE)
                 if match:
                     default_from_help = match.group(1).strip()
             if default_from_help:
                 default = default_from_help
-            elif param.default is not None and str(param.default) != 'Sentinel.UNSET':
+            elif param.default is not None and str(param.default) != "Sentinel.UNSET":
                 if param.is_flag:
-                    default = '-'
+                    default = "-"
                 elif isinstance(param.default, (int, float)):
                     default = str(param.default)
                 elif isinstance(param.default, str):
-                    default = f'<code>{param.default}</code>'
+                    default = f"<code>{param.default}</code>"
                 else:
                     default = str(param.default)
             else:
-                default = '-'
-            table += f'<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n'
-    table += '</tbody>\n</table>'
+                default = "-"
+            table += f"<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n"
+    table += "</tbody>\n</table>"
     return table
+
 
 def generate_description(command):
     if command.help:
         help_text = command.help
-        if 'Example' in help_text:
-            description = help_text.split('Example')[0].strip()
+        if "Example" in help_text:
+            description = help_text.split("Example")[0].strip()
         else:
             description = help_text.strip()
-        lines = description.split('\n')
+        lines = description.split("\n")
         if len(lines) > 1:
-            description = '\n'.join(lines[1:]).strip()
-            return f'<p>{description}</p>'
-    return ''
+            description = "\n".join(lines[1:]).strip()
+            return f"<p>{description}</p>"
+    return ""
 
-def generate_example(command, default_text=''):
-    if command.help and 'Example' in command.help:
-        example_section = command.help.split('Example')[1]
-        if ':' in example_section:
-            example_section = example_section.split(':', 1)[1]
+
+def generate_example(command, default_text=""):
+    if command.help and "Example" in command.help:
+        example_section = command.help.split("Example")[1]
+        if ":" in example_section:
+            example_section = example_section.split(":", 1)[1]
         example_section = textwrap.dedent(example_section).strip()
-        output = ''
+        output = ""
         if default_text:
-            output += f'<p>{default_text}</p>\n'
+            output += f"<p>{default_text}</p>\n"
         output += f'<pre><code class="language-bash">{example_section}</code></pre>'
         return output
-    return ''
+    return ""
 ```
 
 ## Overview
@@ -108,6 +113,7 @@ Show a summary of a QPX dataset.
 
 ```python exec="1" html="1" session="info_utils"
 from qpx.cli.info import info
+
 print(generate_params_table(info))
 ```
 
@@ -115,6 +121,7 @@ print(generate_params_table(info))
 
 ```python exec="1" html="1" session="info_utils"
 from qpx.cli.info import info
+
 print(generate_description(info))
 ```
 
@@ -122,7 +129,8 @@ print(generate_description(info))
 
 ```python exec="1" html="1" session="info_utils"
 from qpx.cli.info import info
-print(generate_example(info, 'Show dataset summary:'))
+
+print(generate_example(info, "Show dataset summary:"))
 ```
 
 ---
@@ -135,6 +143,7 @@ Show the Arrow schema for a QPX data structure.
 
 ```python exec="1" html="1" session="info_utils"
 from qpx.cli.info import info_schema_cmd
+
 print(generate_description(info_schema_cmd))
 ```
 
@@ -142,6 +151,7 @@ print(generate_description(info_schema_cmd))
 
 ```python exec="1" html="1" session="info_utils"
 from qpx.cli.info import info_schema_cmd
+
 print(generate_params_table(info_schema_cmd))
 ```
 
@@ -149,7 +159,8 @@ print(generate_params_table(info_schema_cmd))
 
 ```python exec="1" html="1" session="info_utils"
 from qpx.cli.info import info_schema_cmd
-print(generate_example(info_schema_cmd, 'Inspect data structure schemas:'))
+
+print(generate_example(info_schema_cmd, "Inspect data structure schemas:"))
 ```
 
 ---
@@ -162,6 +173,7 @@ Show Parquet footer metadata for QPX files.
 
 ```python exec="1" html="1" session="info_utils"
 from qpx.cli.info import info_metadata_cmd
+
 print(generate_description(info_metadata_cmd))
 ```
 
@@ -169,6 +181,7 @@ print(generate_description(info_metadata_cmd))
 
 ```python exec="1" html="1" session="info_utils"
 from qpx.cli.info import info_metadata_cmd
+
 print(generate_params_table(info_metadata_cmd))
 ```
 
@@ -176,7 +189,8 @@ print(generate_params_table(info_metadata_cmd))
 
 ```python exec="1" html="1" session="info_utils"
 from qpx.cli.info import info_metadata_cmd
-print(generate_example(info_metadata_cmd, 'View Parquet file metadata:'))
+
+print(generate_example(info_metadata_cmd, "View Parquet file metadata:"))
 ```
 
 ---

--- a/docs/guide/ontology.md
+++ b/docs/guide/ontology.md
@@ -6,91 +6,96 @@ Manage controlled vocabulary (CV) ontology data used by QPX, including PSI-MS an
 import click
 import textwrap
 
+
 def get_click_type_display(param):
     param_type = param.type
     type_str = str(param_type)
-    if 'Path' in type_str:
-        if hasattr(param_type, 'dir_okay') and not param_type.dir_okay:
-            return 'FILE'
-        elif hasattr(param_type, 'file_okay') and not param_type.file_okay:
-            return 'DIRECTORY'
+    if "Path" in type_str:
+        if hasattr(param_type, "dir_okay") and not param_type.dir_okay:
+            return "FILE"
+        elif hasattr(param_type, "file_okay") and not param_type.file_okay:
+            return "DIRECTORY"
         else:
-            return 'PATH'
+            return "PATH"
     elif isinstance(param_type, click.types.FloatParamType):
-        return 'FLOAT'
+        return "FLOAT"
     elif isinstance(param_type, click.types.IntParamType):
-        return 'INTEGER'
+        return "INTEGER"
     elif param.is_flag:
-        return 'FLAG'
+        return "FLAG"
     elif isinstance(param_type, click.Choice):
-        return 'CHOICE'
+        return "CHOICE"
     else:
-        return 'TEXT'
+        return "TEXT"
+
 
 def generate_params_table(command):
-    table = '<table>\n<thead>\n<tr>\n'
-    table += '<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n'
-    table += '</tr>\n</thead>\n<tbody>\n'
+    table = "<table>\n<thead>\n<tr>\n"
+    table += "<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n"
+    table += "</tr>\n</thead>\n<tbody>\n"
     for param in command.params:
-        if isinstance(param, click.Option) and param.name not in ['help']:
+        if isinstance(param, click.Option) and param.name not in ["help"]:
             param_names = param.opts
             param_name = param_names[0] if param_names else f"--{param.name}"
             param_type = get_click_type_display(param)
-            required = 'Yes' if param.required else 'No'
-            description = param.help or ''
+            required = "Yes" if param.required else "No"
+            description = param.help or ""
             default_from_help = None
-            if '(default:' in description.lower():
+            if "(default:" in description.lower():
                 import re
-                match = re.search(r'\(default:\s*([^)]+)\)', description, re.IGNORECASE)
+
+                match = re.search(r"\(default:\s*([^)]+)\)", description, re.IGNORECASE)
                 if match:
                     default_from_help = match.group(1).strip()
             if default_from_help:
                 default = default_from_help
-            elif param.default is not None and str(param.default) != 'Sentinel.UNSET':
+            elif param.default is not None and str(param.default) != "Sentinel.UNSET":
                 if param.is_flag:
-                    default = '-'
+                    default = "-"
                 elif isinstance(param.default, (int, float)):
                     default = str(param.default)
                 elif isinstance(param.default, str):
-                    default = f'<code>{param.default}</code>'
+                    default = f"<code>{param.default}</code>"
                 else:
                     default = str(param.default)
             else:
-                default = '-'
-            table += f'<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n'
+                default = "-"
+            table += f"<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n"
     # Also handle Arguments
     for param in command.params:
         if isinstance(param, click.Argument):
             param_name = param.name.upper()
-            table += f'<tr>\n<td><code>{param_name}</code></td>\n<td>TEXT</td>\n<td>Yes</td>\n<td>-</td>\n<td>Positional argument</td>\n</tr>\n'
-    table += '</tbody>\n</table>'
+            table += f"<tr>\n<td><code>{param_name}</code></td>\n<td>TEXT</td>\n<td>Yes</td>\n<td>-</td>\n<td>Positional argument</td>\n</tr>\n"
+    table += "</tbody>\n</table>"
     return table
+
 
 def generate_description(command):
     if command.help:
         help_text = command.help
-        if 'Example' in help_text:
-            description = help_text.split('Example')[0].strip()
+        if "Example" in help_text:
+            description = help_text.split("Example")[0].strip()
         else:
             description = help_text.strip()
-        lines = description.split('\n')
+        lines = description.split("\n")
         if len(lines) > 1:
-            description = '\n'.join(lines[1:]).strip()
-            return f'<p>{description}</p>'
-    return ''
+            description = "\n".join(lines[1:]).strip()
+            return f"<p>{description}</p>"
+    return ""
 
-def generate_example(command, default_text=''):
-    if command.help and 'Example' in command.help:
-        example_section = command.help.split('Example')[1]
-        if ':' in example_section:
-            example_section = example_section.split(':', 1)[1]
+
+def generate_example(command, default_text=""):
+    if command.help and "Example" in command.help:
+        example_section = command.help.split("Example")[1]
+        if ":" in example_section:
+            example_section = example_section.split(":", 1)[1]
         example_section = textwrap.dedent(example_section).strip()
-        output = ''
+        output = ""
         if default_text:
-            output += f'<p>{default_text}</p>\n'
+            output += f"<p>{default_text}</p>\n"
         output += f'<pre><code class="language-bash">{example_section}</code></pre>'
         return output
-    return ''
+    return ""
 ```
 
 ## Overview
@@ -114,6 +119,7 @@ Show loaded ontology sources, versions, and cache status.
 
 ```python exec="1" html="1" session="ontology_utils"
 from qpx.cli.ontology import info
+
 print(generate_params_table(info))
 ```
 
@@ -121,7 +127,8 @@ print(generate_params_table(info))
 
 ```python exec="1" html="1" session="ontology_utils"
 from qpx.cli.ontology import info
-print(generate_example(info, 'Show ontology source status:'))
+
+print(generate_example(info, "Show ontology source status:"))
 ```
 
 ---
@@ -134,6 +141,7 @@ Search for CV terms matching a query string.
 
 ```python exec="1" html="1" session="ontology_utils"
 from qpx.cli.ontology import search
+
 print(generate_params_table(search))
 ```
 
@@ -141,7 +149,8 @@ print(generate_params_table(search))
 
 ```python exec="1" html="1" session="ontology_utils"
 from qpx.cli.ontology import search
-print(generate_example(search, 'Search for CV terms:'))
+
+print(generate_example(search, "Search for CV terms:"))
 ```
 
 ---
@@ -154,6 +163,7 @@ Force download the latest ontology data from the repository.
 
 ```python exec="1" html="1" session="ontology_utils"
 from qpx.cli.ontology import update
+
 print(generate_params_table(update))
 ```
 
@@ -161,7 +171,8 @@ print(generate_params_table(update))
 
 ```python exec="1" html="1" session="ontology_utils"
 from qpx.cli.ontology import update
-print(generate_example(update, 'Update ontology data:'))
+
+print(generate_example(update, "Update ontology data:"))
 ```
 
 ---
@@ -174,6 +185,7 @@ Rebuild ontology Parquet files from OBO sources. This is a maintainer command fo
 
 ```python exec="1" html="1" session="ontology_utils"
 from qpx.cli.ontology import build
+
 print(generate_params_table(build))
 ```
 
@@ -181,5 +193,6 @@ print(generate_params_table(build))
 
 ```python exec="1" html="1" session="ontology_utils"
 from qpx.cli.ontology import build
-print(generate_example(build, 'Rebuild ontology Parquet files:'))
+
+print(generate_example(build, "Rebuild ontology Parquet files:"))
 ```

--- a/docs/guide/project.md
+++ b/docs/guide/project.md
@@ -21,11 +21,11 @@ ds = qpx.Dataset("path/to/dataset/")
 print(ds.dataset_meta)
 
 # Access specific metadata fields
-if hasattr(ds.dataset_meta, 'name'):
+if hasattr(ds.dataset_meta, "name"):
     print(f"Dataset name: {ds.dataset_meta.name}")
-if hasattr(ds.dataset_meta, 'description'):
+if hasattr(ds.dataset_meta, "description"):
     print(f"Description: {ds.dataset_meta.description}")
-if hasattr(ds.dataset_meta, 'version'):
+if hasattr(ds.dataset_meta, "version"):
     print(f"Version: {ds.dataset_meta.version}")
 ```
 
@@ -63,12 +63,12 @@ import qpx
 ds = qpx.Dataset("./output/")
 
 # Sample metadata is stored in sample.parquet
-if hasattr(ds, 'sample'):
+if hasattr(ds, "sample"):
     sample_data = ds.sample.data
     print(sample_data.head())
 
     # Access specific sample information
-    sample_ids = sample_data['sample_accession'].unique()
+    sample_ids = sample_data["sample_accession"].unique()
     print(f"Number of samples: {len(sample_ids)}")
 
     # Sample metadata includes:
@@ -90,12 +90,12 @@ import qpx
 ds = qpx.Dataset("./output/")
 
 # Run metadata is stored in run.parquet
-if hasattr(ds, 'run'):
+if hasattr(ds, "run"):
     run_data = ds.run.data
     print(run_data.head())
 
     # Access specific run information
-    run_ids = run_data['run_accession'].unique()
+    run_ids = run_data["run_accession"].unique()
     print(f"Number of runs: {len(run_ids)}")
 
     # Run metadata includes:
@@ -113,6 +113,7 @@ Generate a comprehensive metadata summary:
 ```python
 import qpx
 
+
 def print_dataset_summary(dataset_path):
     """Print comprehensive dataset metadata summary."""
     ds = qpx.Dataset(dataset_path)
@@ -124,33 +125,33 @@ def print_dataset_summary(dataset_path):
 
     # Dataset-level metadata
     print("Dataset Information:")
-    if hasattr(ds, 'dataset_meta'):
-        if hasattr(ds.dataset_meta, 'name'):
+    if hasattr(ds, "dataset_meta"):
+        if hasattr(ds.dataset_meta, "name"):
             print(f"  Name: {ds.dataset_meta.name}")
-        if hasattr(ds.dataset_meta, 'version'):
+        if hasattr(ds.dataset_meta, "version"):
             print(f"  Version: {ds.dataset_meta.version}")
-        if hasattr(ds.dataset_meta, 'description'):
+        if hasattr(ds.dataset_meta, "description"):
             print(f"  Description: {ds.dataset_meta.description}")
     print()
 
     # Sample information
-    if hasattr(ds, 'sample') and ds.sample.count() > 0:
+    if hasattr(ds, "sample") and ds.sample.count() > 0:
         print("Sample Information:")
         print(f"  Total samples: {ds.sample.count()}")
-        if 'organism' in ds.sample.data.columns:
-            organisms = ds.sample.data['organism'].unique()
+        if "organism" in ds.sample.data.columns:
+            organisms = ds.sample.data["organism"].unique()
             print(f"  Organisms: {', '.join(organisms)}")
-        if 'condition' in ds.sample.data.columns:
-            conditions = ds.sample.data['condition'].unique()
+        if "condition" in ds.sample.data.columns:
+            conditions = ds.sample.data["condition"].unique()
             print(f"  Conditions: {', '.join(map(str, conditions))}")
     print()
 
     # Run information
-    if hasattr(ds, 'run') and ds.run.count() > 0:
+    if hasattr(ds, "run") and ds.run.count() > 0:
         print("Run Information:")
         print(f"  Total runs: {ds.run.count()}")
-        if 'instrument' in ds.run.data.columns:
-            instruments = ds.run.data['instrument'].unique()
+        if "instrument" in ds.run.data.columns:
+            instruments = ds.run.data["instrument"].unique()
             print(f"  Instruments: {', '.join(instruments)}")
     print()
 
@@ -162,6 +163,7 @@ def print_dataset_summary(dataset_path):
     print()
 
     print("=" * 60)
+
 
 # Usage
 print_dataset_summary("./output/")
@@ -200,7 +202,7 @@ import qpx
 ds = qpx.Dataset("./output/")
 
 # Provenance information is stored in provenance.parquet
-if hasattr(ds, 'provenance'):
+if hasattr(ds, "provenance"):
     prov_data = ds.provenance.data
     print("Processing Provenance:")
     print(prov_data)
@@ -264,6 +266,7 @@ Validate metadata completeness:
 ```python
 import qpx
 
+
 def validate_metadata(dataset_path):
     """Check for required metadata fields."""
     ds = qpx.Dataset(dataset_path)
@@ -271,17 +274,17 @@ def validate_metadata(dataset_path):
     issues = []
 
     # Check dataset-level metadata
-    if not hasattr(ds, 'dataset_meta'):
+    if not hasattr(ds, "dataset_meta"):
         issues.append("Missing dataset metadata")
-    elif not hasattr(ds.dataset_meta, 'name'):
+    elif not hasattr(ds.dataset_meta, "name"):
         issues.append("Missing dataset name")
 
     # Check sample metadata
-    if not hasattr(ds, 'sample') or ds.sample.count() == 0:
+    if not hasattr(ds, "sample") or ds.sample.count() == 0:
         issues.append("Missing sample metadata")
 
     # Check run metadata
-    if not hasattr(ds, 'run') or ds.run.count() == 0:
+    if not hasattr(ds, "run") or ds.run.count() == 0:
         issues.append("Missing run metadata")
 
     # Report
@@ -293,6 +296,7 @@ def validate_metadata(dataset_path):
     else:
         print("Metadata validation passed!")
         return True
+
 
 # Usage
 validate_metadata("./output/")
@@ -306,6 +310,7 @@ Export metadata for sharing:
 import qpx
 import json
 
+
 def export_metadata(dataset_path, output_file):
     """Export dataset metadata to JSON."""
     ds = qpx.Dataset(dataset_path)
@@ -313,32 +318,27 @@ def export_metadata(dataset_path, output_file):
     metadata = {}
 
     # Dataset-level metadata
-    if hasattr(ds, 'dataset_meta'):
-        metadata['dataset'] = {
-            'name': getattr(ds.dataset_meta, 'name', None),
-            'version': getattr(ds.dataset_meta, 'version', None),
-            'description': getattr(ds.dataset_meta, 'description', None)
+    if hasattr(ds, "dataset_meta"):
+        metadata["dataset"] = {
+            "name": getattr(ds.dataset_meta, "name", None),
+            "version": getattr(ds.dataset_meta, "version", None),
+            "description": getattr(ds.dataset_meta, "description", None),
         }
 
     # Sample summary
-    if hasattr(ds, 'sample') and ds.sample.count() > 0:
-        metadata['samples'] = {
-            'count': ds.sample.count(),
-            'sample_ids': ds.sample.data['sample_accession'].tolist()
-        }
+    if hasattr(ds, "sample") and ds.sample.count() > 0:
+        metadata["samples"] = {"count": ds.sample.count(), "sample_ids": ds.sample.data["sample_accession"].tolist()}
 
     # Run summary
-    if hasattr(ds, 'run') and ds.run.count() > 0:
-        metadata['runs'] = {
-            'count': ds.run.count(),
-            'run_ids': ds.run.data['run_accession'].tolist()
-        }
+    if hasattr(ds, "run") and ds.run.count() > 0:
+        metadata["runs"] = {"count": ds.run.count(), "run_ids": ds.run.data["run_accession"].tolist()}
 
     # Save to file
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         json.dump(metadata, f, indent=2)
 
     print(f"Metadata exported to: {output_file}")
+
 
 # Usage
 export_metadata("./output/", "./metadata_export.json")

--- a/docs/guide/query.md
+++ b/docs/guide/query.md
@@ -6,86 +6,91 @@ Query and inspect QPX datasets using SQL, filters, or quick previews.
 import click
 import textwrap
 
+
 def get_click_type_display(param):
     param_type = param.type
     type_str = str(param_type)
-    if 'Path' in type_str:
-        if hasattr(param_type, 'dir_okay') and not param_type.dir_okay:
-            return 'FILE'
-        elif hasattr(param_type, 'file_okay') and not param_type.file_okay:
-            return 'DIRECTORY'
+    if "Path" in type_str:
+        if hasattr(param_type, "dir_okay") and not param_type.dir_okay:
+            return "FILE"
+        elif hasattr(param_type, "file_okay") and not param_type.file_okay:
+            return "DIRECTORY"
         else:
-            return 'PATH'
+            return "PATH"
     elif isinstance(param_type, click.types.FloatParamType):
-        return 'FLOAT'
+        return "FLOAT"
     elif isinstance(param_type, click.types.IntParamType):
-        return 'INTEGER'
+        return "INTEGER"
     elif param.is_flag:
-        return 'FLAG'
+        return "FLAG"
     elif isinstance(param_type, click.Choice):
-        return 'CHOICE'
+        return "CHOICE"
     else:
-        return 'TEXT'
+        return "TEXT"
+
 
 def generate_params_table(command):
-    table = '<table>\n<thead>\n<tr>\n'
-    table += '<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n'
-    table += '</tr>\n</thead>\n<tbody>\n'
+    table = "<table>\n<thead>\n<tr>\n"
+    table += "<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n"
+    table += "</tr>\n</thead>\n<tbody>\n"
     for param in command.params:
-        if isinstance(param, click.Option) and param.name not in ['help']:
+        if isinstance(param, click.Option) and param.name not in ["help"]:
             param_names = param.opts
             param_name = param_names[0] if param_names else f"--{param.name}"
             param_type = get_click_type_display(param)
-            required = 'Yes' if param.required else 'No'
-            description = param.help or ''
+            required = "Yes" if param.required else "No"
+            description = param.help or ""
             default_from_help = None
-            if '(default:' in description.lower():
+            if "(default:" in description.lower():
                 import re
-                match = re.search(r'\(default:\s*([^)]+)\)', description, re.IGNORECASE)
+
+                match = re.search(r"\(default:\s*([^)]+)\)", description, re.IGNORECASE)
                 if match:
                     default_from_help = match.group(1).strip()
             if default_from_help:
                 default = default_from_help
-            elif param.default is not None and str(param.default) != 'Sentinel.UNSET':
+            elif param.default is not None and str(param.default) != "Sentinel.UNSET":
                 if param.is_flag:
-                    default = '-'
+                    default = "-"
                 elif isinstance(param.default, (int, float)):
                     default = str(param.default)
                 elif isinstance(param.default, str):
-                    default = f'<code>{param.default}</code>'
+                    default = f"<code>{param.default}</code>"
                 else:
                     default = str(param.default)
             else:
-                default = '-'
-            table += f'<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n'
-    table += '</tbody>\n</table>'
+                default = "-"
+            table += f"<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n"
+    table += "</tbody>\n</table>"
     return table
+
 
 def generate_description(command):
     if command.help:
         help_text = command.help
-        if 'Example' in help_text:
-            description = help_text.split('Example')[0].strip()
+        if "Example" in help_text:
+            description = help_text.split("Example")[0].strip()
         else:
             description = help_text.strip()
-        lines = description.split('\n')
+        lines = description.split("\n")
         if len(lines) > 1:
-            description = '\n'.join(lines[1:]).strip()
-            return f'<p>{description}</p>'
-    return ''
+            description = "\n".join(lines[1:]).strip()
+            return f"<p>{description}</p>"
+    return ""
 
-def generate_example(command, default_text=''):
-    if command.help and 'Example' in command.help:
-        example_section = command.help.split('Example')[1]
-        if ':' in example_section:
-            example_section = example_section.split(':', 1)[1]
+
+def generate_example(command, default_text=""):
+    if command.help and "Example" in command.help:
+        example_section = command.help.split("Example")[1]
+        if ":" in example_section:
+            example_section = example_section.split(":", 1)[1]
         example_section = textwrap.dedent(example_section).strip()
-        output = ''
+        output = ""
         if default_text:
-            output += f'<p>{default_text}</p>\n'
+            output += f"<p>{default_text}</p>\n"
         output += f'<pre><code class="language-bash">{example_section}</code></pre>'
         return output
-    return ''
+    return ""
 ```
 
 ## Overview
@@ -108,6 +113,7 @@ Run an arbitrary SQL query against a QPX dataset.
 
 ```python exec="1" html="1" session="query_utils"
 from qpx.cli.query import query_sql_cmd
+
 print(generate_description(query_sql_cmd))
 ```
 
@@ -115,6 +121,7 @@ print(generate_description(query_sql_cmd))
 
 ```python exec="1" html="1" session="query_utils"
 from qpx.cli.query import query_sql_cmd
+
 print(generate_params_table(query_sql_cmd))
 ```
 
@@ -122,7 +129,8 @@ print(generate_params_table(query_sql_cmd))
 
 ```python exec="1" html="1" session="query_utils"
 from qpx.cli.query import query_sql_cmd
-print(generate_example(query_sql_cmd, 'Run SQL queries against QPX datasets:'))
+
+print(generate_example(query_sql_cmd, "Run SQL queries against QPX datasets:"))
 ```
 
 ---
@@ -135,6 +143,7 @@ Filter a QPX data structure by a SQL condition.
 
 ```python exec="1" html="1" session="query_utils"
 from qpx.cli.query import query_filter_cmd
+
 print(generate_description(query_filter_cmd))
 ```
 
@@ -142,6 +151,7 @@ print(generate_description(query_filter_cmd))
 
 ```python exec="1" html="1" session="query_utils"
 from qpx.cli.query import query_filter_cmd
+
 print(generate_params_table(query_filter_cmd))
 ```
 
@@ -149,7 +159,8 @@ print(generate_params_table(query_filter_cmd))
 
 ```python exec="1" html="1" session="query_utils"
 from qpx.cli.query import query_filter_cmd
-print(generate_example(query_filter_cmd, 'Filter data structures by conditions:'))
+
+print(generate_example(query_filter_cmd, "Filter data structures by conditions:"))
 ```
 
 ---
@@ -162,6 +173,7 @@ Show the first N rows of a QPX data structure.
 
 ```python exec="1" html="1" session="query_utils"
 from qpx.cli.query import query_head_cmd
+
 print(generate_description(query_head_cmd))
 ```
 
@@ -169,6 +181,7 @@ print(generate_description(query_head_cmd))
 
 ```python exec="1" html="1" session="query_utils"
 from qpx.cli.query import query_head_cmd
+
 print(generate_params_table(query_head_cmd))
 ```
 
@@ -176,7 +189,8 @@ print(generate_params_table(query_head_cmd))
 
 ```python exec="1" html="1" session="query_utils"
 from qpx.cli.query import query_head_cmd
-print(generate_example(query_head_cmd, 'Quick preview of data structure contents:'))
+
+print(generate_example(query_head_cmd, "Quick preview of data structure contents:"))
 ```
 
 ---

--- a/docs/guide/stats.md
+++ b/docs/guide/stats.md
@@ -38,19 +38,19 @@ total_psms = ds.psm.count()
 print(f"Number of PSMs: {total_psms:,}")
 
 # Unique peptides (without modifications)
-unique_peptides = ds.psm.data['sequence'].nunique()
+unique_peptides = ds.psm.data["sequence"].nunique()
 print(f"Number of peptides: {unique_peptides:,}")
 
 # Unique peptidoforms (with modifications)
-unique_peptidoforms = ds.psm.data['peptidoform'].nunique()
+unique_peptidoforms = ds.psm.data["peptidoform"].nunique()
 print(f"Number of peptidoforms: {unique_peptidoforms:,}")
 
 # Unique proteins
-unique_proteins = ds.psm.data['protein_accessions'].nunique()
+unique_proteins = ds.psm.data["protein_accessions"].nunique()
 print(f"Number of proteins: {unique_proteins:,}")
 
 # Number of MS runs
-num_runs = ds.psm.data['run_file_name'].nunique()
+num_runs = ds.psm.data["run_file_name"].nunique()
 print(f"Number of msruns: {num_runs:,}")
 ```
 
@@ -68,13 +68,11 @@ total_features = ds.feature.count()
 print(f"Total features: {total_features:,}")
 
 # Samples with quantification data
-num_samples = len([col for col in ds.feature.data.columns
-                   if col.startswith('sample_')])
+num_samples = len([col for col in ds.feature.data.columns if col.startswith("sample_")])
 print(f"Number of samples: {num_samples}")
 
 # Missing value analysis
-intensity_cols = [col for col in ds.feature.data.columns
-                 if col.startswith('sample_')]
+intensity_cols = [col for col in ds.feature.data.columns if col.startswith("sample_")]
 missing_values = ds.feature.data[intensity_cols].isna().sum().sum()
 total_values = ds.feature.data[intensity_cols].size
 completeness = (1 - missing_values / total_values) * 100
@@ -95,9 +93,8 @@ total_pgs = ds.pg.count()
 print(f"Number of protein groups: {total_pgs:,}")
 
 # iBAQ statistics (if available)
-if 'ibaq' in ds.pg.data.columns:
-    ibaq_cols = [col for col in ds.pg.data.columns
-                 if col.startswith('sample_') and 'ibaq' in col.lower()]
+if "ibaq" in ds.pg.data.columns:
+    ibaq_cols = [col for col in ds.pg.data.columns if col.startswith("sample_") and "ibaq" in col.lower()]
     num_ibaq_samples = len(ibaq_cols)
     num_ibaq_proteins = ds.pg.data[ibaq_cols].notna().any(axis=1).sum()
     print(f"iBAQ Number of proteins: {num_ibaq_proteins:,}")
@@ -111,6 +108,7 @@ Generate a complete statistics summary:
 ```python
 import qpx
 
+
 def generate_stats_report(dataset_path, output_file=None):
     """Generate comprehensive statistics for a QPX dataset."""
     ds = qpx.Dataset(dataset_path)
@@ -122,7 +120,7 @@ def generate_stats_report(dataset_path, output_file=None):
     report.append("")
 
     # PSM Statistics
-    if hasattr(ds, 'psm') and ds.psm.count() > 0:
+    if hasattr(ds, "psm") and ds.psm.count() > 0:
         report.append("PSM Statistics:")
         report.append(f"  Number of PSMs: {ds.psm.count():,}")
         report.append(f"  Number of peptides: {ds.psm.data['sequence'].nunique():,}")
@@ -132,26 +130,25 @@ def generate_stats_report(dataset_path, output_file=None):
         report.append("")
 
     # Feature Statistics
-    if hasattr(ds, 'feature') and ds.feature.count() > 0:
-        intensity_cols = [col for col in ds.feature.data.columns
-                         if col.startswith('sample_')]
+    if hasattr(ds, "feature") and ds.feature.count() > 0:
+        intensity_cols = [col for col in ds.feature.data.columns if col.startswith("sample_")]
         report.append("Feature Statistics:")
         report.append(f"  Number of features: {ds.feature.count():,}")
         report.append(f"  Number of samples: {len(intensity_cols)}")
         report.append("")
 
     # Protein Group Statistics
-    if hasattr(ds, 'pg') and ds.pg.count() > 0:
+    if hasattr(ds, "pg") and ds.pg.count() > 0:
         report.append("Protein Group Statistics:")
         report.append(f"  Number of protein groups: {ds.pg.count():,}")
         report.append("")
 
     # Dataset metadata
-    if hasattr(ds, 'dataset_meta'):
+    if hasattr(ds, "dataset_meta"):
         report.append("Dataset Metadata:")
-        if hasattr(ds.dataset_meta, 'name'):
+        if hasattr(ds.dataset_meta, "name"):
             report.append(f"  Name: {ds.dataset_meta.name}")
-        if hasattr(ds.dataset_meta, 'version'):
+        if hasattr(ds.dataset_meta, "version"):
             report.append(f"  Version: {ds.dataset_meta.version}")
 
     report.append("=" * 50)
@@ -159,13 +156,14 @@ def generate_stats_report(dataset_path, output_file=None):
     # Output
     report_text = "\n".join(report)
     if output_file:
-        with open(output_file, 'w') as f:
+        with open(output_file, "w") as f:
             f.write(report_text)
         print(f"Report saved to: {output_file}")
     else:
         print(report_text)
 
     return report_text
+
 
 # Usage
 generate_stats_report("./output/", "./reports/statistics.txt")
@@ -231,6 +229,7 @@ Complete QC workflow example:
 import qpx
 import pandas as pd
 
+
 def quality_control_report(dataset_path):
     """Perform comprehensive quality control analysis."""
     ds = qpx.Dataset(dataset_path)
@@ -245,17 +244,16 @@ def quality_control_report(dataset_path):
     # 2. Identification rates
     print("2. Identification Rates")
     total_psms = ds.psm.count()
-    unique_peptides = ds.psm.data['sequence'].nunique()
-    unique_proteins = ds.psm.data['protein_accessions'].nunique()
+    unique_peptides = ds.psm.data["sequence"].nunique()
+    unique_proteins = ds.psm.data["protein_accessions"].nunique()
     print(f"   PSMs per peptide: {total_psms / unique_peptides:.2f}")
     print(f"   Peptides per protein: {unique_peptides / unique_proteins:.2f}")
     print()
 
     # 3. Missing value analysis
-    if hasattr(ds, 'feature') and ds.feature.count() > 0:
+    if hasattr(ds, "feature") and ds.feature.count() > 0:
         print("3. Missing Value Analysis")
-        intensity_cols = [col for col in ds.feature.data.columns
-                         if col.startswith('sample_')]
+        intensity_cols = [col for col in ds.feature.data.columns if col.startswith("sample_")]
         missing_pct = ds.feature.data[intensity_cols].isna().mean() * 100
         print(f"   Average missing values: {missing_pct.mean():.2f}%")
         print(f"   Range: {missing_pct.min():.2f}% - {missing_pct.max():.2f}%")
@@ -263,8 +261,8 @@ def quality_control_report(dataset_path):
 
     # 4. Modification analysis
     print("4. Modification Analysis")
-    peptidoforms = ds.psm.data['peptidoform'].nunique()
-    peptides = ds.psm.data['sequence'].nunique()
+    peptidoforms = ds.psm.data["peptidoform"].nunique()
+    peptides = ds.psm.data["sequence"].nunique()
     mod_ratio = peptidoforms / peptides
     print(f"   Peptidoforms per peptide: {mod_ratio:.2f}")
     print(f"   Status: {'Normal' if 1 <= mod_ratio <= 3 else 'Review recommended'}")
@@ -272,19 +270,20 @@ def quality_control_report(dataset_path):
 
     # 5. Run completeness
     print("5. MS Run Completeness")
-    num_runs = ds.psm.data['run_file_name'].nunique()
+    num_runs = ds.psm.data["run_file_name"].nunique()
     print(f"   Total runs: {num_runs}")
-    run_psms = ds.psm.data.groupby('run_file_name').size()
+    run_psms = ds.psm.data.groupby("run_file_name").size()
     print(f"   PSMs per run: {run_psms.mean():.0f} ± {run_psms.std():.0f}")
     print()
 
     return {
-        'total_psms': total_psms,
-        'unique_peptides': unique_peptides,
-        'unique_proteins': unique_proteins,
-        'num_runs': num_runs,
-        'mod_ratio': mod_ratio
+        "total_psms": total_psms,
+        "unique_peptides": unique_peptides,
+        "unique_proteins": unique_proteins,
+        "num_runs": num_runs,
+        "mod_ratio": mod_ratio,
     }
+
 
 # Usage
 qc_results = quality_control_report("./output/")
@@ -297,40 +296,35 @@ Define and check quality thresholds:
 ```python
 import qpx
 
+
 def check_quality_thresholds(dataset_path):
     """Check dataset against defined quality thresholds."""
     ds = qpx.Dataset(dataset_path)
 
     # Define thresholds
-    thresholds = {
-        'min_proteins': 1000,
-        'min_peptides': 5000,
-        'min_psms': 10000,
-        'max_missing_pct': 30,
-        'min_runs': 3
-    }
+    thresholds = {"min_proteins": 1000, "min_peptides": 5000, "min_psms": 10000, "max_missing_pct": 30, "min_runs": 3}
 
     # Check against thresholds
     warnings = []
 
     # Protein count
-    protein_count = ds.psm.data['protein_accessions'].nunique()
-    if protein_count < thresholds['min_proteins']:
+    protein_count = ds.psm.data["protein_accessions"].nunique()
+    if protein_count < thresholds["min_proteins"]:
         warnings.append(f"Low protein count: {protein_count:,} (threshold: {thresholds['min_proteins']:,})")
 
     # Peptide count
-    peptide_count = ds.psm.data['sequence'].nunique()
-    if peptide_count < thresholds['min_peptides']:
+    peptide_count = ds.psm.data["sequence"].nunique()
+    if peptide_count < thresholds["min_peptides"]:
         warnings.append(f"Low peptide count: {peptide_count:,} (threshold: {thresholds['min_peptides']:,})")
 
     # PSM count
     psm_count = ds.psm.count()
-    if psm_count < thresholds['min_psms']:
+    if psm_count < thresholds["min_psms"]:
         warnings.append(f"Low PSM count: {psm_count:,} (threshold: {thresholds['min_psms']:,})")
 
     # Run count
-    run_count = ds.psm.data['run_file_name'].nunique()
-    if run_count < thresholds['min_runs']:
+    run_count = ds.psm.data["run_file_name"].nunique()
+    if run_count < thresholds["min_runs"]:
         warnings.append(f"Low run count: {run_count} (threshold: {thresholds['min_runs']})")
 
     # Report
@@ -342,6 +336,7 @@ def check_quality_thresholds(dataset_path):
         print("All quality thresholds passed!")
 
     return len(warnings) == 0
+
 
 # Usage
 passes_qc = check_quality_thresholds("./output/")
@@ -358,9 +353,9 @@ import qpx
 
 ds = qpx.Dataset("./output/")
 stats = {
-    'proteins': ds.psm.data['protein_accessions'].nunique(),
-    'peptides': ds.psm.data['sequence'].nunique(),
-    'psms': ds.psm.count()
+    "proteins": ds.psm.data["protein_accessions"].nunique(),
+    "peptides": ds.psm.data["sequence"].nunique(),
+    "psms": ds.psm.count(),
 }
 
 print(f"Identified {stats['proteins']:,} proteins from {stats['psms']:,} PSMs")
@@ -391,9 +386,8 @@ import qpx
 
 ds = qpx.Dataset("./output/")
 
-if hasattr(ds, 'feature') and ds.feature.count() > 0:
-    intensity_cols = [col for col in ds.feature.data.columns
-                     if col.startswith('sample_')]
+if hasattr(ds, "feature") and ds.feature.count() > 0:
+    intensity_cols = [col for col in ds.feature.data.columns if col.startswith("sample_")]
 
     # Per-sample completeness
     for col in intensity_cols:
@@ -430,6 +424,7 @@ Process multiple datasets:
 import qpx
 from pathlib import Path
 
+
 def batch_statistics(dataset_paths, output_file):
     """Generate statistics for multiple datasets."""
     results = []
@@ -437,21 +432,23 @@ def batch_statistics(dataset_paths, output_file):
     for path in dataset_paths:
         ds = qpx.Dataset(path)
         stats = {
-            'dataset': Path(path).name,
-            'proteins': ds.psm.data['protein_accessions'].nunique(),
-            'peptides': ds.psm.data['sequence'].nunique(),
-            'psms': ds.psm.count(),
-            'runs': ds.psm.data['run_file_name'].nunique()
+            "dataset": Path(path).name,
+            "proteins": ds.psm.data["protein_accessions"].nunique(),
+            "peptides": ds.psm.data["sequence"].nunique(),
+            "psms": ds.psm.count(),
+            "runs": ds.psm.data["run_file_name"].nunique(),
         }
         results.append(stats)
 
     # Save to file
     import pandas as pd
+
     df = pd.DataFrame(results)
     df.to_csv(output_file, index=False)
     print(f"Batch statistics saved to: {output_file}")
 
     return df
+
 
 # Usage
 datasets = ["./dataset1/", "./dataset2/", "./dataset3/"]

--- a/docs/guide/transform.md
+++ b/docs/guide/transform.md
@@ -6,89 +6,94 @@ Transform and process data within the QPX ecosystem.
 import click
 import textwrap
 
+
 def get_click_type_display(param):
     param_type = param.type
     type_str = str(param_type)
-    if 'Path' in type_str:
-        if hasattr(param_type, 'dir_okay') and not param_type.dir_okay:
-            return 'FILE'
-        elif hasattr(param_type, 'file_okay') and not param_type.file_okay:
-            return 'DIRECTORY'
+    if "Path" in type_str:
+        if hasattr(param_type, "dir_okay") and not param_type.dir_okay:
+            return "FILE"
+        elif hasattr(param_type, "file_okay") and not param_type.file_okay:
+            return "DIRECTORY"
         else:
-            return 'PATH'
+            return "PATH"
     elif isinstance(param_type, click.types.FloatParamType):
-        return 'FLOAT'
+        return "FLOAT"
     elif isinstance(param_type, click.types.IntParamType):
-        return 'INTEGER'
+        return "INTEGER"
     elif param.is_flag:
-        return 'FLAG'
+        return "FLAG"
     else:
-        return 'TEXT'
+        return "TEXT"
+
 
 def generate_params_table(command):
-    table = '<table>\n<thead>\n<tr>\n'
-    table += '<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n'
-    table += '</tr>\n</thead>\n<tbody>\n'
+    table = "<table>\n<thead>\n<tr>\n"
+    table += "<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n"
+    table += "</tr>\n</thead>\n<tbody>\n"
     for param in command.params:
-        if isinstance(param, click.Option) and param.name not in ['help']:
+        if isinstance(param, click.Option) and param.name not in ["help"]:
             param_names = param.opts
             param_name = param_names[0] if param_names else f"--{param.name}"
             param_type = get_click_type_display(param)
-            required = 'Yes' if param.required else 'No'
+            required = "Yes" if param.required else "No"
 
             # Extract default value from help text if it contains "(default: ...)"
-            description = param.help or ''
+            description = param.help or ""
             default_from_help = None
-            if '(default:' in description.lower():
+            if "(default:" in description.lower():
                 import re
-                match = re.search(r'\(default:\s*([^)]+)\)', description, re.IGNORECASE)
+
+                match = re.search(r"\(default:\s*([^)]+)\)", description, re.IGNORECASE)
                 if match:
                     default_from_help = match.group(1).strip()
 
             # Determine default value display
             if default_from_help:
                 default = default_from_help
-            elif param.default is not None and str(param.default) != 'Sentinel.UNSET':
+            elif param.default is not None and str(param.default) != "Sentinel.UNSET":
                 if param.is_flag:
-                    default = '-'
+                    default = "-"
                 elif isinstance(param.default, (int, float)):
                     default = str(param.default)
                 elif isinstance(param.default, str):
-                    default = f'<code>{param.default}</code>'
+                    default = f"<code>{param.default}</code>"
                 else:
                     default = str(param.default)
             else:
-                default = '-'
+                default = "-"
 
-            table += f'<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n'
-    table += '</tbody>\n</table>'
+            table += f"<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n"
+    table += "</tbody>\n</table>"
     return table
+
 
 def generate_description(command):
     if command.help:
         help_text = command.help
-        if 'Example' in help_text:
-            description = help_text.split('Example')[0].strip()
+        if "Example" in help_text:
+            description = help_text.split("Example")[0].strip()
         else:
             description = help_text.strip()
-        lines = description.split('\n')
+        lines = description.split("\n")
         if len(lines) > 1:
-            description = '\n'.join(lines[1:]).strip()
-            return f'<p>{description}</p>'
-    return ''
+            description = "\n".join(lines[1:]).strip()
+            return f"<p>{description}</p>"
+    return ""
 
-def generate_example(command, default_text=''):
-    if command.help and 'Example' in command.help:
-        example_section = command.help.split('Example')[1]
-        if ':' in example_section:
-            example_section = example_section.split(':', 1)[1]
+
+def generate_example(command, default_text=""):
+    if command.help and "Example" in command.help:
+        example_section = command.help.split("Example")[1]
+        if ":" in example_section:
+            example_section = example_section.split(":", 1)[1]
         example_section = textwrap.dedent(example_section).strip()
-        output = ''
+        output = ""
         if default_text:
-            output += f'<p>{default_text}</p>\n'
+            output += f"<p>{default_text}</p>\n"
         output += f'<pre><code class="language-bash">{example_section}</code></pre>'
         return output
-    return ''
+    return ""
 ```
 
 ## Overview
@@ -112,6 +117,7 @@ Map gene information from FASTA to parquet format.
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_gene_map_cmd
+
 print(generate_description(transform_gene_map_cmd))
 ```
 
@@ -119,6 +125,7 @@ print(generate_description(transform_gene_map_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_gene_map_cmd
+
 print(generate_params_table(transform_gene_map_cmd))
 ```
 
@@ -128,7 +135,8 @@ print(generate_params_table(transform_gene_map_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_gene_map_cmd
-print(generate_example(transform_gene_map_cmd, 'Map gene information to parquet file:'))
+
+print(generate_example(transform_gene_map_cmd, "Map gene information to parquet file:"))
 ```
 
 #### With Species Parameter {#gene-map-example-species}
@@ -162,6 +170,7 @@ Normalize protein accession formats between full UniProt form (`sp|ACC|NAME`) an
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_normalize_accessions_cmd
+
 print(generate_description(transform_normalize_accessions_cmd))
 ```
 
@@ -169,6 +178,7 @@ print(generate_description(transform_normalize_accessions_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_normalize_accessions_cmd
+
 print(generate_params_table(transform_normalize_accessions_cmd))
 ```
 
@@ -176,7 +186,8 @@ print(generate_params_table(transform_normalize_accessions_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_normalize_accessions_cmd
-print(generate_example(transform_normalize_accessions_cmd, 'Normalize protein accession formats:'))
+
+print(generate_example(transform_normalize_accessions_cmd, "Normalize protein accession formats:"))
 ```
 
 ---
@@ -189,6 +200,7 @@ Update `sample.parquet` and `run.parquet` metadata from a revised SDRF file, wit
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_update_metadata_cmd
+
 print(generate_description(transform_update_metadata_cmd))
 ```
 
@@ -196,6 +208,7 @@ print(generate_description(transform_update_metadata_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_update_metadata_cmd
+
 print(generate_params_table(transform_update_metadata_cmd))
 ```
 
@@ -203,7 +216,8 @@ print(generate_params_table(transform_update_metadata_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_update_metadata_cmd
-print(generate_example(transform_update_metadata_cmd, 'Update dataset metadata from SDRF:'))
+
+print(generate_example(transform_update_metadata_cmd, "Update dataset metadata from SDRF:"))
 ```
 
 ---
@@ -216,6 +230,7 @@ Compute protein-level quantification from QPX feature data using [mokume](https:
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_quantify_cmd
+
 print(generate_description(transform_quantify_cmd))
 ```
 
@@ -223,6 +238,7 @@ print(generate_description(transform_quantify_cmd))
 
 ```python exec="1" html="1" session="doc_utils"
 from qpx.cli.transform import transform_quantify_cmd
+
 print(generate_params_table(transform_quantify_cmd))
 ```
 

--- a/docs/guide/validate.md
+++ b/docs/guide/validate.md
@@ -6,86 +6,91 @@ Validate QPX datasets and individual structures against their canonical schemas.
 import click
 import textwrap
 
+
 def get_click_type_display(param):
     param_type = param.type
     type_str = str(param_type)
-    if 'Path' in type_str:
-        if hasattr(param_type, 'dir_okay') and not param_type.dir_okay:
-            return 'FILE'
-        elif hasattr(param_type, 'file_okay') and not param_type.file_okay:
-            return 'DIRECTORY'
+    if "Path" in type_str:
+        if hasattr(param_type, "dir_okay") and not param_type.dir_okay:
+            return "FILE"
+        elif hasattr(param_type, "file_okay") and not param_type.file_okay:
+            return "DIRECTORY"
         else:
-            return 'PATH'
+            return "PATH"
     elif isinstance(param_type, click.types.FloatParamType):
-        return 'FLOAT'
+        return "FLOAT"
     elif isinstance(param_type, click.types.IntParamType):
-        return 'INTEGER'
+        return "INTEGER"
     elif param.is_flag:
-        return 'FLAG'
+        return "FLAG"
     elif isinstance(param_type, click.Choice):
-        return 'CHOICE'
+        return "CHOICE"
     else:
-        return 'TEXT'
+        return "TEXT"
+
 
 def generate_params_table(command):
-    table = '<table>\n<thead>\n<tr>\n'
-    table += '<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n'
-    table += '</tr>\n</thead>\n<tbody>\n'
+    table = "<table>\n<thead>\n<tr>\n"
+    table += "<th>Parameter</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th>\n"
+    table += "</tr>\n</thead>\n<tbody>\n"
     for param in command.params:
-        if isinstance(param, click.Option) and param.name not in ['help']:
+        if isinstance(param, click.Option) and param.name not in ["help"]:
             param_names = param.opts
             param_name = param_names[0] if param_names else f"--{param.name}"
             param_type = get_click_type_display(param)
-            required = 'Yes' if param.required else 'No'
-            description = param.help or ''
+            required = "Yes" if param.required else "No"
+            description = param.help or ""
             default_from_help = None
-            if '(default:' in description.lower():
+            if "(default:" in description.lower():
                 import re
-                match = re.search(r'\(default:\s*([^)]+)\)', description, re.IGNORECASE)
+
+                match = re.search(r"\(default:\s*([^)]+)\)", description, re.IGNORECASE)
                 if match:
                     default_from_help = match.group(1).strip()
             if default_from_help:
                 default = default_from_help
-            elif param.default is not None and str(param.default) != 'Sentinel.UNSET':
+            elif param.default is not None and str(param.default) != "Sentinel.UNSET":
                 if param.is_flag:
-                    default = '-'
+                    default = "-"
                 elif isinstance(param.default, (int, float)):
                     default = str(param.default)
                 elif isinstance(param.default, str):
-                    default = f'<code>{param.default}</code>'
+                    default = f"<code>{param.default}</code>"
                 else:
                     default = str(param.default)
             else:
-                default = '-'
-            table += f'<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n'
-    table += '</tbody>\n</table>'
+                default = "-"
+            table += f"<tr>\n<td><code>{param_name}</code></td>\n<td>{param_type}</td>\n<td>{required}</td>\n<td>{default}</td>\n<td>{description}</td>\n</tr>\n"
+    table += "</tbody>\n</table>"
     return table
+
 
 def generate_description(command):
     if command.help:
         help_text = command.help
-        if 'Example' in help_text:
-            description = help_text.split('Example')[0].strip()
+        if "Example" in help_text:
+            description = help_text.split("Example")[0].strip()
         else:
             description = help_text.strip()
-        lines = description.split('\n')
+        lines = description.split("\n")
         if len(lines) > 1:
-            description = '\n'.join(lines[1:]).strip()
-            return f'<p>{description}</p>'
-    return ''
+            description = "\n".join(lines[1:]).strip()
+            return f"<p>{description}</p>"
+    return ""
 
-def generate_example(command, default_text=''):
-    if command.help and 'Example' in command.help:
-        example_section = command.help.split('Example')[1]
-        if ':' in example_section:
-            example_section = example_section.split(':', 1)[1]
+
+def generate_example(command, default_text=""):
+    if command.help and "Example" in command.help:
+        example_section = command.help.split("Example")[1]
+        if ":" in example_section:
+            example_section = example_section.split(":", 1)[1]
         example_section = textwrap.dedent(example_section).strip()
-        output = ''
+        output = ""
         if default_text:
-            output += f'<p>{default_text}</p>\n'
+            output += f"<p>{default_text}</p>\n"
         output += f'<pre><code class="language-bash">{example_section}</code></pre>'
         return output
-    return ''
+    return ""
 ```
 
 ## Overview
@@ -96,6 +101,7 @@ The `validate` command checks QPX datasets and individual Parquet files against 
 
 ```python exec="1" html="1" session="validate_utils"
 from qpx.cli.validate import validate_cmd
+
 print(generate_params_table(validate_cmd))
 ```
 
@@ -103,6 +109,7 @@ print(generate_params_table(validate_cmd))
 
 ```python exec="1" html="1" session="validate_utils"
 from qpx.cli.validate import validate_cmd
+
 print(generate_description(validate_cmd))
 ```
 
@@ -110,7 +117,8 @@ print(generate_description(validate_cmd))
 
 ```python exec="1" html="1" session="validate_utils"
 from qpx.cli.validate import validate_cmd
-print(generate_example(validate_cmd, 'Validate QPX datasets and files:'))
+
+print(generate_example(validate_cmd, "Validate QPX datasets and files:"))
 ```
 
 ## Validation Checks

--- a/docs/guide/visualize.md
+++ b/docs/guide/visualize.md
@@ -18,9 +18,9 @@ ds = qpx.Dataset("path/to/dataset/")
 
 # View-based plotting
 ds.identifications.plot()  # Identification summary plot
-ds.runs.plot()             # Run-level QC plot
-ds.modifications.plot()    # Modification distribution plot
-ds.qc.plot()              # Quality control dashboard
+ds.runs.plot()  # Run-level QC plot
+ds.modifications.plot()  # Modification distribution plot
+ds.qc.plot()  # Quality control dashboard
 ```
 
 ## Available Visualizations
@@ -38,7 +38,7 @@ ds = qpx.Dataset("./output/")
 fig = ds.identifications.plot()
 
 # Save to file
-fig.savefig("./plots/identifications.svg", format='svg', bbox_inches='tight')
+fig.savefig("./plots/identifications.svg", format="svg", bbox_inches="tight")
 ```
 
 **Output**:
@@ -66,7 +66,7 @@ ds = qpx.Dataset("./output/")
 fig = ds.runs.plot()
 
 # Save to file
-fig.savefig("./plots/run_summary.svg", format='svg', bbox_inches='tight')
+fig.savefig("./plots/run_summary.svg", format="svg", bbox_inches="tight")
 ```
 
 **Output**:
@@ -95,7 +95,7 @@ ds = qpx.Dataset("./output/")
 fig = ds.modifications.plot()
 
 # Save to file
-fig.savefig("./plots/modifications.svg", format='svg', bbox_inches='tight')
+fig.savefig("./plots/modifications.svg", format="svg", bbox_inches="tight")
 ```
 
 **Output**:
@@ -123,7 +123,7 @@ ds = qpx.Dataset("./output/")
 fig = ds.qc.plot()
 
 # Save to file
-fig.savefig("./plots/qc_dashboard.svg", format='svg', bbox_inches='tight')
+fig.savefig("./plots/qc_dashboard.svg", format="svg", bbox_inches="tight")
 ```
 
 **Output**:
@@ -153,20 +153,19 @@ import matplotlib.pyplot as plt
 ds = qpx.Dataset("./output/")
 
 # Get intensity columns
-intensity_cols = [col for col in ds.feature.data.columns
-                 if col.startswith('sample_')]
+intensity_cols = [col for col in ds.feature.data.columns if col.startswith("sample_")]
 
 # Create box plot
 fig, ax = plt.subplots(figsize=(12, 6))
-ds.feature.data[intensity_cols].apply(lambda x: x[x > 0].apply('log10')).boxplot(ax=ax)
-ax.set_xlabel('Sample')
-ax.set_ylabel('log10(Intensity)')
-ax.set_title('Intensity Distribution Across Samples')
-plt.xticks(rotation=45, ha='right')
+ds.feature.data[intensity_cols].apply(lambda x: x[x > 0].apply("log10")).boxplot(ax=ax)
+ax.set_xlabel("Sample")
+ax.set_ylabel("log10(Intensity)")
+ax.set_title("Intensity Distribution Across Samples")
+plt.xticks(rotation=45, ha="right")
 plt.tight_layout()
 
 # Save
-fig.savefig("./plots/intensity_boxplot.svg", format='svg', bbox_inches='tight')
+fig.savefig("./plots/intensity_boxplot.svg", format="svg", bbox_inches="tight")
 ```
 
 **Output**:
@@ -196,8 +195,7 @@ import numpy as np
 ds = qpx.Dataset("./output/")
 
 # Get intensity columns (limit to first 10 samples for readability)
-intensity_cols = [col for col in ds.feature.data.columns
-                 if col.startswith('sample_')][:10]
+intensity_cols = [col for col in ds.feature.data.columns if col.startswith("sample_")][:10]
 
 # Create KDE plot
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -207,14 +205,14 @@ for col in intensity_cols:
         log_intensities = np.log10(intensities[intensities > 0])
         log_intensities.plot.kde(ax=ax, label=col)
 
-ax.set_xlabel('log10(Intensity)')
-ax.set_ylabel('Density')
-ax.set_title('Intensity Distribution (KDE)')
-ax.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+ax.set_xlabel("log10(Intensity)")
+ax.set_ylabel("Density")
+ax.set_title("Intensity Distribution (KDE)")
+ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left")
 plt.tight_layout()
 
 # Save
-fig.savefig("./plots/intensity_kde.svg", format='svg', bbox_inches='tight')
+fig.savefig("./plots/intensity_kde.svg", format="svg", bbox_inches="tight")
 ```
 
 **Output**:
@@ -243,20 +241,20 @@ import matplotlib.pyplot as plt
 ds = qpx.Dataset("./output/")
 
 # Count peptides per protein
-peptides_per_protein = ds.psm.data.groupby('protein_accessions')['sequence'].nunique()
+peptides_per_protein = ds.psm.data.groupby("protein_accessions")["sequence"].nunique()
 top_proteins = peptides_per_protein.nlargest(20)
 
 # Create bar plot
 fig, ax = plt.subplots(figsize=(12, 6))
 top_proteins.plot.bar(ax=ax)
-ax.set_xlabel('Protein')
-ax.set_ylabel('Number of Peptides')
-ax.set_title('Peptide Distribution Across Top 20 Proteins')
-plt.xticks(rotation=45, ha='right')
+ax.set_xlabel("Protein")
+ax.set_ylabel("Number of Peptides")
+ax.set_title("Peptide Distribution Across Top 20 Proteins")
+plt.xticks(rotation=45, ha="right")
 plt.tight_layout()
 
 # Save
-fig.savefig("./plots/peptides_per_protein.svg", format='svg', bbox_inches='tight')
+fig.savefig("./plots/peptides_per_protein.svg", format="svg", bbox_inches="tight")
 ```
 
 **Output**:
@@ -284,20 +282,20 @@ ds = qpx.Dataset("./output/")
 
 # Assuming 'condition' column exists in PSM data or can be derived from sample metadata
 # This is a simplified example - adapt based on your metadata structure
-if 'condition' in ds.psm.data.columns:
-    peptides_by_condition = ds.psm.data.groupby('condition')['sequence'].nunique()
+if "condition" in ds.psm.data.columns:
+    peptides_by_condition = ds.psm.data.groupby("condition")["sequence"].nunique()
 
     # Create bar plot
     fig, ax = plt.subplots(figsize=(10, 6))
     peptides_by_condition.plot.bar(ax=ax)
-    ax.set_xlabel('Condition')
-    ax.set_ylabel('Number of Peptides')
-    ax.set_title('Peptides Identified by Condition')
-    plt.xticks(rotation=45, ha='right')
+    ax.set_xlabel("Condition")
+    ax.set_ylabel("Number of Peptides")
+    ax.set_title("Peptides Identified by Condition")
+    plt.xticks(rotation=45, ha="right")
     plt.tight_layout()
 
     # Save
-    fig.savefig("./plots/peptides_by_condition.svg", format='svg', bbox_inches='tight')
+    fig.savefig("./plots/peptides_by_condition.svg", format="svg", bbox_inches="tight")
 ```
 
 **Interpretation**:
@@ -318,8 +316,7 @@ import numpy as np
 ds = qpx.Dataset("./output/")
 
 # Assuming iBAQ columns exist in protein group data
-ibaq_cols = [col for col in ds.pg.data.columns
-            if 'ibaq' in col.lower() and col.startswith('sample_')]
+ibaq_cols = [col for col in ds.pg.data.columns if "ibaq" in col.lower() and col.startswith("sample_")]
 
 if ibaq_cols:
     # Plot first sample as example
@@ -330,17 +327,17 @@ if ibaq_cols:
         # Create histogram with KDE
         fig, ax = plt.subplots(figsize=(10, 6))
         log_ibaq = np.log10(ibaq_values[ibaq_values > 0])
-        log_ibaq.plot.hist(bins=50, alpha=0.6, ax=ax, label='Histogram')
-        log_ibaq.plot.kde(ax=ax, label='KDE', linewidth=2)
+        log_ibaq.plot.hist(bins=50, alpha=0.6, ax=ax, label="Histogram")
+        log_ibaq.plot.kde(ax=ax, label="KDE", linewidth=2)
 
-        ax.set_xlabel('log10(iBAQ Intensity)')
-        ax.set_ylabel('Frequency / Density')
-        ax.set_title(f'iBAQ Distribution - {sample_col}')
+        ax.set_xlabel("log10(iBAQ Intensity)")
+        ax.set_ylabel("Frequency / Density")
+        ax.set_title(f"iBAQ Distribution - {sample_col}")
         ax.legend()
         plt.tight_layout()
 
         # Save
-        fig.savefig("./plots/ibaq_distribution.svg", format='svg', bbox_inches='tight')
+        fig.savefig("./plots/ibaq_distribution.svg", format="svg", bbox_inches="tight")
 ```
 
 **Output**:
@@ -368,25 +365,24 @@ import seaborn as sns
 ds = qpx.Dataset("./output/")
 
 # Get intensity columns
-intensity_cols = [col for col in ds.feature.data.columns
-                 if col.startswith('sample_')]
+intensity_cols = [col for col in ds.feature.data.columns if col.startswith("sample_")]
 
 # Calculate missing value percentages
 missing_pct = ds.feature.data[intensity_cols].isna().mean() * 100
 
 # Create bar plot
 fig, ax = plt.subplots(figsize=(12, 6))
-missing_pct.plot.bar(ax=ax, color='coral')
-ax.set_xlabel('Sample')
-ax.set_ylabel('Missing Values (%)')
-ax.set_title('Missing Value Percentage by Sample')
-ax.axhline(y=30, color='r', linestyle='--', label='30% threshold')
-plt.xticks(rotation=45, ha='right')
+missing_pct.plot.bar(ax=ax, color="coral")
+ax.set_xlabel("Sample")
+ax.set_ylabel("Missing Values (%)")
+ax.set_title("Missing Value Percentage by Sample")
+ax.axhline(y=30, color="r", linestyle="--", label="30% threshold")
+plt.xticks(rotation=45, ha="right")
 plt.legend()
 plt.tight_layout()
 
 # Save
-fig.savefig("./plots/missing_values.svg", format='svg', bbox_inches='tight')
+fig.savefig("./plots/missing_values.svg", format="svg", bbox_inches="tight")
 ```
 
 **Interpretation**:
@@ -406,11 +402,11 @@ import qpx
 import matplotlib.pyplot as plt
 
 # Set publication style
-plt.style.use('seaborn-v0_8-paper')
-plt.rcParams['figure.dpi'] = 300
-plt.rcParams['font.size'] = 12
-plt.rcParams['axes.labelsize'] = 14
-plt.rcParams['axes.titlesize'] = 16
+plt.style.use("seaborn-v0_8-paper")
+plt.rcParams["figure.dpi"] = 300
+plt.rcParams["font.size"] = 12
+plt.rcParams["axes.labelsize"] = 14
+plt.rcParams["axes.titlesize"] = 16
 
 ds = qpx.Dataset("./output/")
 
@@ -418,9 +414,9 @@ ds = qpx.Dataset("./output/")
 fig = ds.identifications.plot()
 
 # Save in multiple formats
-fig.savefig("./plots/identifications.svg", format='svg', bbox_inches='tight', dpi=300)
-fig.savefig("./plots/identifications.pdf", format='pdf', bbox_inches='tight', dpi=300)
-fig.savefig("./plots/identifications.png", format='png', bbox_inches='tight', dpi=300)
+fig.savefig("./plots/identifications.svg", format="svg", bbox_inches="tight", dpi=300)
+fig.savefig("./plots/identifications.pdf", format="pdf", bbox_inches="tight", dpi=300)
+fig.savefig("./plots/identifications.png", format="png", bbox_inches="tight", dpi=300)
 ```
 
 ### Multi-Panel Figures
@@ -439,46 +435,45 @@ fig, axes = plt.subplots(2, 2, figsize=(16, 12))
 # Panel 1: Identifications
 ax1 = axes[0, 0]
 stats = {
-    'Proteins': ds.psm.data['protein_accessions'].nunique(),
-    'Peptides': ds.psm.data['sequence'].nunique(),
-    'PSMs': ds.psm.count()
+    "Proteins": ds.psm.data["protein_accessions"].nunique(),
+    "Peptides": ds.psm.data["sequence"].nunique(),
+    "PSMs": ds.psm.count(),
 }
 ax1.bar(stats.keys(), stats.values())
-ax1.set_ylabel('Count')
-ax1.set_title('A. Identifications')
+ax1.set_ylabel("Count")
+ax1.set_title("A. Identifications")
 
 # Panel 2: Runs
 ax2 = axes[0, 1]
-run_psms = ds.psm.data.groupby('run_file_name').size()
+run_psms = ds.psm.data.groupby("run_file_name").size()
 ax2.bar(range(len(run_psms)), run_psms.values)
-ax2.set_xlabel('Run')
-ax2.set_ylabel('PSM Count')
-ax2.set_title('B. PSMs per Run')
+ax2.set_xlabel("Run")
+ax2.set_ylabel("PSM Count")
+ax2.set_title("B. PSMs per Run")
 
 # Panel 3: Modifications
 ax3 = axes[1, 0]
-if 'modifications' in ds.psm.data.columns:
-    mod_counts = ds.psm.data['modifications'].value_counts().head(10)
+if "modifications" in ds.psm.data.columns:
+    mod_counts = ds.psm.data["modifications"].value_counts().head(10)
     mod_counts.plot.barh(ax=ax3)
-    ax3.set_xlabel('Count')
-    ax3.set_title('C. Top 10 Modifications')
+    ax3.set_xlabel("Count")
+    ax3.set_title("C. Top 10 Modifications")
 
 # Panel 4: Intensity distribution (if feature data available)
 ax4 = axes[1, 1]
-if hasattr(ds, 'feature') and ds.feature.count() > 0:
-    intensity_cols = [col for col in ds.feature.data.columns
-                     if col.startswith('sample_')][:5]
+if hasattr(ds, "feature") and ds.feature.count() > 0:
+    intensity_cols = [col for col in ds.feature.data.columns if col.startswith("sample_")][:5]
     for col in intensity_cols:
         intensities = ds.feature.data[col].dropna()
         if len(intensities) > 0:
-            intensities[intensities > 0].apply('log10').plot.kde(ax=ax4, label=col)
-    ax4.set_xlabel('log10(Intensity)')
-    ax4.set_ylabel('Density')
-    ax4.set_title('D. Intensity Distribution')
+            intensities[intensities > 0].apply("log10").plot.kde(ax=ax4, label=col)
+    ax4.set_xlabel("log10(Intensity)")
+    ax4.set_ylabel("Density")
+    ax4.set_title("D. Intensity Distribution")
     ax4.legend()
 
 plt.tight_layout()
-fig.savefig("./plots/comprehensive_qc.svg", format='svg', bbox_inches='tight', dpi=300)
+fig.savefig("./plots/comprehensive_qc.svg", format="svg", bbox_inches="tight", dpi=300)
 ```
 
 ## General Plotting Tips
@@ -517,25 +512,26 @@ Combine statistics and visualization:
 import qpx
 import matplotlib.pyplot as plt
 
+
 def comprehensive_qc_workflow(dataset_path, output_dir):
     """Generate comprehensive QC report with plots."""
     ds = qpx.Dataset(dataset_path)
 
     # Generate all plots
     plots = {
-        'identifications': ds.identifications.plot(),
-        'runs': ds.runs.plot(),
-        'modifications': ds.modifications.plot(),
-        'qc': ds.qc.plot()
+        "identifications": ds.identifications.plot(),
+        "runs": ds.runs.plot(),
+        "modifications": ds.modifications.plot(),
+        "qc": ds.qc.plot(),
     }
 
     # Save plots
     for name, fig in plots.items():
-        fig.savefig(f"{output_dir}/{name}.svg", format='svg', bbox_inches='tight')
+        fig.savefig(f"{output_dir}/{name}.svg", format="svg", bbox_inches="tight")
         plt.close(fig)
 
     # Generate statistics summary
-    with open(f"{output_dir}/statistics.txt", 'w') as f:
+    with open(f"{output_dir}/statistics.txt", "w") as f:
         f.write("QPX Quality Control Report\n")
         f.write("=" * 50 + "\n\n")
         f.write(f"Proteins: {ds.psm.data['protein_accessions'].nunique():,}\n")
@@ -544,6 +540,7 @@ def comprehensive_qc_workflow(dataset_path, output_dir):
         f.write(f"Runs: {ds.psm.data['run_file_name'].nunique()}\n")
 
     print(f"QC report generated in: {output_dir}")
+
 
 # Usage
 comprehensive_qc_workflow("./output/", "./qc_report/")
@@ -568,12 +565,12 @@ pg_df = ds.pg.data
 # Create custom visualizations using matplotlib, seaborn, plotly, etc.
 # Example: Custom scatter plot
 fig, ax = plt.subplots(figsize=(10, 6))
-ax.scatter(psm_df['rt'], psm_df['observed_mz'], alpha=0.5, s=10)
-ax.set_xlabel('Retention Time (seconds)')
-ax.set_ylabel('Observed m/z')
-ax.set_title('PSM Distribution in RT-m/z Space')
+ax.scatter(psm_df["rt"], psm_df["observed_mz"], alpha=0.5, s=10)
+ax.set_xlabel("Retention Time (seconds)")
+ax.set_ylabel("Observed m/z")
+ax.set_title("PSM Distribution in RT-m/z Space")
 plt.tight_layout()
-fig.savefig("./plots/custom_scatter.svg", format='svg', bbox_inches='tight')
+fig.savefig("./plots/custom_scatter.svg", format="svg", bbox_inches="tight")
 ```
 
 ## Related Documentation

--- a/docs/spec/absolute.md
+++ b/docs/spec/absolute.md
@@ -90,32 +90,42 @@ import numpy as np
 import pandas as pd
 
 # Sample metadata (obs)
-obs = pd.DataFrame({
-    "organism": ["Homo sapiens", "Homo sapiens"],
-    "organism_part": ["heart", "liver"],
-    "disease": ["normal", "normal"],
-    "biological_replicate": [1, 1],
-}, index=["PXD000000-Sample-1", "PXD000000-Sample-2"])
+obs = pd.DataFrame(
+    {
+        "organism": ["Homo sapiens", "Homo sapiens"],
+        "organism_part": ["heart", "liver"],
+        "disease": ["normal", "normal"],
+        "biological_replicate": [1, 1],
+    },
+    index=["PXD000000-Sample-1", "PXD000000-Sample-2"],
+)
 
 # Protein metadata (var)
-var = pd.DataFrame({
-    "gene_name": ["A1BG", "HBB", "TP53"],
-}, index=["P04217", "P68871", "P04637"])
+var = pd.DataFrame(
+    {
+        "gene_name": ["A1BG", "HBB", "TP53"],
+    },
+    index=["P04217", "P68871", "P04637"],
+)
 
 # Primary matrix: ibaq_log (samples x proteins)
-X = np.array([
-    [8.48, 6.23, 7.91],   # Sample-1
-    [7.12, 9.45, 8.03],   # Sample-2
-])
+X = np.array(
+    [
+        [8.48, 6.23, 7.91],  # Sample-1
+        [7.12, 9.45, 8.03],  # Sample-2
+    ]
+)
 
 # Create AnnData
 adata = ad.AnnData(X=X, obs=obs, var=var)
 
 # Add alternative quantifications as layers
-adata.layers["ibaq_raw"] = np.array([
-    [5678.9, 234.5, 2345.6],
-    [1234.5, 6789.0, 3456.7],
-])
+adata.layers["ibaq_raw"] = np.array(
+    [
+        [5678.9, 234.5, 2345.6],
+        [1234.5, 6789.0, 3456.7],
+    ]
+)
 
 # Add file-level metadata
 adata.uns["qpx_version"] = "2.0"

--- a/docs/spec/dataset.md
+++ b/docs/spec/dataset.md
@@ -20,27 +20,26 @@ See the full YAML schema in [`dataset.yaml`](schemas/dataset.yaml).
 ```python
 import pyarrow as pa
 
-dataset_schema = pa.schema([
-    # Project identity
-    pa.field("project_accession", pa.string()),
-    pa.field("project_title", pa.string(), nullable=True),
-    pa.field("project_description", pa.string(), nullable=True),
-    pa.field("pubmed_id", pa.string(), nullable=True),
-
-    # Software
-    pa.field("software_name", pa.string(), nullable=True),
-    pa.field("software_version", pa.string(), nullable=True),
-
-    # Provenance
-    pa.field("creation_date", pa.string()),
-
-    # Integrity / Packaging
-    pa.field("file_checksums", pa.map_(pa.string(), pa.string()), nullable=True),
-    pa.field("file_row_counts", pa.map_(pa.string(), pa.int64()), nullable=True),
-    pa.field("file_sizes_bytes", pa.map_(pa.string(), pa.int64()), nullable=True),
-    pa.field("total_structures", pa.int32(), nullable=True),
-    pa.field("packaged_at", pa.string(), nullable=True),
-])
+dataset_schema = pa.schema(
+    [
+        # Project identity
+        pa.field("project_accession", pa.string()),
+        pa.field("project_title", pa.string(), nullable=True),
+        pa.field("project_description", pa.string(), nullable=True),
+        pa.field("pubmed_id", pa.string(), nullable=True),
+        # Software
+        pa.field("software_name", pa.string(), nullable=True),
+        pa.field("software_version", pa.string(), nullable=True),
+        # Provenance
+        pa.field("creation_date", pa.string()),
+        # Integrity / Packaging
+        pa.field("file_checksums", pa.map_(pa.string(), pa.string()), nullable=True),
+        pa.field("file_row_counts", pa.map_(pa.string(), pa.int64()), nullable=True),
+        pa.field("file_sizes_bytes", pa.map_(pa.string(), pa.int64()), nullable=True),
+        pa.field("total_structures", pa.int32(), nullable=True),
+        pa.field("packaged_at", pa.string(), nullable=True),
+    ]
+)
 ```
 
 ### Field Reference
@@ -111,8 +110,8 @@ These fields enable dataset validation after packaging or transfer. They are pop
     dataset = pq.read_table("PXD014414.dataset.parquet")
     row = dataset.to_pydict()
 
-    print(row["project_accession"])   # ['PXD014414']
-    print(row["software_name"])       # ['quantms']
+    print(row["project_accession"])  # ['PXD014414']
+    print(row["software_name"])  # ['quantms']
     ```
 
 !!! tip "Reading dataset.parquet with DuckDB"

--- a/docs/spec/differential.md
+++ b/docs/spec/differential.md
@@ -33,18 +33,18 @@ DE results are stored in `uns["de_results"]` as a dictionary keyed by contrast i
 ```python
 adata.uns["de_results"] = {
     "cancer_vs_normal": {
-        "names": np.array(["P04217", "P68871", ...]),           # protein accessions
-        "gene_names": np.array(["A1BG", "HBB", ...]),          # gene symbols
-        "logfoldchanges": np.array([-1.542, 0.891, ...]),       # log2 fold change
-        "scores": np.array([-8.567, 4.321, ...]),               # t-value / test statistic
-        "pvals": np.array([0.0001, 0.002, ...]),                # raw p-values
-        "pvals_adj": np.array([0.005, 0.045, ...]),             # adjusted p-values (BH)
-        "se": np.array([0.18, 0.206, ...]),                     # standard error
-        "df": np.array([37, 35, ...]),                          # degrees of freedom
-        "is_significant": np.array([True, True, ...]),          # pre-computed significance
-        "issue": np.array([None, None, ...]),                   # inference issues
-        "condition_test": "squamous cell carcinoma",            # test condition
-        "condition_reference": "normal",                        # reference condition
+        "names": np.array(["P04217", "P68871", ...]),  # protein accessions
+        "gene_names": np.array(["A1BG", "HBB", ...]),  # gene symbols
+        "logfoldchanges": np.array([-1.542, 0.891, ...]),  # log2 fold change
+        "scores": np.array([-8.567, 4.321, ...]),  # t-value / test statistic
+        "pvals": np.array([0.0001, 0.002, ...]),  # raw p-values
+        "pvals_adj": np.array([0.005, 0.045, ...]),  # adjusted p-values (BH)
+        "se": np.array([0.18, 0.206, ...]),  # standard error
+        "df": np.array([37, 35, ...]),  # degrees of freedom
+        "is_significant": np.array([True, True, ...]),  # pre-computed significance
+        "issue": np.array([None, None, ...]),  # inference issues
+        "condition_test": "squamous cell carcinoma",  # test condition
+        "condition_reference": "normal",  # reference condition
     }
 }
 ```
@@ -105,9 +105,12 @@ import numpy as np
 import pandas as pd
 
 # Protein metadata
-var = pd.DataFrame({
-    "gene_name": ["A1BG", "HBB", "TP53"],
-}, index=["P04217", "P68871", "P04637"])
+var = pd.DataFrame(
+    {
+        "gene_name": ["A1BG", "HBB", "TP53"],
+    },
+    index=["P04217", "P68871", "P04637"],
+)
 
 # Sample metadata (optional — can be empty if only storing DE results)
 obs = pd.DataFrame(index=["Sample-1", "Sample-2", "Sample-3", "Sample-4"])
@@ -180,14 +183,16 @@ adata = ad.read_h5ad("PXD000000.de.h5ad")
 
 # Get significant up-regulated proteins in a contrast
 contrast = adata.uns["de_results"]["cancer_vs_normal"]
-de_df = pd.DataFrame({
-    "protein": contrast["names"],
-    "gene_name": contrast["gene_names"],
-    "log2fc": contrast["logfoldchanges"],
-    "pvalue": contrast["pvals"],
-    "adj_pvalue": contrast["pvals_adj"],
-    "significant": contrast["is_significant"],
-})
+de_df = pd.DataFrame(
+    {
+        "protein": contrast["names"],
+        "gene_name": contrast["gene_names"],
+        "log2fc": contrast["logfoldchanges"],
+        "pvalue": contrast["pvals"],
+        "adj_pvalue": contrast["pvals_adj"],
+        "significant": contrast["is_significant"],
+    }
+)
 
 # Filter: significant and up-regulated
 up_regulated = de_df[(de_df["significant"]) & (de_df["log2fc"] > 1.0)]

--- a/docs/spec/ontology.md
+++ b/docs/spec/ontology.md
@@ -25,17 +25,19 @@ See the full YAML schema in [`ontology.yaml`](schemas/ontology.yaml).
 ```python
 import pyarrow as pa
 
-ontology_schema = pa.schema([
-    pa.field("field_name", pa.string()),          # snake_case QPX field name (e.g. "comet_xcorr")
-    pa.field("ontology_name", pa.string(), nullable=True),  # proper ontology term (e.g. "Comet:xcorr")
-    pa.field("ontology_accession", pa.string(), nullable=True),  # CV accession (e.g. "MS:1002252")
-    pa.field("ontology_source", pa.string(), nullable=True),  # ontology prefix (e.g. "MS", "UBERON", "UNIMOD")
-    pa.field("ontology_version", pa.string(), nullable=True),  # version of the ontology (e.g. "4.1.235")
-    pa.field("view", pa.string()),                # which view (e.g. "psm", "feature", "sample")
-    pa.field("description", pa.string(), nullable=True),  # human-readable description
-    pa.field("source_column_name", pa.string(), nullable=True),  # original column name in tool output
-    pa.field("source_tool", pa.string(), nullable=True),  # tool that produced this field
-])
+ontology_schema = pa.schema(
+    [
+        pa.field("field_name", pa.string()),  # snake_case QPX field name (e.g. "comet_xcorr")
+        pa.field("ontology_name", pa.string(), nullable=True),  # proper ontology term (e.g. "Comet:xcorr")
+        pa.field("ontology_accession", pa.string(), nullable=True),  # CV accession (e.g. "MS:1002252")
+        pa.field("ontology_source", pa.string(), nullable=True),  # ontology prefix (e.g. "MS", "UBERON", "UNIMOD")
+        pa.field("ontology_version", pa.string(), nullable=True),  # version of the ontology (e.g. "4.1.235")
+        pa.field("view", pa.string()),  # which view (e.g. "psm", "feature", "sample")
+        pa.field("description", pa.string(), nullable=True),  # human-readable description
+        pa.field("source_column_name", pa.string(), nullable=True),  # original column name in tool output
+        pa.field("source_tool", pa.string(), nullable=True),  # tool that produced this field
+    ]
+)
 ```
 
 ### Example rows

--- a/docs/spec/provenance.md
+++ b/docs/spec/provenance.md
@@ -14,31 +14,31 @@ See the full YAML schema in [`provenance.yaml`](schemas/provenance.yaml).
 ```python
 import pyarrow as pa
 
-PARAMETER = pa.struct([
-    pa.field("key", pa.string()),        # parameter name (snake_case)
-    pa.field("value", pa.string()),      # parameter value (as string)
-])
+PARAMETER = pa.struct(
+    [
+        pa.field("key", pa.string()),  # parameter name (snake_case)
+        pa.field("value", pa.string()),  # parameter value (as string)
+    ]
+)
 
-provenance_schema = pa.schema([
-    # Step identity
-    pa.field("step_order", pa.int32()),               # execution order (1, 2, 3...)
-    pa.field("step_category", pa.string()),           # broad category
-    pa.field("step_name", pa.string()),               # specific step name
-
-    # Tool
-    pa.field("tool_name", pa.string()),               # tool name (e.g. "comet", "percolator")
-    pa.field("tool_version", pa.string(), nullable=True),  # tool version
-    pa.field("tool_uri", pa.string(), nullable=True),      # container URI or tool URL
-
-    # Parameters -- curated summary of key settings
-    pa.field("parameters", pa.list_(PARAMETER), nullable=True),
-
-    # Full configuration -- raw JSON for complete reference
-    pa.field("config", pa.string(), nullable=True),
-
-    # What this step produced
-    pa.field("output_views", pa.list_(pa.string()), nullable=True),
-])
+provenance_schema = pa.schema(
+    [
+        # Step identity
+        pa.field("step_order", pa.int32()),  # execution order (1, 2, 3...)
+        pa.field("step_category", pa.string()),  # broad category
+        pa.field("step_name", pa.string()),  # specific step name
+        # Tool
+        pa.field("tool_name", pa.string()),  # tool name (e.g. "comet", "percolator")
+        pa.field("tool_version", pa.string(), nullable=True),  # tool version
+        pa.field("tool_uri", pa.string(), nullable=True),  # container URI or tool URL
+        # Parameters -- curated summary of key settings
+        pa.field("parameters", pa.list_(PARAMETER), nullable=True),
+        # Full configuration -- raw JSON for complete reference
+        pa.field("config", pa.string(), nullable=True),
+        # What this step produced
+        pa.field("output_views", pa.list_(pa.string()), nullable=True),
+    ]
+)
 ```
 
 ## Field Reference

--- a/docs/spec/run.md
+++ b/docs/spec/run.md
@@ -17,13 +17,15 @@ Instrument, enzyme, and dissociation method fields store **plain strings** (huma
 Modification parameters use a dedicated struct with explicit fields, since modifications have well-known properties (fixed/variable, position, target residue) that benefit from a typed schema:
 
 ```python
-MODIFICATION = pa.struct([
-    pa.field("accession", pa.string()),                        # UNIMOD accession (required), e.g. "UNIMOD:21"
-    pa.field("name", pa.string(), nullable=True),               # human-readable name, e.g. "Phospho"
-    pa.field("fixed", pa.bool_(), nullable=True),               # true = fixed, false = variable
-    pa.field("position", pa.string(), nullable=True),           # e.g. "Anywhere", "Protein N-term"
-    pa.field("target_amino_acid", pa.string(), nullable=True),  # e.g. "S,T,Y", "C"
-])
+MODIFICATION = pa.struct(
+    [
+        pa.field("accession", pa.string()),  # UNIMOD accession (required), e.g. "UNIMOD:21"
+        pa.field("name", pa.string(), nullable=True),  # human-readable name, e.g. "Phospho"
+        pa.field("fixed", pa.bool_(), nullable=True),  # true = fixed, false = variable
+        pa.field("position", pa.string(), nullable=True),  # e.g. "Anywhere", "Protein N-term"
+        pa.field("target_amino_acid", pa.string(), nullable=True),  # e.g. "S,T,Y", "C"
+    ]
+)
 ```
 
 ---
@@ -35,31 +37,36 @@ import pyarrow as pa
 
 # (ONTOLOGY_TERM and MODIFICATION defined above)
 
-run_schema = pa.schema([
-    # Identity -- maps to SDRF "assay name"
-    pa.field("run_accession", pa.string()),             # PK
-    pa.field("run_file_name", pa.string()),              # raw data file name (without extension)
-    pa.field("file_name", pa.string(), nullable=True),   # original file name with extension (e.g. "S1_Frontal_1.raw")
-
-    # Sample-channel mapping (one run can contain multiple samples via TMT/iTRAQ)
-    pa.field("samples", pa.list_(pa.struct([
-        pa.field("sample_accession", pa.string()),      # FK to sample.parquet
-        pa.field("label", pa.string()),                 # channel label, e.g. "TMT126", "LFQ"
-        pa.field("biological_replicate", pa.int32(), nullable=True),
-        pa.field("technical_replicate", pa.int32(), nullable=True),
-    ]))),
-
-    # Run-level properties
-    pa.field("fraction", pa.string(), nullable=True),
-
-    # Instrument and method (plain strings; CV mappings in ontology.parquet)
-    pa.field("instrument", pa.string(), nullable=True),
-    pa.field("enzymes", pa.list_(pa.string()), nullable=True),
-    pa.field("dissociation_method", pa.string(), nullable=True),
-
-    # Modification parameters -- list of typed modification structs
-    pa.field("modification_parameters", pa.list_(MODIFICATION), nullable=True),
-])
+run_schema = pa.schema(
+    [
+        # Identity -- maps to SDRF "assay name"
+        pa.field("run_accession", pa.string()),  # PK
+        pa.field("run_file_name", pa.string()),  # raw data file name (without extension)
+        pa.field("file_name", pa.string(), nullable=True),  # original file name with extension (e.g. "S1_Frontal_1.raw")
+        # Sample-channel mapping (one run can contain multiple samples via TMT/iTRAQ)
+        pa.field(
+            "samples",
+            pa.list_(
+                pa.struct(
+                    [
+                        pa.field("sample_accession", pa.string()),  # FK to sample.parquet
+                        pa.field("label", pa.string()),  # channel label, e.g. "TMT126", "LFQ"
+                        pa.field("biological_replicate", pa.int32(), nullable=True),
+                        pa.field("technical_replicate", pa.int32(), nullable=True),
+                    ]
+                )
+            ),
+        ),
+        # Run-level properties
+        pa.field("fraction", pa.string(), nullable=True),
+        # Instrument and method (plain strings; CV mappings in ontology.parquet)
+        pa.field("instrument", pa.string(), nullable=True),
+        pa.field("enzymes", pa.list_(pa.string()), nullable=True),
+        pa.field("dissociation_method", pa.string(), nullable=True),
+        # Modification parameters -- list of typed modification structs
+        pa.field("modification_parameters", pa.list_(MODIFICATION), nullable=True),
+    ]
+)
 ```
 
 ## Field Reference
@@ -181,9 +188,7 @@ Each MODIFICATION struct contains:
     #  'instrument', 'enzymes', ...]
 
     # Get all sample-channel mappings for a specific run
-    run_row = runs.filter(
-        pq.compute.equal(runs.column("run_accession"), "Run_01")
-    ).to_pydict()
+    run_row = runs.filter(pq.compute.equal(runs.column("run_accession"), "Run_01")).to_pydict()
     print(run_row["samples"])
     ```
 

--- a/docs/spec/sample.md
+++ b/docs/spec/sample.md
@@ -14,29 +14,28 @@ See the full YAML schema in [`sample.yaml`](schemas/sample.yaml).
 ```python
 import pyarrow as pa
 
-sample_schema = pa.schema([
-    # Identity -- maps to SDRF "source name"
-    pa.field("sample_accession", pa.string()),          # PK, required
-
-    # Mandatory biological properties
-    pa.field("organism", pa.string()),                   # required
-    pa.field("organism_part", pa.string()),              # required
-
-    # Optional standard properties
-    pa.field("disease", pa.string(), nullable=True),
-    pa.field("cell_line", pa.string(), nullable=True),
-    pa.field("cell_type", pa.string(), nullable=True),
-    pa.field("sex", pa.string(), nullable=True),
-    pa.field("age", pa.string(), nullable=True),
-    pa.field("developmental_stage", pa.string(), nullable=True),
-    pa.field("ancestry", pa.string(), nullable=True),
-    pa.field("individual", pa.string(), nullable=True),
-    pa.field("sample_description", pa.string(), nullable=True),
-
-    # Extra columns from SDRF characteristics are added dynamically
-    # e.g. pa.field("biological_replicate", pa.string(), nullable=True),
-    # e.g. pa.field("bmi", pa.string(), nullable=True),
-])
+sample_schema = pa.schema(
+    [
+        # Identity -- maps to SDRF "source name"
+        pa.field("sample_accession", pa.string()),  # PK, required
+        # Mandatory biological properties
+        pa.field("organism", pa.string()),  # required
+        pa.field("organism_part", pa.string()),  # required
+        # Optional standard properties
+        pa.field("disease", pa.string(), nullable=True),
+        pa.field("cell_line", pa.string(), nullable=True),
+        pa.field("cell_type", pa.string(), nullable=True),
+        pa.field("sex", pa.string(), nullable=True),
+        pa.field("age", pa.string(), nullable=True),
+        pa.field("developmental_stage", pa.string(), nullable=True),
+        pa.field("ancestry", pa.string(), nullable=True),
+        pa.field("individual", pa.string(), nullable=True),
+        pa.field("sample_description", pa.string(), nullable=True),
+        # Extra columns from SDRF characteristics are added dynamically
+        # e.g. pa.field("biological_replicate", pa.string(), nullable=True),
+        # e.g. pa.field("bmi", pa.string(), nullable=True),
+    ]
+)
 ```
 
 ## Field Reference
@@ -89,6 +88,7 @@ Any non-standard SDRF `characteristics[X]` column becomes its own string column 
 
     # Get unique organisms
     import pyarrow.compute as pc
+
     organisms = pc.unique(samples.column("organism")).to_pylist()
     print(organisms)  # ['Homo sapiens', 'Homo sapiens; Saccharomyces cerevisiae']
     ```

--- a/docs/spec/serialization.md
+++ b/docs/spec/serialization.md
@@ -192,21 +192,18 @@ Every QPX Parquet file includes metadata as key-value pairs stored in the Parque
 
     # Define file-level metadata
     file_metadata = {
-        'qpx_version': '1.0',
-        'software_provider': 'QuantMS 1.3.0',
-        'project_accession': 'PXD012345',
-        'file_type': 'psm_file',
-        'creation_date': '2021-01-01',
+        "qpx_version": "1.0",
+        "software_provider": "QuantMS 1.3.0",
+        "project_accession": "PXD012345",
+        "file_type": "psm_file",
+        "creation_date": "2021-01-01",
     }
 
     # Merge with existing schema metadata and write
     existing_metadata = table.schema.metadata or {}
-    merged_metadata = {
-        **existing_metadata,
-        **{k.encode(): v.encode() for k, v in file_metadata.items()}
-    }
+    merged_metadata = {**existing_metadata, **{k.encode(): v.encode() for k, v in file_metadata.items()}}
     table = table.replace_schema_metadata(merged_metadata)
-    pq.write_table(table, 'psm_data.parquet')
+    pq.write_table(table, "psm_data.parquet")
     ```
 
 !!! tip "Reading file metadata in Python"

--- a/docs/spec/versioning.md
+++ b/docs/spec/versioning.md
@@ -24,7 +24,7 @@ All QPX views (PSM, Feature, PG, Peptide, Protein, MZ, and others serialized as 
 import pyarrow.parquet as pq
 
 # Writing a file with version metadata
-metadata = {'qpx_version': '1.0'}
+metadata = {"qpx_version": "1.0"}
 ```
 
 !!! tip "Reading the version from a file"
@@ -33,7 +33,7 @@ metadata = {'qpx_version': '1.0'}
 
     parquet_file = pq.ParquetFile("experiment.psm.parquet")
     schema_metadata = parquet_file.schema_arrow.metadata
-    qpx_version = schema_metadata.get(b'qpx_version', b'unknown').decode()
+    qpx_version = schema_metadata.get(b"qpx_version", b"unknown").decode()
     print(f"QPX version: {qpx_version}")
     ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -227,8 +227,9 @@ with qpx.open_dataset("./PXD014414") as ds:
 
    ```python
    import pandas as pd
-   sdrf = pd.read_csv('experiment.sdrf.tsv', sep='\t')
-   print(sdrf['source name'].unique())
+
+   sdrf = pd.read_csv("experiment.sdrf.tsv", sep="\t")
+   print(sdrf["source name"].unique())
    ```
 
 ### Missing factor values


### PR DESCRIPTION
`CONTRIBUTING.md` mentions that one of the first steps one need to do to confirm to the code standards is to format your code with ruff:

```
ruff check .
ruff format .
```

But if you do this a lot of files unrelated to your PR are also reformatted. This PR runs `ruff format` on the complete codebase so that new PRs have a clean slate to work from.