### PR TITLE
feat(openms-consensus): structured modifications, localization scores, metadata tables

### DIFF
--- a/qpx/cli/convert.py
+++ b/qpx/cli/convert.py
@@ -853,7 +853,16 @@ def convert_openms_cmd(**kwargs):
     help="Parquet compression codec.",
 )
 def convert_openms_consensus_cmd(
-    consensusxml_path, sdrf_path, output_folder, output_prefix, structures, pg_top, streaming, verbose, project_accession, compression
+    consensusxml_path,
+    sdrf_path,
+    output_folder,
+    output_prefix,
+    structures,
+    pg_top,
+    streaming,
+    verbose,
+    project_accession,
+    compression,
 ):
     """Convert an OpenMS consensusXML (+ SDRF) to QPX.
 

--- a/qpx/cli/convert.py
+++ b/qpx/cli/convert.py
@@ -841,8 +841,19 @@ def convert_openms_cmd(**kwargs):
     ),
 )
 @click.option("--verbose", is_flag=True, help="Enable verbose logging.")
+@click.option(
+    "--project-accession",
+    help="PRIDE / ProteomeXchange accession (e.g. PXD001819)",
+)
+@click.option(
+    "--compression",
+    type=click.Choice(["zstd", "snappy", "gzip", "none"], case_sensitive=False),
+    default="zstd",
+    show_default=True,
+    help="Parquet compression codec.",
+)
 def convert_openms_consensus_cmd(
-    consensusxml_path, sdrf_path, output_folder, output_prefix, structures, pg_top, streaming, verbose
+    consensusxml_path, sdrf_path, output_folder, output_prefix, structures, pg_top, streaming, verbose, project_accession, compression
 ):
     """Convert an OpenMS consensusXML (+ SDRF) to QPX.
 
@@ -865,6 +876,8 @@ def convert_openms_consensus_cmd(
         structures=structs,
         pg_top=pg_top,
         streaming=streaming,
+        project_accession=project_accession,
+        compression=compression,
     )
     click.echo(f"consensusXML conversion complete. Wrote: {sorted(written)}")
 

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -20,6 +20,9 @@ from qpx.converters.openms_consensus.feature_adapter import (
     load_consensus_map,
 )
 from qpx.converters.openms_consensus.pg_adapter import accession_to_anchor, consensus_protein_groups_to_records
+from qpx._version import __version__
+from qpx.converters.orchestrator import BaseOrchestrator
+from qpx.core.constants import FEATURE, ONTOLOGY, PG, PSM, RUN, SAMPLE
 from qpx.core.data import FeatureSchema, PsmSchema
 from qpx.core.data.identity import derive_id
 from qpx.writers.feature import FeatureWriter
@@ -97,7 +100,7 @@ def _should_stream(path: str) -> bool:
         return False
 
 
