### PR TITLE
Unpin package version pins in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM python:3.11-slim-bookworm
 
 # Runtime system deps required by pyOpenMS (see environment.yml).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends libglib2.0-0=2.74.6-2+deb12u8 procps=2:4.0.2-3 \
+ && apt-get install -y --no-install-recommends libglib2.0-0 procps \
  && rm -rf /var/lib/apt/lists/*
 
 # hatch-vcs derives the version from git history; when the build context lacks


### PR DESCRIPTION
The [Build and push to GHCR](https://github.com/bigbio/qpx/actions/runs/30445340091/job/90555315499) CI step fails with `Version '2.74.6-2+deb12u8' for 'libglib2.0-0' was not found`.

This PR removes both package-version pins:

 ```
apt-get install -y --no-install-recommends libglib2.0-0 procps
 ```

This is preferable to updating just the GLib patch version, which will break again when Debian rotates security updates. The base image digest/version ensures reproducibility.