### PR TITLE
fix: restrict Python to <3.14 and widen pyopenms to <4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 description = "Quantitative proteomics data toolkit — convert, transform, query, and validate QPX Parquet datasets"
 readme = "README.md"
 license = { text = "Apache-2.0" }
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 authors = [{ name = "BigBio Team", email = "ypriverol@gmail.com" }]
 keywords = ["python", "multiomics", "proteomics", "quantms", "reanalysis", "parquet", "proteomics-data", "standardized-format", "bioinformatics-data"]
 classifiers = [
@@ -18,7 +18,7 @@ dependencies = [
     "click>=8.1",
     "pandas>=2.1",
     "pyarrow>=14.0",
-    "pyopenms>=3.3.0,<3.5.0",
+    "pyopenms>=3.3.0,<4.0.0",
     "numpy>=1.24",
     "duckdb>=1.1.3",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Problem

`uv run pre-commit run --all-files` (and any `uv run` command) fails on Python 3.14 because:

1. **`pyopenms<3.5.0`** — only ships wheels up to `cp313`; Python 3.14 requires `pyopenms>=3.5.0` which has `cp314` wheels.
2. **`numpy<2.1`** (pinned indirectly via `mokume==0.1.0` → `numpy<2.1.0`) — no `numpy<2.1` version ships Python 3.14 wheels, and building from source requires a C compiler toolchain unavailable on many Windows setups.
3. **No explicit Python upper bound** — users on Python 3.14 hit a cryptic resolution failure.

## Changes

| File | Change | Reason |
|------|--------|--------|
| `pyproject.toml` | `requires-python = ">=3.10"` → `">=3.10,<3.14"` | Explicitly prevent Python 3.14 until upstream deps support it |
| `pyproject.toml` | `pyopenms>=3.3.0,<3.5.0` → `">=3.3.0,<4.0.0"` | Allow pyopenms 3.5+ which has broader Python wheel coverage |

## Verification

```
$ pre-commit run --all-files
fix end of files...................................Passed
trim trailing whitespace...........................Passed
detect private key.................................Passed
ruff (legacy alias)................................Passed
ruff format........................................Passed
```