-def _convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top) -> dict:
+def _convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression="zstd") -> dict:
     """Single-pass, low-memory feature/psm/pg from a streamed consensusXML.
 
     One ordered ``iter_all()`` pass over the elements + unassigned IDs feeds the
@@ -149,6 +152,7 @@ def _convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_p
                     str(out / f"{output_prefix}.feature.parquet"),
                     creator=creator,
                     identity_composite=_FEATURE_IDENTITY_COMPOSITE,
+                    compression=compression,
                 )
             )
         if want_psm:
@@ -157,6 +161,7 @@ def _convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_p
                     str(out / f"{output_prefix}.psm.parquet"),
                     creator=creator,
                     identity_composite=_PSM_IDENTITY_COMPOSITE,
+                    compression=compression,
                 )
             )
         feat_buf: list[dict] = []
@@ -204,7 +209,7 @@ def _convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_p
     if want_pg:
         records = build_pg_records(cm, map_info, maps, pep_intensity, sdrf_path, pg_top)
         path = out / f"{output_prefix}.pg.parquet"
-        with PgWriter(str(path), creator=creator) as w:
+        with PgWriter(str(path), creator=creator, compression=compression) as w:
             if records:
                 w.write_batch(records)
         written["pg"] = path
@@ -221,16 +226,46 @@ def _validate_structures(structures: tuple[str, ...], sdrf_path: Optional[str]) 
         raise ValueError(f"An SDRF is required to write {sorted(metadata)}")
 
 
+def _collect_score_names(table_path: Path) -> set[str]:
+    """Read ``additional_scores`` score names from a written parquet file."""
+    table = pa.parquet.read_table(str(table_path), columns=["additional_scores"])
+    names: set[str] = set()
+    for row in table.column("additional_scores").to_pylist():
+        if row:
+            for score in row:
+                if score and score.get("score_name"):
+                    names.add(score["score_name"])
+    return names
+
+
+def _consensus_is_isobaric(consensusxml_path: str) -> bool:
+    """Return whether a consensusXML's map labels indicate an isobaric (TMT/iTRAQ) run."""
+    try:
+        cm = load_consensus_map(consensusxml_path)
+        headers = cm.getColumnHeaders()
+        from qpx.converters.openms_consensus.feature_adapter import consensus_channels
+
+        return bool(consensus_channels(cm))
+    except Exception:  # noqa: BLE001 - best-effort provenance hint
+        return False
+
+
 def _write_sdrf_metadata(
     output_folder: Path,
     output_prefix: str,
     sdrf_path: str,
     requested: set[str],
-) -> dict[str, Path]:
-    """Write the requested SDRF-backed run/sample structures."""
+    compression: str = "zstd",
+) -> tuple[dict[str, Path], list[dict]]:
+    """Write the requested SDRF-backed run/sample structures.
+
+    Returns ``(paths, run_ontology_entries)`` — the latter collected from the
+    same ``SdrfConverter`` instance (its parse state populates the run ontology),
+    so callers need not re-parse the SDRF.
+    """
     metadata = requested.intersection({"run", "sample"})
     if not metadata:
-        return {}
+        return {}, []
 
     from qpx.converters.sdrf import SdrfConverter
 
@@ -238,16 +273,17 @@ def _write_sdrf_metadata(
         "sample": output_folder / f"{output_prefix}.sample.parquet",
         "run": output_folder / f"{output_prefix}.run.parquet",
     }
-    with SdrfConverter() as sdrf_converter:
+    with SdrfConverter(compression=compression) as sdrf_converter:
         sdrf_converter.convert(
             sdrf_path=sdrf_path,
             sample_output=str(paths["sample"]) if "sample" in metadata else None,
             run_output=str(paths["run"]) if "run" in metadata else None,
         )
-    return {name: paths[name] for name in metadata}
+        run_ontology = list(sdrf_converter.run_ontology_entries())
+    return {name: paths[name] for name in metadata}, run_ontology
 
 
-class OpenMSConsensusConverter:  # pylint: disable=too-few-public-methods
+class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-public-methods
     """consensusXML + SDRF -> QPX views.
 
     A single-entry orchestrator (``convert``) — the interim counterpart to the
@@ -264,6 +300,8 @@ class OpenMSConsensusConverter:  # pylint: disable=too-few-public-methods
         creator: str = "openms-consensus",
         pg_top: int = 0,
         streaming: Optional[bool] = None,
+        project_accession: Optional[str] = None,
+        compression: str = "zstd",
     ) -> dict[str, Path]:
         """Write the requested QPX views and return ``{structure: parquet path}``.
 
@@ -275,7 +313,12 @@ class OpenMSConsensusConverter:  # pylint: disable=too-few-public-methods
         — the low-memory streaming reader for files above ``_STREAM_THRESHOLD_BYTES``
         (which pyopenms would otherwise load whole into ~0.8x-file RAM), else the
         faster in-memory pyopenms load. ``True``/``False`` forces the choice.
+
+        ``project_accession`` (e.g. ``PXD001819``) is stamped into dataset.parquet.
+
+        ``compression`` is the Parquet codec for every written view (default zstd).
         """
+        self._compression = compression
         _validate_structures(structures, sdrf_path)
         requested = set(structures)
 
@@ -289,20 +332,103 @@ class OpenMSConsensusConverter:  # pylint: disable=too-few-public-methods
                 # Low-memory path: a single ordered pass over the consensusXML builds
                 # feature/psm/pg together and writes in batches, so the whole map is
                 # never in memory and the file is parsed once (not once per view).
-                written.update(_convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top))
+                written.update(_convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression))
             else:
                 # In-memory path: pyopenms loads the map once (fast for smaller files);
                 # the adapters iterate it cheaply. Output is identical either way.
                 written.update(
-                    self._convert_in_memory(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top)
+                    self._convert_in_memory(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression)
                 )
 
-        written.update(_write_sdrf_metadata(out, output_prefix, sdrf_path, requested))
+        sdrf_paths, run_ontology = _write_sdrf_metadata(out, output_prefix, sdrf_path, requested, compression)
+        written.update(sdrf_paths)
+
+        # Metadata tables (ontology / provenance / dataset) — written when the
+        # core + run/sample structures they describe are present. Best-effort:
+        # ontology entries only materialise when a PSI-MS term resolves.
+        if written:
+            self._write_metadata(out, output_prefix, written, consensusxml_path, run_ontology, requested, project_accession)
 
         return written
 
+    def _write_metadata(
+        self,
+        out: Path,
+        output_prefix: str,
+        written: dict[str, Path],
+        consensusxml_path: str,
+        run_ontology: list[dict],
+        requested: set[str],
+        project_accession: Optional[str] = None,
+    ) -> None:
+        """Write ontology/provenance/dataset metadata tables (best-effort).
+
+        Mirrors the ``openms`` enrichment path: ontology collects the run-level
+        terms from the SDRF plus the score names discovered in the written core
+        tables; provenance records the consensusXML -> QPX conversion steps; the
+        dataset table carries the project-level metadata.
+        """
+        ontology_entries = list(run_ontology)
+        for view in (PSM, FEATURE, PG):
+            path = written.get(view)
+            if not path:
+                continue
+            try:
+                names = _collect_score_names(path)
+            except (KeyError, pa.ArrowInvalid):
+                continue
+            if names:
+                from qpx.core.scores import score_ontology_entries
+
+                ontology_entries.extend(score_ontology_entries(names, view=view))  # noqa: PERF401
+        self._write_ontology(out, output_prefix, ontology_entries)
+
+        structures = sorted(requested & {PSM, FEATURE, PG, RUN, SAMPLE})
+        provenance_records = self._build_provenance(structures, consensusxml_path)
+        self._write_provenance(out, output_prefix, provenance_records)
+        if provenance_records:
+            self._write_dataset(
+                out,
+                output_prefix,
+                project_accession,
+                software_name=provenance_records[0]["tool_name"],
+                software_version=None,
+                provenance_records=provenance_records,
+            )
+
     @staticmethod
-    def _convert_in_memory(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top) -> dict:
+    def _build_provenance(structures: list[str], consensusxml_path: str) -> list[dict]:
+        """Provenance records: consensusXML parsing + QPX conversion."""
+        is_isobaric = _consensus_is_isobaric(consensusxml_path)
+        step_name = "isobaric_quantification" if is_isobaric else "label_free_quantification"
+        tool_name = "OpenMS/IsobaricWorkflow" if is_isobaric else "OpenMS/ProteomicsLFQ"
+        return [
+            {
+                "step_order": 1,
+                "step_category": "quantification",
+                "step_name": step_name,
+                "tool_name": tool_name,
+                "tool_version": None,
+                "tool_uri": None,
+                "parameters": None,
+                "config": None,
+                "output_views": [v for v in (FEATURE, PSM, PG) if v in structures],
+            },
+            {
+                "step_order": 2,
+                "step_category": "format_conversion",
+                "step_name": "openms_consensus_qpx_conversion",
+                "tool_name": "qpx",
+                "tool_version": __version__,
+                "tool_uri": None,
+                "parameters": None,
+                "config": None,
+                "output_views": [SAMPLE, RUN, ONTOLOGY],
+            },
+        ]
+
+    @staticmethod
+    def _convert_in_memory(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression="zstd") -> dict:
         """feature/psm/pg via the in-memory pyopenms map (loaded once, iterated cheaply)."""
         from qpx.converters.openms_consensus.feature_adapter import feature_map_info, feature_records_for_cf
         from qpx.converters.openms_consensus.psm_adapter import _cf_element_runs, _run_resolver, psm_records_for_pid
@@ -342,20 +468,20 @@ class OpenMSConsensusConverter:  # pylint: disable=too-few-public-methods
                     psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen))
             if want_feature:
                 path = out / f"{output_prefix}.feature.parquet"
-                with FeatureWriter(str(path), creator=creator, identity_composite=_FEATURE_IDENTITY_COMPOSITE) as w:
+                with FeatureWriter(str(path), creator=creator, identity_composite=_FEATURE_IDENTITY_COMPOSITE, compression=compression) as w:
                     if feat_recs:
                         w.write_batch(feat_recs)
                 written["feature"] = path
             if want_psm:
                 path = out / f"{output_prefix}.psm.parquet"
-                with PsmWriter(str(path), creator=creator, identity_composite=_PSM_IDENTITY_COMPOSITE) as w:
+                with PsmWriter(str(path), creator=creator, identity_composite=_PSM_IDENTITY_COMPOSITE, compression=compression) as w:
                     if psm_recs:
                         w.write_batch(psm_recs)
                 written["psm"] = path
         if "pg" in structures:
             recs = consensus_protein_groups_to_records(sdrf_path=sdrf_path, cm=cm, top=pg_top)
             path = out / f"{output_prefix}.pg.parquet"
-            with PgWriter(str(path), creator=creator) as w:
+            with PgWriter(str(path), creator=creator, compression=compression) as w:
                 if recs:
                     w.write_batch(recs)
             written["pg"] = path

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -15,12 +15,12 @@ from typing import Optional
 
 import pyarrow as pa
 
+from qpx._version import __version__
 from qpx.converters.openms_consensus.feature_adapter import (
     check_channels_vs_sdrf,
     load_consensus_map,
 )
 from qpx.converters.openms_consensus.pg_adapter import accession_to_anchor, consensus_protein_groups_to_records
-from qpx._version import __version__
 from qpx.converters.orchestrator import BaseOrchestrator
 from qpx.core.constants import FEATURE, ONTOLOGY, PG, PSM, RUN, SAMPLE
 from qpx.core.data import FeatureSchema, PsmSchema
@@ -242,7 +242,6 @@ def _consensus_is_isobaric(consensusxml_path: str) -> bool:
     """Return whether a consensusXML's map labels indicate an isobaric (TMT/iTRAQ) run."""
     try:
         cm = load_consensus_map(consensusxml_path)
-        headers = cm.getColumnHeaders()
         from qpx.converters.openms_consensus.feature_adapter import consensus_channels
 
         return bool(consensus_channels(cm))
@@ -332,12 +331,16 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
                 # Low-memory path: a single ordered pass over the consensusXML builds
                 # feature/psm/pg together and writes in batches, so the whole map is
                 # never in memory and the file is parsed once (not once per view).
-                written.update(_convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression))
+                written.update(
+                    _convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression)
+                )
             else:
                 # In-memory path: pyopenms loads the map once (fast for smaller files);
                 # the adapters iterate it cheaply. Output is identical either way.
                 written.update(
-                    self._convert_in_memory(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression)
+                    self._convert_in_memory(
+                        consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression
+                    )
                 )
 
         sdrf_paths, run_ontology = _write_sdrf_metadata(out, output_prefix, sdrf_path, requested, compression)
@@ -428,7 +431,9 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         ]
 
     @staticmethod
-    def _convert_in_memory(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression="zstd") -> dict:
+    def _convert_in_memory(
+        consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression="zstd"
+    ) -> dict:
         """feature/psm/pg via the in-memory pyopenms map (loaded once, iterated cheaply)."""
         from qpx.converters.openms_consensus.feature_adapter import feature_map_info, feature_records_for_cf
         from qpx.converters.openms_consensus.psm_adapter import _cf_element_runs, _run_resolver, psm_records_for_pid
@@ -468,13 +473,17 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
                     psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen))
             if want_feature:
                 path = out / f"{output_prefix}.feature.parquet"
-                with FeatureWriter(str(path), creator=creator, identity_composite=_FEATURE_IDENTITY_COMPOSITE, compression=compression) as w:
+                with FeatureWriter(
+                    str(path), creator=creator, identity_composite=_FEATURE_IDENTITY_COMPOSITE, compression=compression
+                ) as w:
                     if feat_recs:
                         w.write_batch(feat_recs)
                 written["feature"] = path
             if want_psm:
                 path = out / f"{output_prefix}.psm.parquet"
-                with PsmWriter(str(path), creator=creator, identity_composite=_PSM_IDENTITY_COMPOSITE, compression=compression) as w:
+                with PsmWriter(
+                    str(path), creator=creator, identity_composite=_PSM_IDENTITY_COMPOSITE, compression=compression
+                ) as w:
                     if psm_recs:
                         w.write_batch(psm_recs)
                 written["psm"] = path

--- a/qpx/converters/openms_consensus/feature_adapter.py
+++ b/qpx/converters/openms_consensus/feature_adapter.py
@@ -95,6 +95,115 @@ def to_proforma(aa_sequence) -> str:
     return s
 
 
+def _parse_site_scores(raw) -> dict[int, float]:
+    """Parse a Luciphor ``Luciphor_site_scores`` UserParam into {position: score}.
+
+    The value is a stringified dict (e.g. ``{1: -31.36, 9: 31.36}``) keyed by
+    1-based amino-acid index. Positional ``None`` values are dropped so a site
+    without a localisation score contributes no score entry.
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = eval(str(raw))  # noqa: S307 - trusted OpenMS float dict
+        if not isinstance(parsed, dict):
+            return {}
+        out = {}
+        for k, v in parsed.items():
+            try:
+                pos = int(k)
+            except (TypeError, ValueError):
+                continue
+            if v is not None:
+                try:
+                    out[pos] = float(v)
+                except (TypeError, ValueError):
+                    pass
+        return out
+    except Exception:
+        return {}
+
+
+def to_modifications(aa_sequence, site_scores: dict[int, list[dict]] | None = None) -> list[dict]:
+    """Convert a pyopenms ``AASequence`` to the QPX ``modifications`` structure.
+
+    Each modification is ``{name, accession, positions: [{position, amino_acid,
+    scores}]}`` — the residue position (1-based) plus, when a site-localisation
+    score dict is supplied, the per-site localisation score(s) (as QPX ``score``
+    structs). N- and C-terminal modifications are reported at position 1 /
+    ``len(sequence)`` with an ``amino_acid`` of ``None`` (no single residue
+    carries them), mirroring ``to_proforma``'s ``[UNIMOD:N]-`` / ``-[UNIMOD:N]``
+    rendering.
+    """
+    mods: list[dict] = []
+    seen: dict[str, dict] = {}
+
+    def _add_mod(name: str, accession: str | None, position: int, amino_acid: str | None, scores: list[dict] | None) -> None:
+        key = name or accession or ""
+        entry = seen.get(key)
+        if entry is None:
+            entry = {"name": name, "accession": accession, "positions": []}
+            seen[key] = entry
+            mods.append(entry)
+        entry["positions"].append({"position": position, "amino_acid": amino_acid, "scores": scores})
+
+    def _acc(accession) -> str | None:
+        # Normalise pyopenms "UniMod:N" to QPX's canonical "UNIMOD:N".
+        if not accession:
+            return None
+        return str(accession).replace("UniMod:", "UNIMOD:")
+
+    for i in range(aa_sequence.size()):
+        mod = aa_sequence[i].getModification()
+        if not mod:
+            continue
+        _add_mod(mod.getId() or "", _acc(mod.getUniModAccession()), i + 1, aa_sequence[i].getOneLetterCode(), site_scores.get(i + 1) if site_scores else None)
+
+    nterm = aa_sequence.getNTerminalModification() if hasattr(aa_sequence, "getNTerminalModification") else None
+    if nterm:
+        _add_mod(nterm.getId() or "", _acc(nterm.getUniModAccession()), 1, None, None)
+    cterm = aa_sequence.getCTerminalModification() if hasattr(aa_sequence, "getCTerminalModification") else None
+    if cterm:
+        _add_mod(cterm.getId() or "", _acc(cterm.getUniModAccession()), aa_sequence.size(), None, None)
+    return mods or None
+
+
+# Site-localisation algorithms whose UserParams OpenMS may stamp onto peptide
+# hits: ``<name>_pep_score`` (peptide-level score) and ``<name>_site_scores``
+# (a ``{position: score}`` dict keyed by 1-based residue index). Multiple
+# algorithms may be present in one file (e.g. a run localised by Ascore and
+# another by PhosphoRS), so all matches are collected rather than a single one.
+_LOCALIZATION_ALGORITHMS = ("Luciphor", "Ascore", "PhosphoRS", "AScore")
+
+
+def localization_scores(hit) -> tuple[list[dict] | None, dict[int, list[dict]]]:
+    """Return ``(additional_scores, site_scores)`` from a hit's site-localisation UserParams.
+
+    For each known localisation algorithm present on the hit, ``<Algo>_pep_score``
+    and ``<Algo>_global_flr`` (when present) become ``additional_scores`` entries
+    (the QPX ``score`` struct); ``<Algo>_site_scores`` is parsed into
+    ``{position: [score, ...]}`` so :func:`to_modifications` can attach the
+    per-site localisation score(s) to the matching modification position.
+    """
+    additional: list[dict] = []
+    site_scores: dict[int, list[dict]] = {}
+    for algo in _LOCALIZATION_ALGORITHMS:
+        pep_key = f"{algo}_pep_score"
+        if hit.metaValueExists(pep_key):
+            additional.append({"score_name": pep_key, "score_value": float(hit.getMetaValue(pep_key)), "higher_better": None})
+        flr_key = f"{algo}_global_flr"
+        if hit.metaValueExists(flr_key):
+            additional.append({"score_name": flr_key, "score_value": float(hit.getMetaValue(flr_key)), "higher_better": None})
+        site_key = f"{algo}_site_scores"
+        if hit.metaValueExists(site_key):
+            parsed = _parse_site_scores(hit.getMetaValue(site_key))
+            for pos, score in parsed.items():
+                site_scores.setdefault(pos, []).append(
+                    {"score_name": f"{algo.lower()}_site_score", "score_value": score, "higher_better": None}
+                )
+    return (additional or None), site_scores
+
+
 def load_consensus_map(consensusxml_path: str):
     """Parse a consensusXML into a ``ConsensusMap`` — the single parse point.
 
@@ -206,6 +315,8 @@ def feature_records_for_cf(cf, map_info: dict[int, tuple[str, str]], anchor_map=
     seq_obj = hit.getSequence()
     peptidoform = to_proforma(seq_obj)
     sequence = seq_obj.toUnmodifiedString()
+    additional_scores, site_scores = localization_scores(hit)
+    modifications = to_modifications(seq_obj, site_scores)
     charge = int(cf.getCharge() or hit.getCharge() or 0)
     is_decoy = False
     if hit.metaValueExists("target_decoy"):
@@ -230,6 +341,7 @@ def feature_records_for_cf(cf, map_info: dict[int, tuple[str, str]], anchor_map=
             {
                 "sequence": sequence,
                 "peptidoform": peptidoform,
+                "modifications": modifications,
                 "charge": charge,
                 "run_file_name": run,
                 "scan": scan_by_run.get(run, []),
@@ -240,6 +352,7 @@ def feature_records_for_cf(cf, map_info: dict[int, tuple[str, str]], anchor_map=
                 "observed_mz": observed_mz,
                 "consensus_rt": consensus_rt,
                 "anchor_protein": anchor_protein,
+                "additional_scores": additional_scores,
             }
         )
     return records

--- a/qpx/converters/openms_consensus/feature_adapter.py
+++ b/qpx/converters/openms_consensus/feature_adapter.py
@@ -157,7 +157,13 @@ def to_modifications(aa_sequence, site_scores: dict[int, list[dict]] | None = No
         mod = aa_sequence[i].getModification()
         if not mod:
             continue
-        _add_mod(mod.getId() or "", _acc(mod.getUniModAccession()), i + 1, aa_sequence[i].getOneLetterCode(), site_scores.get(i + 1) if site_scores else None)
+        _add_mod(
+            mod.getId() or "",
+            _acc(mod.getUniModAccession()),
+            i + 1,
+            aa_sequence[i].getOneLetterCode(),
+            site_scores.get(i + 1) if site_scores else None,
+        )
 
     nterm = aa_sequence.getNTerminalModification() if hasattr(aa_sequence, "getNTerminalModification") else None
     if nterm:

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -12,7 +12,14 @@ from __future__ import annotations
 import logging
 import re
 
-from qpx.converters.openms_consensus.feature_adapter import _run_stem, feature_map_info, load_consensus_map, to_proforma
+from qpx.converters.openms_consensus.feature_adapter import (
+    _run_stem,
+    feature_map_info,
+    load_consensus_map,
+    localization_scores,
+    to_modifications,
+    to_proforma,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -153,10 +160,15 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None) -> lis
                     "higher_better": True,
                 }
             )
+        loc_scores, site_scores = localization_scores(hit)
+        if loc_scores:
+            additional_scores.extend(loc_scores)
+        modifications = to_modifications(seq_obj, site_scores)
         records.append(
             {
                 "sequence": seq_obj.toUnmodifiedString(),
                 "peptidoform": peptidoform,
+                "modifications": modifications,
                 "charge": charge,
                 "run_file_name": run,
                 "scan": scan,


### PR DESCRIPTION
## Summary

Extends the `openms-consensus` converter to full parity with the `openms` enrichment path.

### Structured `modifications`
- Populate the structured `modifications` column in **feature** and **psm** views from `pyopenms` `AASequence` per-residue / N-/C-terminal modifications, with canonical `UNIMOD:N` accessions.
- Verified against LFQ / TMT / phospho datasets: every modification position matches the `peptidoform` string exactly (0 mismatches).

### Site-localisation scores
- Extract per-position localisation scores from OpenMS hit UserParams for **Luciphor**, **Ascore**, and **PhosphoRS**:
  - `<algo>_pep_score` → `additional_scores`
  - `<algo>_global_flr` → `additional_scores`
  - `<algo>_site_scores` (`{position: score}`) → `modifications[].positions[].scores`
- Multiple algorithms in one file are all collected.

### Metadata tables
- Write **ontology** / **provenance** / **dataset** so the output is a complete 8-structure QPX dataset (previously only 5 structures).
- Provenance auto-detects isobaric (TMT/iTRAQ) vs label-free from the consensusXML map labels.

### CLI parity with `convert openms`
- Add `--project-accession` (stamped into `dataset.parquet`).
- Add `--compression [zstd|snappy|gzip|none]`, threaded through every writer (feature/psm/pg/run/sample/ontology/provenance/dataset).

## Validation
- Re-converted LFQ (PXD001819), TMT (PXD007683TMT), and three phospho-localisation variants (Luciphor / Ascore / PhosphoRS) against the source consensusXML.
- All datasets: 8/8 structures, `qpxc validate` Overall VALID, schema columns exact, PK unique, record-level intensities match source, modifications positions ↔ peptidoform consistent (0 mismatches), site scores attached correctly.

## Files changed
- `qpx/cli/convert.py`
- `qpx/converters/openms_consensus/converter.py`
- `qpx/converters/openms_consensus/feature_adapter.py`
- `qpx/converters/openms_consensus/psm_adapter.py`

Co-Authored-By: Claude <noreply@anthropic.com>