### PR TITLE
fix(pg): key pg_id on full group membership, not the leader

### DIFF
--- a/docs/spec/data-model.md
+++ b/docs/spec/data-model.md
@@ -27,7 +27,7 @@ Define these once; the rest of the spec uses them consistently.
 | **label** | The **canonical name of a channel** (`LFQ`, `TMT126`, `iTRAQ114`, …). This is the string that ties a quantity to a sample. For LFQ there is exactly one label, `"LFQ"`. For TMT/iTRAQ/plexDIA each channel is a distinct label mapping to a distinct sample. | `run.samples[].label`, `feature.intensities[].label`, `pg.label` |
 | **fraction** | A fractionated portion of one sample. Fractions of one sample share the same (source, biological replicate, technical replicate) and differ **only** in `run.fraction`. Each fraction is a separate run/raw file. | `run.fraction` |
 | **grouped_runs** | The **set of raw files aggregated into one quantification unit** — the fractions of one sample+channel context, aggregated together. `list<string>` of `run_file_name`. Single-element for unfractionated or DIA data. | `pg.grouped_runs` |
-| **quantification unit** | The thing a protein quantity is measured *over*: one `grouped_runs` set. A protein abundance exists per quantification unit, **not** per single raw file, because a protein quantity only emerges after aggregating its peptides across the sample's fractions. | `pg` (one row per `(anchor_protein, grouped_runs, label)`) |
+| **quantification unit** | The thing a protein quantity is measured *over*: one `grouped_runs` set. A protein abundance exists per quantification unit, **not** per single raw file, because a protein quantity only emerges after aggregating its peptides across the sample's fractions. | `pg` (one row per `(pg_accessions, grouped_runs, label)`) |
 | **peptidoform** | Peptide sequence + modifications in ProForma notation. The identity thread linking PSM ↔ feature ↔ pepmap. | `psm`, `feature`, `pepmap` |
 | **entity ID** | Mandatory opaque primary key for a PSM, Feature, or protein-group row: `psm_id`, `feature_id`, or `pg_id`. It may be supplied by the producer or derived by QPX from the file's footer-declared `identity_composite`. | `psm`, `feature`, `pg` |
 | **anchor_protein** | The representative (leading) protein of a protein group. On `feature` it is an annotation used for semantic protein mapping; an explicit Feature-to-PG link uses `feature.pg_ids[]` → `pg.pg_id`. On `pg` it participates in the default identity composite. | `feature`, `pg` |
@@ -67,7 +67,7 @@ graph LR
   override for their producer's Feature entity. Covers DDA **and** DIA.
 - **pg** — a protein group quantified over one **quantification unit**
   (`grouped_runs`) for one **label**. PK `pg_id`; schema-default identity
-  composite `[anchor_protein, grouped_runs, label]`. There is **one row per
+  composite `[pg_accessions, grouped_runs, label]`. There is **one row per
   label** (flattened since QPX 1.1).
 
 !!! note "Granularity shifts at each step"
@@ -213,7 +213,7 @@ graph TD
 
 !!! note "Fractionated TMT combines both"
     Fractionated TMT has `grouped_runs` with several files **and** N labels: one
-    pg row per `(anchor_protein, grouped_runs, label)` — the fractions collapse
+    pg row per `(pg_accessions, grouped_runs, label)` — the fractions collapse
     into the set, the channels stay as separate rows.
 
 ## Label / channel → sample resolution

--- a/docs/spec/intensities.md
+++ b/docs/spec/intensities.md
@@ -126,7 +126,7 @@ additional_intensities: array[struct{
     The `intensities: list<{label, intensity}>` struct on this page describes the
     **feature** view. Since QPX 1.1 the protein-group view is **flattened**: each
     row carries scalar `label` + `intensity` columns and there is one row per
-    `(anchor_protein, grouped_runs, label)`. `label`/`intensity` are null for
+    `(pg_accessions, grouped_runs, label)`. `label`/`intensity` are null for
     identification-only groups. See [Protein Group](pg.md) and the
     [Data Model](data-model.md).
 

--- a/docs/spec/pg.md
+++ b/docs/spec/pg.md
@@ -14,7 +14,7 @@ This view is analogous to outputs from tools such as MaxQuant (`proteinGroups.tx
 ## Schema
 
 `pg_id` is the non-null primary key. The schema-default `identity_composite` is
-`[anchor_protein, grouped_runs, label]`; `label` is null only for
+`[pg_accessions, grouped_runs, label]`; `label` is null only for
 identification-only protein groups that carry no quantity. Fields marked with
 **(nullable)** may have null values. See the full YAML schema in
 [`pg.yaml`](schemas/pg.yaml).
@@ -68,7 +68,7 @@ identification-only protein groups that carry no quantity. Fields marked with
 | `additional_intensities` | Pre-computed intensity values from the upstream tool (normalized, LFQ, iBAQ, etc.) for this row's label. See [Intensities](intensities.md) | `array[struct]` | No |
 | `additional_scores` | Additional scores and metrics (posterior error probability, confidence, etc.). See [Scores](scores.md) | `array[struct]` | No |
 
-Since QPX 1.1 the protein-group quantification is **flattened**: instead of an `intensities` list, each row carries a scalar `label` + `intensity`, so there is one row per `(anchor_protein, grouped_runs, label)`. Identification-only groups (no quantity) have null `label`/`intensity`.
+Since QPX 1.1 the protein-group quantification is **flattened**: instead of an `intensities` list, each row carries a scalar `label` + `intensity`, so there is one row per `(pg_accessions, grouped_runs, label)`. Identification-only groups (no quantity) have null `label`/`intensity`.
 
 Each entry in `additional_intensities` contains:
 

--- a/docs/spec/schemas/pg.yaml
+++ b/docs/spec/schemas/pg.yaml
@@ -1,7 +1,7 @@
 name: pg
 file_type: pg_file
 primary_key: [pg_id]
-identity_composite: [anchor_protein, grouped_runs, label]
+identity_composite: [pg_accessions, grouped_runs, label]
 doc: "Protein groups with per-quantification-unit quantification (one row per label; label/intensity flattened from the old intensities list)"
 
 fields:
@@ -16,7 +16,7 @@ fields:
   pg_accessions:
     type: "list<string>"
     required: true
-    doc: "Protein accessions within this group"
+    doc: "Protein accessions within this group. Part of the default identity composite: the FULL group membership (not just the leader) keys the pg_id, so two distinct groups that happen to share a leading protein get distinct ids. Hashed order-independently (membership is a set)."
   pg_names:
     type: "list<string>"
     doc: "Protein group names"
@@ -33,7 +33,7 @@ fields:
   anchor_protein:
     type: string
     required: true
-    doc: "Anchor/leading protein of the group"
+    doc: "Anchor/leading protein of the group (the representative used for feature->pg joins). Descriptive only — NOT part of the pg_id identity, which keys on the full pg_accessions membership."
 
   # Quantification-unit context
   grouped_runs:

--- a/docs/spec/versioning.md
+++ b/docs/spec/versioning.md
@@ -52,17 +52,28 @@ This version defines all core serialized views (PSM, Feature, PG, MZ), the deriv
 
 ### Changelog
 
-- **PG identity now keys on full group membership** (backward-incompatible for
-  `pg_id` values): the PG schema-default `identity_composite` changed from
-  `[anchor_protein, grouped_runs, label]` to `[pg_accessions, grouped_runs, label]`.
-  Keying on only the group **leader** (`anchor_protein`) gave two genuinely distinct
-  protein groups that share a leading protein the **same** `pg_id`, and split a
-  single group with inconsistent per-precursor annotations into duplicate-identity
-  rows. The identity now hashes the full `pg_accessions` membership
-  (order-independently, like `grouped_runs`), so distinct groups get distinct ids.
-  `anchor_protein` remains a descriptive field. This changes derived `pg_id`
-  values, so pg files must be regenerated. (Whether this ships as a spec-version
-  bump is deferred to the maintainer; `QPX_SPEC_VERSION` is unchanged here.)
+- **1.1.2** (on-disk spec version stays `1.1`): two related fixes to identity
+  handling.
+    - **PG identity now keys on full group membership** (backward-incompatible for
+      `pg_id` values): the PG schema-default `identity_composite` changed from
+      `[anchor_protein, grouped_runs, label]` to
+      `[pg_accessions, grouped_runs, label]`. Keying on only the group **leader**
+      (`anchor_protein`) gave two genuinely distinct protein groups that share a
+      leading protein the **same** `pg_id`, and split a single group with
+      inconsistent per-precursor annotations into duplicate-identity rows. The
+      identity now hashes the full `pg_accessions` membership (order-independently,
+      like `grouped_runs`), so distinct groups get distinct ids. `anchor_protein`
+      remains a descriptive field.
+    - **Duplicate primary keys on the write/convert path are now a warning, not a
+      hard error.** While the format stabilises, writers and converters persist
+      source data as-produced and log a warning on a duplicate identity id rather
+      than crashing (a duplicate usually signals a converter identity bug worth
+      investigating). A **NULL primary key remains a fatal error**, and
+      `qpxc validate --strict` (the audit/CI path) still reports a duplicate
+      primary key as an **error**.
+    - **No in-place migration.** These changes affect derived `pg_id` values and
+      identity handling; regenerate qpx files by **re-converting from the original
+      source files** — there is no on-disk migration.
 - **1.1** (backward-incompatible, pre-2.0 stabilisation): the PG view now keys on
   `grouped_runs` (`list<string>`) instead of the scalar `run_file_name`. A
   protein-group quantity applies to the set of raw files (fractions) aggregated

--- a/docs/spec/versioning.md
+++ b/docs/spec/versioning.md
@@ -52,6 +52,17 @@ This version defines all core serialized views (PSM, Feature, PG, MZ), the deriv
 
 ### Changelog
 
+- **PG identity now keys on full group membership** (backward-incompatible for
+  `pg_id` values): the PG schema-default `identity_composite` changed from
+  `[anchor_protein, grouped_runs, label]` to `[pg_accessions, grouped_runs, label]`.
+  Keying on only the group **leader** (`anchor_protein`) gave two genuinely distinct
+  protein groups that share a leading protein the **same** `pg_id`, and split a
+  single group with inconsistent per-precursor annotations into duplicate-identity
+  rows. The identity now hashes the full `pg_accessions` membership
+  (order-independently, like `grouped_runs`), so distinct groups get distinct ids.
+  `anchor_protein` remains a descriptive field. This changes derived `pg_id`
+  values, so pg files must be regenerated. (Whether this ships as a spec-version
+  bump is deferred to the maintainer; `QPX_SPEC_VERSION` is unchanged here.)
 - **1.1** (backward-incompatible, pre-2.0 stabilisation): the PG view now keys on
   `grouped_runs` (`list<string>`) instead of the scalar `run_file_name`. A
   protein-group quantity applies to the set of raw files (fractions) aggregated

--- a/qpx/converters/column_mappings.yaml
+++ b/qpx/converters/column_mappings.yaml
@@ -28,7 +28,10 @@ fragpipe:
       pg_accessions: ["Protein", "Protein ID"]
       gg_accessions: ["Gene", "Gene Names"]
       pg_names: ["Description", "Protein Description"]
-      pg_qvalue: ["Protein Probability", "Protein FDR", "Protein Q-Value", "Combined Protein FDR"]
+      # Real FDR/Q-Value columns first (low = best); "Protein Probability" is a
+      # confidence score (~1.0 = best) and must only be a last-resort fallback,
+      # converted as 1 - probability by the adapter — never used raw as a q-value.
+      pg_qvalue: ["Protein FDR", "Protein Q-Value", "Combined Protein FDR", "Protein Probability"]
       peptide_count_total: ["Combined Total Peptides", "Total Peptides"]
       peptide_count_unique: ["Combined Unique Peptides", "Unique Peptides"]
       spectral_count: ["Combined Spectral Count", "Spectral Count"]

--- a/qpx/converters/diann/pg_adapter.py
+++ b/qpx/converters/diann/pg_adapter.py
@@ -45,6 +45,19 @@ _PG_EXTRA_COLS = [
 _DECOY_PREFIXES = ("DECOY_", "decoy_", "rev_", "REV_")
 
 
+def _first_non_null(series: pd.Series):
+    """Return the first non-null, non-empty value in *series* (else None).
+
+    Used to collapse a protein group's per-precursor name/gene annotations to a
+    single representative value so inconsistent annotations do not split the
+    group into duplicate-identity records.
+    """
+    for value in series:
+        if pd.notna(value) and value != "":
+            return value
+    return None
+
+
 class DiannPgAdapter(DiaNNBaseAdapter):
     """Convert DIA-NN report + PG matrix to ``pg.parquet``.
 
@@ -233,17 +246,23 @@ class DiannPgAdapter(DiaNNBaseAdapter):
         report_df["run_file_name"] = report_df["run_file_name_clean"]
         report_df.drop(columns=["run_file_name_clean"], inplace=True)
 
-        # Aggregate per protein group per run — single groupby over the whole batch
+        # Aggregate per protein group per run — one record per (pg_accessions, run).
+        # Grouping additionally on pg_names/gg_accessions would split a single
+        # protein group into multiple records when DIA-NN emits inconsistent
+        # name/gene annotations across a group's precursor rows; those records
+        # share the same (pg_accessions, grouped_runs, label) identity and would
+        # collide on pg_id. Names/genes are instead derived within the group
+        # below (first non-null), so annotation noise no longer splits a group.
         pg_groups = report_df.groupby(
-            ["pg_accessions", "pg_names", "gg_accessions", "run_file_name"],
+            ["pg_accessions", "run_file_name"],
             dropna=False,
         )
 
-        for (pg_acc, pg_nm, gg_acc, ref), group in pg_groups:
+        for (pg_acc, ref), group in pg_groups:
             rec = self._build_pg_record(
                 pg_acc=str(pg_acc),
-                pg_names_raw=pg_nm,
-                gg_acc_raw=gg_acc,
+                pg_names_raw=_first_non_null(group["pg_names"]),
+                gg_acc_raw=_first_non_null(group["gg_accessions"]),
                 run_file_name=str(ref),
                 group=group,
                 pg_matrix_indexed=pg_matrix_indexed,

--- a/qpx/converters/fragpipe/constants.py
+++ b/qpx/converters/fragpipe/constants.py
@@ -9,6 +9,27 @@ from typing import Optional
 from qpx.converters.ptm import build_proforma, from_proforma, mass_to_unimod
 
 # ---------------------------------------------------------------------------
+# Decoy detection
+# ---------------------------------------------------------------------------
+# FragPipe/Philosopher tag decoy accessions with one of these prefixes. Keep the
+# set identical across the psm/feature/pg adapters so a decoy is labelled the
+# same everywhere. Detection must run on the RAW accession, before any
+# ``sp|ACC|NAME`` parsing strips the prefix.
+DECOY_PREFIXES = ("rev_", "REV_", "DECOY_", "decoy_")
+
+
+def is_decoy_accession(protein_field: str) -> bool:
+    """True if any accession in a (possibly comma-joined) protein field is a decoy.
+
+    Operates on the raw string so ``rev_sp|P123|NAME`` is still recognised as a
+    decoy (``parse_uniprot_id`` would otherwise drop the ``rev_`` prefix).
+    """
+    if not protein_field:
+        return False
+    return any(part.strip().startswith(DECOY_PREFIXES) for part in str(protein_field).split(","))
+
+
+# ---------------------------------------------------------------------------
 # PTM parsing: FragPipe "Assigned Modifications" -> ProForma
 # ---------------------------------------------------------------------------
 

--- a/qpx/converters/fragpipe/feature_adapter.py
+++ b/qpx/converters/fragpipe/feature_adapter.py
@@ -12,7 +12,7 @@ from typing import Optional
 import pandas as pd
 
 from qpx.converters.base import BaseConverter, resolve_columns
-from qpx.converters.fragpipe.constants import to_modifications, to_proforma
+from qpx.converters.fragpipe.constants import is_decoy_accession, to_modifications, to_proforma
 from qpx.converters.mappings import get_field_mappings
 from qpx.converters.utils import parse_uniprot_id, safe_float
 from qpx.core.sql import escape_path, sql_build
@@ -186,11 +186,20 @@ class FragPipeFeatureAdapter(BaseConverter):
     # ------------------------------------------------------------------
 
     def _build_psm_lookup(self, psm_path: str) -> dict[tuple, dict]:
-        """Build a lookup from (run_file_name, peptidoform, charge) -> PSM info.
+        """Build a lookup for feature-level PSM enrichment.
 
-        Loads FragPipe ``psm.tsv`` into a temporary DuckDB table and extracts
-        the first-occurrence PSM per key, providing mass error, PEP, scan,
-        and decoy flag for feature-level enrichment.
+        Loads FragPipe ``psm.tsv`` into a temporary DuckDB table and extracts the
+        first-occurrence PSM providing mass error, PEP, scan, and decoy flag.
+
+        Each PSM is registered under two keys so that the feature side (which is
+        keyed by *experiment*, not raw file) can always resolve a match:
+
+        * ``(source_file, peptidoform, charge)`` — exact, used when the FragPipe
+          experiment name equals the raw-file stem (non-fractionated case);
+        * ``(peptidoform, charge)`` — fallback, used when experiment != raw file
+          (fractionated runs), where the 3-tuple would otherwise always miss.
+
+        The 2- and 3-element tuples never collide, so a single dict holds both.
         """
         lookup: dict[tuple, dict] = {}
 
@@ -285,19 +294,16 @@ class FragPipeFeatureAdapter(BaseConverter):
                 charge_str = str(charge) if charge is not None else "0"
 
                 key = (source_file, peptidoform, charge_str)
+                fallback_key = (peptidoform, charge_str)
                 if key not in lookup:
                     # PEP = 1 - PeptideProphet Probability
                     pep = None
                     if pp_prob is not None:
                         pep = 1.0 - pp_prob if pp_prob <= 1.0 else pp_prob
 
-                    is_decoy = (
-                        any(acc.strip().startswith(("rev_", "DECOY_", "decoy_", "REV_")) for acc in str(protein).split(","))
-                        if protein
-                        else False
-                    )
+                    is_decoy = is_decoy_accession(protein)
 
-                    lookup[key] = {
+                    info = {
                         "observed_mz": float(obs_mz) if obs_mz is not None else None,
                         "calculated_mz": (float(calc_mz) if calc_mz is not None else None),
                         "pep": pep,
@@ -306,6 +312,11 @@ class FragPipeFeatureAdapter(BaseConverter):
                         "ion_mobility": (float(ion_mobility) if ion_mobility is not None else None),
                         "missed_cleavages": (int(missed_cleavages_val) if missed_cleavages_val is not None else None),
                     }
+                    lookup[key] = info
+                    # Register the run-agnostic fallback (first occurrence wins) so
+                    # the experiment-keyed feature query still resolves when the
+                    # experiment name differs from the raw-file stem.
+                    lookup.setdefault(fallback_key, info)
 
             # Clean up temporary table
             self._conn.execute("DROP TABLE IF EXISTS _fp_psm_lookup")
@@ -404,22 +415,22 @@ class FragPipeFeatureAdapter(BaseConverter):
 
             intensities = [{"label": "LFQ", "intensity": float(intensity_val)}]
 
-            # PSM lookup: enrich with mass error, PEP, scan, decoy flag
+            # PSM lookup: enrich with mass error, PEP, scan, decoy flag. Try the
+            # exact (experiment==raw-file) key first, then the run-agnostic
+            # (peptidoform, charge) fallback so fractionated experiments still hit.
             psm_info = {}
             if psm_lookup:
-                psm_key = (experiment, peptidoform, str(charge))
-                psm_info = psm_lookup.get(psm_key, {})
+                psm_info = psm_lookup.get((experiment, peptidoform, str(charge)))
+                if not psm_info:
+                    psm_info = psm_lookup.get((peptidoform, str(charge)), {})
 
             _calc = psm_info.get("calculated_mz")
             _obs = psm_info.get("observed_mz")
             mass_error_ppm = 1e6 * (_obs - _calc) / _calc if _calc and _obs else None
 
-            # Is decoy: prefer PSM lookup; fall back to protein prefix
-            _is_decoy_fallback = (
-                any(p["accession"].startswith(("rev_", "DECOY_", "decoy_", "REV_")) for p in pg_accessions)
-                if pg_accessions
-                else False
-            )
+            # Is decoy: prefer PSM lookup; fall back to the decoy prefix on the RAW
+            # protein field (before parse_uniprot_id strips e.g. the "rev_" prefix).
+            _is_decoy_fallback = is_decoy_accession(protein_raw)
 
             rec = {
                 "sequence": sequence,

--- a/qpx/converters/fragpipe/pg_adapter.py
+++ b/qpx/converters/fragpipe/pg_adapter.py
@@ -17,6 +17,7 @@ import pandas as pd
 
 from qpx.converters.base import BaseConverter, resolve_columns
 from qpx.converters.channel_labels import experiment_runs_from_sdrf
+from qpx.converters.fragpipe.constants import is_decoy_accession
 from qpx.converters.mappings import get_field_mappings
 from qpx.converters.utils import safe_float
 from qpx.core.sql import escape_path, sql_build
@@ -300,8 +301,8 @@ class FragPipePgAdapter(BaseConverter):
 
         anchor_protein = pg_accessions[0] if pg_accessions else ""
 
-        # Is decoy: detected from rev_/DECOY_/decoy_ prefix on any accession
-        is_decoy = any(acc.strip().startswith(("rev_", "DECOY_", "decoy_")) for acc in pg_accessions) if pg_accessions else False
+        # Is decoy: detected from a decoy prefix on any RAW accession
+        is_decoy = is_decoy_accession(protein_raw)
 
         # Combined counts
         total_peptides = int(row.get(r.get("peptide_count_total", "Combined Total Peptides"), 0) or 0)
@@ -315,8 +316,18 @@ class FragPipePgAdapter(BaseConverter):
         if mol_weight is not None:
             mol_weight = mol_weight / 1000.0  # Convert Da to kDa
 
-        # Protein group q-value (Protein Probability, Protein FDR, etc.)
-        pg_qvalue = safe_float(row.get(r.get("pg_qvalue", "Protein Probability")))
+        # Protein group q-value. Real FDR/Q-Value columns are preferred (see the
+        # ordered mapping in column_mappings.yaml). "Protein Probability" is a
+        # confidence score (~1.0 = best), so when it is the only column present it
+        # is converted to an FDR-like value as 1 - probability, never used raw.
+        pg_qvalue_col = r.get("pg_qvalue")
+        pg_qvalue_raw = safe_float(row.get(pg_qvalue_col)) if pg_qvalue_col else None
+        if pg_qvalue_raw is None:
+            pg_qvalue = None
+        elif pg_qvalue_col == "Protein Probability":
+            pg_qvalue = 1.0 - pg_qvalue_raw
+        else:
+            pg_qvalue = pg_qvalue_raw
 
         # Peptides per protein
         peptides = [{"protein_name": acc, "peptide_count": total_peptides} for acc in pg_accessions]
@@ -329,17 +340,24 @@ class FragPipePgAdapter(BaseConverter):
             unique_spec_col = f"{experiment} Unique Spectral Count"
 
             total_intensity = safe_float(row.get(total_int_col)) or 0.0
-            if total_intensity <= 0:
+            maxlfq_val = safe_float(row.get(maxlfq_col))
+            # MaxLFQ-only experiments (detected from a "<exp> MaxLFQ Intensity"
+            # column) have no Total Intensity; fall back to MaxLFQ as the primary
+            # intensity rather than dropping the protein group entirely.
+            if total_intensity > 0:
+                primary_intensity = total_intensity
+            elif maxlfq_val is not None and maxlfq_val > 0:
+                primary_intensity = maxlfq_val
+            else:
                 continue
 
             # Intensities (new schema: {label, intensity})
             label = "LFQ"
-            intensities = [{"label": label, "intensity": float(total_intensity)}]
+            intensities = [{"label": label, "intensity": float(primary_intensity)}]
 
             # Additional intensities pre-computed by FragPipe (MaxLFQ)
             additional_intensities = []
             extra_vals = []
-            maxlfq_val = safe_float(row.get(maxlfq_col))
             if maxlfq_val is not None:
                 extra_vals.append({"intensity_name": "maxlfq", "intensity_value": float(maxlfq_val)})
             if extra_vals:

--- a/qpx/converters/fragpipe/psm_adapter.py
+++ b/qpx/converters/fragpipe/psm_adapter.py
@@ -18,7 +18,7 @@ from typing import Optional, Tuple
 import pandas as pd
 
 from qpx.converters.base import BaseConverter, resolve_columns
-from qpx.converters.fragpipe.constants import to_modifications, to_proforma
+from qpx.converters.fragpipe.constants import is_decoy_accession, to_modifications, to_proforma
 from qpx.converters.mappings import get_field_mappings
 from qpx.converters.utils import safe_float
 from qpx.core.scores import normalize_score_name
@@ -187,8 +187,9 @@ class FragPipePsmAdapter(BaseConverter):
         protein_id = str(row.get(r.get("pg_accessions", "Protein"), ""))
         protein_accessions = [protein_id] if protein_id else []
 
-        # Is decoy (bool) -- FragPipe marks decoys with "rev_" prefix
-        is_decoy = protein_id.startswith("rev_")
+        # Is decoy (bool) -- decoy prefix on any accession in the RAW protein field
+        # (rev_/REV_/DECOY_/decoy_), kept consistent with the feature/pg adapters.
+        is_decoy = is_decoy_accession(protein_id)
 
         # Peptidoform -- build ProForma from sequence + Assigned Modifications
         assigned_mods_raw = row.get("Assigned Modifications")

--- a/qpx/converters/maxquant/feature_adapter.py
+++ b/qpx/converters/maxquant/feature_adapter.py
@@ -82,6 +82,10 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
             chunksize: Rows per batch.
             creator: Creator tag in Parquet metadata.
         """
+        # Track which dropped-TMT-channel warnings have already been emitted so
+        # the message is logged once, not once per batch.
+        self._warned_tmt_channels: set = set()
+
         # Step 1: Load evidence into DuckDB
         self._load_evidence(evidence_path)
 
@@ -122,24 +126,43 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
         self.logger.info(f"MaxQuant feature conversion complete -> {output_path}")
 
     def _deduplicated_evidence_query(self, actual_cols: set[str]) -> str:
-        """Prefer identified evidence when MaxQuant repeats an MBR feature."""
-        identity_columns = [
+        """Collapse rows that share the feature identity, preferring identified evidence.
+
+        The partition key mirrors ``_FEATURE_IDENTITY_COMPOSITE`` -- the columns
+        ``feature_id`` is hashed from -- so rows resolving to the same
+        ``feature_id`` collapse to one. The previous key partitioned on
+        ``Calibrated retention time`` (which is *not* part of the identity), so
+        identity-equal rows differing only in calibrated RT survived as
+        duplicate primary keys. Only identity columns actually present are used;
+        a missing column narrows the partition rather than degrading to a
+        no-dedup ``SELECT * FROM evidence`` (which would let MBR duplicates
+        through).
+        """
+        # Map each identity-composite field to its resolved MaxQuant column.
+        # "Modified sequence" stands in for ``peptidoform`` (a deterministic
+        # function of it); the remaining fields match the composite directly.
+        identity_field_columns = [
             self._resolved.get("modified_sequence", "Modified sequence"),
             self._resolved.get("charge", "Charge"),
             self._resolved.get("run_file_name", "Raw file"),
-            self._resolved.get("rt", "Calibrated retention time"),
+            self._resolved.get("rt_start", "Calibrated retention time start"),
+            self._resolved.get("rt_stop", "Calibrated retention time finish"),
+            self._resolved.get("scan", "MS/MS scan number"),
         ]
-        if "Type" not in actual_cols or not all(column in actual_cols for column in identity_columns):
+        identity_columns = [column for column in identity_field_columns if column in actual_cols]
+        if not identity_columns:
             return "SELECT * FROM evidence"
 
         partition_by = ", ".join(validate_identifier(column) for column in identity_columns)
-        type_column = validate_identifier("Type")
-        order_by = [
-            sql_build(
-                "CASE WHEN UPPER(TRIM(CAST($type_column AS VARCHAR))) = 'MULTI-MATCH' THEN 1 ELSE 0 END",
-                type_column=type_column,
+        order_by = []
+        if "Type" in actual_cols:
+            type_column = validate_identifier("Type")
+            order_by.append(
+                sql_build(
+                    "CASE WHEN UPPER(TRIM(CAST($type_column AS VARCHAR))) = 'MULTI-MATCH' THEN 1 ELSE 0 END",
+                    type_column=type_column,
+                )
             )
-        ]
         pep_column = self._resolved.get("posterior_error_probability", "PEP")
         if pep_column in actual_cols:
             order_by.append(
@@ -155,6 +178,9 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
                     id_column=validate_identifier("id"),
                 )
             )
+        if not order_by:
+            # No preference columns present; keep an arbitrary-but-stable row.
+            order_by.append("1")
 
         return sql_build(
             """
@@ -187,12 +213,22 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
     # ------------------------------------------------------------------
 
     def _build_protein_group_maps(self, protein_groups_path: Optional[str]) -> dict:
-        """Build protein accession lookup maps from proteinGroups.txt.
+        """Build protein-group lookup maps from proteinGroups.txt.
 
-        Returns a dict with ``qvalue`` and ``genes`` sub-maps.
+        Returns a dict with two sub-maps:
+            ``by_group``: full protein-group membership (a ``frozenset`` of
+                normalised accessions) -> ``{"qvalue", "genes"}``. This is the
+                primary key, consistent with the pg identity fix which keys on
+                the whole ``pg_accessions`` membership rather than the leader.
+            ``by_accession``: single accession -> ``{"qvalue", "genes"}``, but
+                *only* for accessions that belong to exactly one protein group.
+                Ambiguous razor accessions (shared across groups) are excluded
+                so a feature cannot inherit another group's q-value/genes via
+                its leader.
         """
+        empty = {"by_group": {}, "by_accession": {}}
         if not protein_groups_path:
-            return {"qvalue": {}, "genes": {}}
+            return empty
         try:
             df = self._conn.execute(
                 "SELECT * FROM read_csv_auto($1, delim='\t', header=true, auto_detect=true, null_padding=true)",
@@ -200,18 +236,17 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
             ).df()
             acc_col, qval_col, gene_col = self._detect_pg_columns(df)
             if not acc_col:
-                return {"qvalue": {}, "genes": {}}
-            qvalue_map = self._extract_qvalue_map(df, acc_col, qval_col)
-            gene_map = self._extract_gene_map(df, acc_col, gene_col)
+                return empty
+            maps = self._build_pg_lookup(df, acc_col, qval_col, gene_col)
             self.logger.info(
-                "Built protein group maps: %d q-values, %d gene entries",
-                len(qvalue_map),
-                len(gene_map),
+                "Built protein group maps: %d group(s), %d unambiguous accession(s)",
+                len(maps["by_group"]),
+                len(maps["by_accession"]),
             )
-            return {"qvalue": qvalue_map, "genes": gene_map}
+            return maps
         except (FileNotFoundError, pd.errors.ParserError, KeyError, ValueError, duckdb.Error) as e:
             self.logger.warning("Could not build protein group maps: %s", e)
-        return {"qvalue": {}, "genes": {}}
+        return empty
 
     @staticmethod
     def _detect_pg_columns(df: pd.DataFrame) -> tuple:
@@ -225,43 +260,68 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
         return acc_col, qval_col, gene_col
 
     @staticmethod
-    def _extract_qvalue_map(df: pd.DataFrame, acc_col: str, qval_col: Optional[str]) -> dict[str, float]:
-        """Build accession -> q-value map from proteinGroups DataFrame."""
-        if not qval_col:
-            return {}
-        sub = df[[acc_col, qval_col]].copy()
-        sub[qval_col] = pd.to_numeric(sub[qval_col], errors="coerce")
-        sub = sub.dropna(subset=[qval_col])
-        # Explode semicolon-separated protein groups into individual accessions
-        sub = sub.assign(**{acc_col: sub[acc_col].astype(str).str.split(";")}).explode(acc_col)
-        sub[acc_col] = sub[acc_col].str.strip().apply(strip_uniprot_prefix)
-        sub = sub[sub[acc_col].str.len() > 0].drop_duplicates(subset=[acc_col], keep="first")
-        return dict(zip(sub[acc_col], sub[qval_col]))
+    def _canonical_group_key(accessions) -> frozenset:
+        """Order-independent key for a protein-group membership."""
+        return frozenset(a.strip() for a in accessions if a and a.strip())
 
     @staticmethod
-    def _extract_gene_map(df: pd.DataFrame, acc_col: str, gene_col: Optional[str]) -> dict[str, list[str]]:
-        """Build accession -> gene name list map from proteinGroups DataFrame."""
-        gene_map: dict[str, list[str]] = {}
+    def _parse_genes(gene_raw, fasta_raw) -> Optional[list[str]]:
+        """Parse gene names from a proteinGroups row (Gene names, else Fasta headers)."""
+        genes: list[str] | None = None
+        if gene_raw is not None and pd.notna(gene_raw) and str(gene_raw).strip():
+            genes = [g.strip() for g in str(gene_raw).split(";") if g.strip()] or None
+        if not genes and fasta_raw is not None and pd.notna(fasta_raw) and str(fasta_raw).strip():
+            genes = []
+            for hdr in str(fasta_raw).split(";"):
+                m = re.search(r"GN=([^\s;]+)", hdr)
+                if m and m.group(1) not in genes:
+                    genes.append(m.group(1))
+            genes = genes or None
+        return genes
+
+    def _build_pg_lookup(self, df: pd.DataFrame, acc_col: str, qval_col: Optional[str], gene_col: Optional[str]) -> dict:
+        """Build the ``by_group``/``by_accession`` lookup maps (see caller)."""
+        by_group: dict[frozenset, dict] = {}
+        acc_to_groups: dict[str, set] = {}
+        acc_value: dict[str, dict] = {}
+
         acc_vals = df[acc_col].astype(str).tolist()
+        qval_vals = pd.to_numeric(df[qval_col], errors="coerce").tolist() if qval_col else [None] * len(df)
         gene_vals = df[gene_col].tolist() if (gene_col and gene_col in df.columns) else [None] * len(df)
         fasta_vals = df["Fasta headers"].tolist() if "Fasta headers" in df.columns else [None] * len(df)
-        for acc_raw, gene_raw, fasta_raw in zip(acc_vals, gene_vals, fasta_vals):
+
+        for acc_raw, qval, gene_raw, fasta_raw in zip(acc_vals, qval_vals, gene_vals, fasta_vals):
             accs = [strip_uniprot_prefix(a.strip()) for a in acc_raw.split(";") if a.strip()]
-            genes: list[str] | None = None
-            if gene_raw and pd.notna(gene_raw):
-                genes = [g.strip() for g in str(gene_raw).split(";") if g.strip()] or None
-            if not genes and fasta_raw and pd.notna(fasta_raw):
-                genes = []
-                for hdr in str(fasta_raw).split(";"):
-                    m = re.search(r"GN=([^\s;]+)", hdr)
-                    if m and m.group(1) not in genes:
-                        genes.append(m.group(1))
-                genes = genes or None
-            if genes:
-                for acc in accs:
-                    if acc not in gene_map:
-                        gene_map[acc] = genes
-        return gene_map
+            if not accs:
+                continue
+            qvalue = float(qval) if qval is not None and pd.notna(qval) else None
+            genes = self._parse_genes(gene_raw, fasta_raw)
+            value = {"qvalue": qvalue, "genes": genes}
+            key = self._canonical_group_key(accs)
+            by_group.setdefault(key, value)
+            for acc in accs:
+                acc_to_groups.setdefault(acc, set()).add(key)
+                acc_value.setdefault(acc, value)
+
+        # Keep only accessions that map to a single protein group for the
+        # leader fallback; ambiguous accessions would otherwise collide.
+        by_accession = {acc: acc_value[acc] for acc, keys in acc_to_groups.items() if len(keys) == 1}
+        return {"by_group": by_group, "by_accession": by_accession}
+
+    def _lookup_pg_metadata(self, pg_maps: Optional[dict], pg_acc_list: list[str], anchor_protein: str) -> tuple:
+        """Resolve ``(pg_global_qvalue, genes)`` for a feature's protein group.
+
+        Keyed on the full protein-group membership first; only falls back to the
+        leader accession when that leader is unambiguous (belongs to one group).
+        """
+        if not pg_maps:
+            return None, None
+        entry = pg_maps.get("by_group", {}).get(self._canonical_group_key(pg_acc_list))
+        if entry is None and anchor_protein:
+            entry = pg_maps.get("by_accession", {}).get(anchor_protein)
+        if entry is None:
+            return None, None
+        return entry.get("qvalue"), entry.get("genes")
 
     def _detect_ri_offset(self, columns) -> int:
         """Detect whether reporter intensity columns are 0-indexed or 1-indexed.
@@ -277,6 +337,39 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
             return 0
         return 1
 
+    def _warn_dropped_tmt_channels(self, columns, experiment_type: str, tmt_channels: list[str], ri_offset: int) -> None:
+        """Warn when the SDRF plex declares channels absent from evidence.txt.
+
+        A ``Reporter intensity N`` column missing for a declared channel means
+        that channel is silently dropped from every feature; surface it once.
+        """
+        if getattr(self, "_warned_tmt_channels", None) is None:  # pragma: no cover - defensive
+            self._warned_tmt_channels = set()
+        exp_type = re.sub(r"\d+", "", experiment_type or "").upper()
+        if exp_type not in ("TMT", "ITRAQ") or not tmt_channels:
+            return
+        col_set = set(columns)
+        dropped: list[tuple[str, str]] = []
+        for seq_idx, channel_name in enumerate(tmt_channels):
+            col_idx = TMT_LABEL_TO_MQ_COL.get(str(channel_name).strip().upper())
+            if col_idx is None:
+                col_idx = seq_idx
+            col_name = f"Reporter intensity {col_idx + ri_offset}"
+            if col_name not in col_set:
+                dropped.append((str(channel_name), col_name))
+        if not dropped:
+            return
+        key = tuple(sorted(ch for ch, _ in dropped))
+        if key in self._warned_tmt_channels:
+            return
+        self._warned_tmt_channels.add(key)
+        logger.warning(
+            "SDRF declares %d TMT/iTRAQ channel(s) with no matching reporter intensity "
+            "column in evidence.txt; these channels are dropped from all features: %s",
+            len(dropped),
+            ", ".join(f"{ch} (expected {col})" for ch, col in dropped),
+        )
+
     def _transform_batch(
         self,
         df: pd.DataFrame,
@@ -290,6 +383,8 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
         records: list[dict] = []
         # Detect reporter intensity column indexing once per batch
         ri_offset = self._detect_ri_offset(df.columns)
+        # Warn (once) about SDRF channels with no reporter column in evidence.txt
+        self._warn_dropped_tmt_channels(df.columns, experiment_type, tmt_channels, ri_offset)
         # Pre-extract column arrays for faster per-row access than to_dict("records")
         col_arrays = {col: df[col].values for col in df.columns}
         n_rows = len(df)
@@ -386,11 +481,14 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
         # Unique peptide indicator
         unique = len(pg_acc_list) <= 1
 
+        # Protein-group q-value and genes, keyed on the full membership.
+        pg_qvalue, pg_genes = self._lookup_pg_metadata(pg_maps, pg_acc_list, anchor_protein)
+
         # Gene names
         gg_raw = row.get(r.get("gg_names", "Gene names"))
         gg_names = str(gg_raw).split(";") if pd.notna(gg_raw) and gg_raw else None
-        if not gg_names and pg_maps and anchor_protein:
-            gg_names = pg_maps.get("genes", {}).get(anchor_protein)
+        if not gg_names:
+            gg_names = pg_genes
 
         # Mass error (ppm) — direct column from evidence.txt
         mass_error_ppm = safe_float(row.get(r.get("mass_error_ppm", "Mass error [ppm]")))
@@ -452,7 +550,7 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
             "pg_accessions": pg_accessions,
             "anchor_protein": anchor_protein,
             "unique": unique,
-            "pg_global_qvalue": (pg_maps.get("qvalue", {}).get(anchor_protein) if pg_maps else None),
+            "pg_global_qvalue": pg_qvalue,
             "ion_mobility_start": None,
             "ion_mobility_stop": None,
             "gg_accessions": gg_names,

--- a/qpx/converters/maxquant/pg_adapter.py
+++ b/qpx/converters/maxquant/pg_adapter.py
@@ -50,6 +50,8 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
         super().__init__(**kwargs)
         self._experiment_to_runs: dict[str, list[str]] = {}
         self._sdrf_experiment_to_runs: dict[str, list[str]] | None = None
+        # Dropped-TMT-channel warnings already emitted (once per experiment).
+        self._warned_tmt_channels: set = set()
 
     def convert(
         self,
@@ -287,6 +289,26 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
             records.extend(recs)
         return records
 
+    def _warn_dropped_tmt_channels(self, experiment: str, dropped_channels: list[str]) -> None:
+        """Warn once per experiment about declared channels absent from proteinGroups.txt.
+
+        A channel with no matching ``Reporter intensity N <experiment>`` column
+        is silently dropped from the protein-group intensities; surface it.
+        """
+        if not dropped_channels:
+            return
+        key = (experiment, tuple(sorted(dropped_channels)))
+        if key in self._warned_tmt_channels:
+            return
+        self._warned_tmt_channels.add(key)
+        logger.warning(
+            "SDRF declares %d TMT/iTRAQ channel(s) with no matching reporter intensity "
+            "column for experiment %r in proteinGroups.txt; dropped: %s",
+            len(dropped_channels),
+            experiment,
+            ", ".join(dropped_channels),
+        )
+
     @staticmethod
     def _extract_gene_names(fasta_headers: str) -> list[str] | None:
         """Extract gene names from Fasta header lines using ``GN=`` tag."""
@@ -421,6 +443,7 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
                 intensities: list[dict] = []
                 additional_intensities: list[dict] = []
                 channels = tmt_channels or []
+                dropped_channels: list[str] = []
                 for seq_idx, channel_name in enumerate(channels):
                     col_idx = TMT_LABEL_TO_MQ_COL.get(str(channel_name).strip().upper())
                     if col_idx is None:
@@ -428,6 +451,7 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
                     mq_col_num = col_idx + ri_offset
                     col_name = ch_cols.get(mq_col_num)
                     if not col_name:
+                        dropped_channels.append(str(channel_name))
                         continue
                     val = safe_float(row.get(col_name))
                     if val and val > 0:
@@ -443,6 +467,7 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
                                     ],
                                 }
                             )
+                self._warn_dropped_tmt_channels(exp, dropped_channels)
                 if intensities:
                     records.append(_make_rec(self._runs_for(exp), intensities, additional_intensities))
         else:

--- a/qpx/converters/maxquant/psm_adapter.py
+++ b/qpx/converters/maxquant/psm_adapter.py
@@ -149,6 +149,10 @@ class MaxQuantPsmAdapter(MaxQuantBaseAdapter):
         if pd.notna(phospho_raw) and phospho_raw:
             site_scores = parse_phospho_probabilities(str(phospho_raw))
 
+        # Mirror the feature adapter: an empty/missing "Modified sequence"
+        # yields no peptidoform, and the tuple-unpack must degrade to
+        # (None, None) rather than a bare None (which raises TypeError and
+        # aborts the whole PSM view).
         peptidoform, modifications = (
             from_proforma(
                 peptidoform,
@@ -156,8 +160,13 @@ class MaxQuantPsmAdapter(MaxQuantBaseAdapter):
                 site_scores=site_scores,
             )
             if peptidoform
-            else None
+            else (None, None)
         )
+        if peptidoform is None:
+            # PsmSchema requires a peptidoform; a row with an empty/missing
+            # "Modified sequence" is skipped rather than aborting the whole view.
+            self.logger.debug("Skipping PSM row with empty modified sequence (sequence=%r)", sequence)
+            return None
         charge_raw = row.get(r.get("charge", "Charge"), 0)
         charge = int(charge_raw) if pd.notna(charge_raw) else 0
 

--- a/qpx/converters/mzidentml/converter.py
+++ b/qpx/converters/mzidentml/converter.py
@@ -154,15 +154,22 @@ class MzIdentMLConverter(BaseOrchestrator):
             scans = rec.get("scan") or []
             if not scans:
                 continue
-            scan = scans[0]
-            spectrum = mgf_index.get_spectrum(scan)
-            if spectrum is None:
-                # Fallback: try 0-based index lookup
-                spectrum = mgf_index.get_spectrum_by_index(scan)
+            value = scans[0]
+            # Honour the nativeID scheme: an ``index=`` value is a 0-based file
+            # position, NOT a scan number. Looking it up by scan number would
+            # match an unrelated spectrum whose ``SCANS=`` equals the index and
+            # attach the wrong peaks/RT. A ``scan=`` value must never be treated
+            # as an index either — use the lookup that matches the scheme only.
+            scheme = rec.get("_spectrum_id_scheme")
+            if scheme == "index":
+                spectrum = mgf_index.get_spectrum_by_index(value)
                 if spectrum is not None:
                     matched_by_index += 1
             else:
-                matched_by_scan += 1
+                # "scan" (or a legacy record without a recorded scheme)
+                spectrum = mgf_index.get_spectrum(value)
+                if spectrum is not None:
+                    matched_by_scan += 1
 
             if spectrum is not None:
                 rec["mz_array"] = spectrum["mz_array"]

--- a/qpx/converters/mzidentml/psm_adapter.py
+++ b/qpx/converters/mzidentml/psm_adapter.py
@@ -8,6 +8,7 @@ crosslinking modifications (``crosslink donor``, ``crosslink acceptor``).
 
 from __future__ import annotations
 
+import copy
 import gzip
 import logging
 import re
@@ -329,7 +330,7 @@ class MzIdentMLPsmAdapter(BaseConverter):
 
         records = []
         for sir in spectrum_results:
-            scan = _parse_scan(sir["spectrum_id"])
+            scan, scan_scheme = _parse_native_id(sir["spectrum_id"])
             run_file = spectra_data.get(sir["spectra_data_ref"], "unknown")
             rt = sir.get("rt")
             siis = sir["siis"]
@@ -349,6 +350,10 @@ class MzIdentMLPsmAdapter(BaseConverter):
                     rt=rt,
                 )
                 if record is not None:
+                    # Transient hint (dropped by the writer) telling
+                    # ``_attach_spectra`` whether ``scan`` is an acquisition scan
+                    # number or a 0-based file index, so it fetches by the right key.
+                    record["_spectrum_id_scheme"] = scan_scheme
                     records.append(record)
 
         return records
@@ -409,9 +414,13 @@ class MzIdentMLPsmAdapter(BaseConverter):
         # Build peptidoform from sequence and parsed modifications
         peptidoform = _build_peptidoform(sequence, alpha_pep.get("modifications"))
 
-        # Enrich modifications with site localization scores from SII cvParams
+        # Enrich modifications with site localization scores from SII cvParams.
+        # ``alpha_pep["modifications"]`` is shared by every PSM that references
+        # this Peptide id, and site-localization scoring mutates positions in
+        # place — deep-copy first so PSMs sharing a peptide_ref do not accumulate
+        # each other's phosphoRS/Ascore values.
         modifications = _attach_site_localization_scores(
-            alpha_pep.get("modifications"),
+            copy.deepcopy(alpha_pep.get("modifications")),
             alpha_sii["cv_params"],
         )
 
@@ -654,20 +663,47 @@ def _source_sii_identity(run_file: str, alpha_sii: dict, beta_sii: dict | None) 
     return derive_id([run_file, source_ids]), cv_params
 
 
-def _parse_scan(spectrum_id: str) -> list[int]:
-    """Extract scan number(s) from mzIdentML spectrumID string.
+def _parse_native_id(spectrum_id: str) -> tuple[list[int], str | None]:
+    """Extract the numeric spectrum reference and its nativeID scheme.
 
-    Handles formats: ``scan=100``, ``index=7483``, ``spectrum=5``.
-    Falls back to 0 if no numeric value is found.
+    Returns ``(values, scheme)`` where ``scheme`` is one of:
+
+    * ``"scan"``  — the value is an acquisition scan number
+      (``scan=N``, ``spectrum=N``, or a bare integer);
+    * ``"index"`` — the value is a 0-based position in the spectrum file
+      (``index=N``). This is NOT a scan number: it must be looked up by
+      position, never by scan number, or peaks/RT from an unrelated spectrum
+      whose ``SCANS=`` happens to equal the index get attached;
+    * ``None``    — no numeric reference could be parsed.
+
+    The scheme is what lets spectra attachment fetch the CORRECT spectrum.
     """
-    m = re.search(r"(?:scan|index|spectrum)=(\d+)", spectrum_id)
+    m = re.search(r"scan=(\d+)", spectrum_id)
     if m:
-        return [int(m.group(1))]
-    # Try bare integer
+        return [int(m.group(1))], "scan"
+    m = re.search(r"index=(\d+)", spectrum_id)
+    if m:
+        return [int(m.group(1))], "index"
+    m = re.search(r"spectrum=(\d+)", spectrum_id)
+    if m:
+        return [int(m.group(1))], "scan"
+    # Bare integer spectrumID — historically treated as a scan number.
     m = re.match(r"^(\d+)$", spectrum_id.strip())
     if m:
-        return [int(m.group(1))]
-    return [0]
+        return [int(m.group(1))], "scan"
+    # Unparseable: return an empty marker (NOT ``[0]``) so a spectrum with no
+    # parseable id does not alias onto a real scan-0 spectrum, and two distinct
+    # unparseable spectra are not silently collapsed onto the same sentinel.
+    return [], None
+
+
+def _parse_scan(spectrum_id: str) -> list[int]:
+    """Return the scan/index value(s) from a spectrumID, without the scheme.
+
+    Prefer :func:`_parse_native_id` when the nativeID scheme matters (e.g. to
+    attach the correct spectrum). Returns an empty list when nothing parses.
+    """
+    return _parse_native_id(spectrum_id)[0]
 
 
 def _group_siis(siis: list[dict]) -> list[dict]:

--- a/qpx/converters/openms/converter.py
+++ b/qpx/converters/openms/converter.py
@@ -153,11 +153,19 @@ def _collect_score_names(table_path: Path) -> set[str]:
 
 
 def _validate_core(discovered: dict[str, Path]) -> None:
-    """Validate each discovered parquet file against its QPX schema."""
+    """Validate each discovered parquet file against its QPX schema.
+
+    Uses ``strict=False`` so the convert path persists source data as-produced:
+    a duplicate primary key (and a null in a non-nullable column) is a warning,
+    not a blocking error, while the format stabilises. Missing columns and type
+    mismatches remain errors regardless of ``strict``. Null primary keys are
+    still fatal — the writer rejects them at close time before this runs. The
+    ``qpxc validate --strict`` audit/CI path stays strict and is unaffected.
+    """
     for view, path in discovered.items():
         schema = load_schema(_VIEW_SCHEMAS[view])
         table = pq.read_table(str(path))
-        result = schema.validate_full(table, strict=True)
+        result = schema.validate_full(table, strict=False)
         if not result.is_valid:
             errors = "; ".join(i.message for i in result.errors)
             raise ValueError(f"Validation failed for {path.name}: {errors}")

--- a/qpx/converters/openms_consensus/feature_adapter.py
+++ b/qpx/converters/openms_consensus/feature_adapter.py
@@ -231,11 +231,19 @@ def load_consensus_map(consensusxml_path: str):
 
 
 def _pid_scans(pid) -> list[int]:
-    """Scan numbers parsed from one identification's spectrum reference."""
+    """Scan numbers parsed from one identification's spectrum reference.
+
+    Uses the shared parser in :mod:`psm_adapter` (imported lazily to avoid a
+    circular import — psm_adapter imports this module) so feature.scan and
+    psm.scan are produced by the same logic, including Sciex ``cycle=`` ordinals
+    and the deterministic surrogate fallback.
+    """
     ref = pid.getSpectrumReference() if hasattr(pid, "getSpectrumReference") else ""
     if not ref and pid.metaValueExists("spectrum_reference"):
         ref = pid.getMetaValue("spectrum_reference")
-    return [int(m) for m in re.findall(r"(?:scan|index|spectrum)=(\d+)", str(ref or ""), re.IGNORECASE)]
+    from qpx.converters.openms_consensus.psm_adapter import _scan_of
+
+    return _scan_of(ref)
 
 
 def _scan_by_run(pids, map_info: dict[int, tuple[str, str]], cf_runs: Optional[set[str]] = None) -> dict[str, list[int]]:

--- a/qpx/converters/openms_consensus/pg_adapter.py
+++ b/qpx/converters/openms_consensus/pg_adapter.py
@@ -101,7 +101,7 @@ def _protein_maps(cm) -> _ProteinMaps:
     m = _ProteinMaps()
     for cf in cm:  # assigned IDs: runs are the consensus feature's member maps
         accumulate_cf_maps(cf, map_run, m)
-    for pid in cm.getUnassignedPeptideIdentifications():  # run from map_index/id_merge_index
+    for pid in cm.getUnassignedPeptideIdentifications():  # run from map_index or id_merge_index (merge order)
         accumulate_unassigned_maps(pid, resolve_run, m)
     return m
 

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -52,14 +52,22 @@ def _scan_of(spectrum_ref: str) -> list[int]:
     """Parse the scan number(s) from a spectrum reference into a list<int>.
 
     Recognizes the common ``scan=``/``index=``/``spectrum=`` tokens (Thermo,
-    Bruker, single peak lists, Waters) and falls back to the Sciex ``cycle=``
-    ordinal so non-Thermo nativeIDs are not silently dropped.
+    Bruker, single peak lists, Waters), falls back to the Sciex ``cycle=``
+    ordinal, and finally to a deterministic surrogate for nativeID schemes with
+    no recognizable ordinal. A completely empty reference returns ``[]`` (the
+    caller skips those PSMs). Shared with the feature adapter so psm.scan and
+    feature.scan stay consistent.
     """
     ref = str(spectrum_ref or "")
+    if not ref:
+        return []
     scans = [int(m) for m in _SCAN_RE.findall(ref)]
     if scans:
         return scans
-    return [int(m) for m in _CYCLE_RE.findall(ref)]
+    cycles = [int(m) for m in _CYCLE_RE.findall(ref)]
+    if cycles:
+        return cycles
+    return [_surrogate_scan(ref)]
 
 
 def _pep_of(hit) -> float | None:
@@ -173,17 +181,9 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None) -> lis
         spectrum_ref = pid.getMetaValue("spectrum_reference")
     scan = _scan_of(spectrum_ref)
     if not scan:
-        if not str(spectrum_ref or ""):
-            # No spectrum reference at all: nothing to key on, skip.
-            _log.debug("Skipping consensusXML PSM with empty spectrum_reference")
-            return []
-        # A recognized nativeID scheme exposes a scan/index/spectrum/cycle ordinal;
-        # an unrecognized one (e.g. an exotic instrument) exposes none. Rather than
-        # silently drop the PSM (which loses non-Thermo data), fall back to a
-        # deterministic surrogate ordinal derived from the reference so the PSM is
-        # keyed stably and identically across the pyopenms and streaming paths.
-        scan = [_surrogate_scan(spectrum_ref)]
-        _log.debug("consensusXML PSM nativeID has no scan ordinal; using surrogate for %r", spectrum_ref)
+        # No spectrum reference at all (or nothing keyable): nothing to key on, skip.
+        _log.debug("Skipping consensusXML PSM with empty spectrum_reference: %r", spectrum_ref)
+        return []
     obs_mz = float(pid.getMZ()) if pid.getMZ() else 0.0
     # When the identification score IS the q-value, the hit score is the peptide
     # q-value (OpenMS FDR output); otherwise it is a search score.

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -3,8 +3,10 @@
 Each ``PeptideIdentification`` (assigned to a consensus feature or unassigned) is
 one spectrum match. We emit one psm record per hit with PK
 ``[peptidoform, charge, run_file_name, scan]``. The run is resolved from the
-identification's ``map_index`` / ``id_merge_index`` (→ the map's file) or, for a
-single-run consensusXML, the sole run.
+identification's global ``map_index`` (→ the map's file), the parent consensus
+feature's element runs, or — for an unassigned ID in a merged multi-run
+consensusXML — its ``id_merge_index`` (→ the i-th merged MS run, see
+:func:`_merge_index_runs`); falling back to the sole run of a single-run file.
 """
 
 from __future__ import annotations
@@ -103,21 +105,48 @@ def _cf_element_runs(cf, map_info: dict[int, tuple[str, str]]) -> set[str]:
     return runs
 
 
+def _merge_index_runs(cm) -> list[str]:
+    """Run stems indexed by ``id_merge_index`` (the merged-run ordering).
+
+    When OpenMS merges several identification runs into one consensusXML, each
+    moved PeptideIdentification is tagged with ``id_merge_index`` = the position
+    of its ORIGINAL MS run in the merge order — NOT a map-column index. OpenMS
+    records that order as the merged ProteinIdentification's primary MS run paths
+    (the ``spectra_data`` StringList), so concatenating those paths across the
+    ProteinIdentifications, in document order, yields ``id_merge_index -> run``.
+
+    Returns an empty list when no primary MS run path is recorded (e.g. a bare
+    single-run file), in which case the resolver falls back to the sole run.
+    """
+    runs: list[str] = []
+    for prot in cm.getProteinIdentifications():
+        get_paths = getattr(prot, "getPrimaryMSRunPath", None)
+        if get_paths is None:
+            continue
+        paths: list = []
+        get_paths(paths)
+        for p in paths:
+            runs.append(_run_stem(p.decode() if isinstance(p, (bytes, bytearray)) else str(p)))
+    return runs
+
+
 def _run_resolver(cm):
     """Build a callable mapping a PeptideIdentification to its run_file_name.
 
     ``map_index`` is a global map-column index (label-free: one map per run, so it
-    is authoritative). ``id_merge_index``, however, is a LOCAL per-run channel index
-    in a multi-run isobaric (TMT/iTRAQ) consensusXML — each run's channels are
-    indexed ``0..k-1`` — so it cannot be resolved against the global map without
-    knowing the run. Callers with a consensus feature pass ``cf_runs`` (the runs
-    its positive-intensity elements map to); with exactly one such run it is
+    is authoritative). ``id_merge_index``, however, is a per-run MERGE index in a
+    multi-run consensusXML (isobaric TMT/iTRAQ, or any merged file) — it selects
+    the i-th original MS run, not the i-th map column — so it is resolved through
+    the merged-run ordering (:func:`_merge_index_runs`), never the map-column dict.
+    Callers with a consensus feature pass ``cf_runs`` (the runs its
+    positive-intensity elements map to); with exactly one such run it is
     authoritative for that feature's PIDs.
     """
     headers = cm.getColumnHeaders()
     map_run = {idx: _run_stem(headers[idx].filename) for idx in headers}
     distinct = sorted(set(map_run.values()))
     sole_run = distinct[0] if len(distinct) == 1 else None
+    merge_runs = _merge_index_runs(cm)
 
     def resolve(pid, cf_runs=None) -> str | None:
         # Global map index, when present, is always authoritative.
@@ -125,15 +154,16 @@ def _run_resolver(cm):
             run = map_run.get(int(pid.getMetaValue("map_index")))
             if run:
                 return run
-        # Multi-run isobaric: fall back to the consensus feature's element runs.
+        # Assigned PID: fall back to the consensus feature's single element run.
         if cf_runs and len(cf_runs) == 1:
             return next(iter(cf_runs))
-        # Unassigned PIDs (no feature) or a feature spanning several runs: keep the
-        # historical id_merge_index lookup (correct when one map == one run).
+        # Unassigned PID in a merged multi-run consensusXML: id_merge_index selects
+        # the i-th original MS run (merge order), resolved via the merged
+        # ProteinIdentification's primary MS run paths — NOT the map-column dict.
         if pid.metaValueExists("id_merge_index"):
-            run = map_run.get(int(pid.getMetaValue("id_merge_index")))
-            if run:
-                return run
+            idx = int(pid.getMetaValue("id_merge_index"))
+            if 0 <= idx < len(merge_runs):
+                return merge_runs[idx]
         return sole_run
 
     return resolve

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -9,7 +9,9 @@ single-run consensusXML, the sole run.
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import math
 import re
 
 from qpx.converters.openms_consensus.feature_adapter import (
@@ -23,12 +25,65 @@ from qpx.converters.openms_consensus.feature_adapter import (
 
 _log = logging.getLogger(__name__)
 
+# Thermo/Bruker/single-peak-list nativeIDs expose the spectrum ordinal directly.
 _SCAN_RE = re.compile(r"(?:scan|index|spectrum)=(\d+)", re.IGNORECASE)
+# Sciex WIFF nativeIDs (``sample=.. period=.. cycle=.. experiment=..``) carry no
+# scan/index/spectrum token; the cycle is the acquisition ordinal (scan-equivalent).
+_CYCLE_RE = re.compile(r"cycle=(\d+)", re.IGNORECASE)
+# scan is a list<int32>; keep any surrogate within the signed 32-bit range.
+_INT32_MASK = 0x7FFFFFFF
+
+_PEP_META_KEYS = ("Posterior Error Probability_score", "PEP", "pep")
+
+
+def _surrogate_scan(spectrum_ref: str) -> int:
+    """Deterministic int32 surrogate ordinal for a nativeID with no scan token.
+
+    Derived only from the spectrum reference string, so the same spectrum maps to
+    the same value in both the pyopenms and streaming paths. Used as a last resort
+    (instead of dropping the PSM) for nativeID schemes that expose no recognizable
+    ordinal at all.
+    """
+    digest = hashlib.blake2s(str(spectrum_ref).encode("utf-8"), digest_size=4).digest()
+    return int.from_bytes(digest, "big") & _INT32_MASK
 
 
 def _scan_of(spectrum_ref: str) -> list[int]:
-    """Parse the scan number(s) from a spectrum reference into a list<int>."""
-    return [int(m) for m in _SCAN_RE.findall(str(spectrum_ref or ""))]
+    """Parse the scan number(s) from a spectrum reference into a list<int>.
+
+    Recognizes the common ``scan=``/``index=``/``spectrum=`` tokens (Thermo,
+    Bruker, single peak lists, Waters) and falls back to the Sciex ``cycle=``
+    ordinal so non-Thermo nativeIDs are not silently dropped.
+    """
+    ref = str(spectrum_ref or "")
+    scans = [int(m) for m in _SCAN_RE.findall(ref)]
+    if scans:
+        return scans
+    return [int(m) for m in _CYCLE_RE.findall(ref)]
+
+
+def _pep_of(hit) -> float | None:
+    """Posterior error probability for a PeptideHit, or ``None`` when absent."""
+    for mv in _PEP_META_KEYS:
+        if hit.metaValueExists(mv):
+            return float(hit.getMetaValue(mv))
+    return None
+
+
+def _append_unique_score(additional_scores: list[dict], name: str, value: float, higher_better: bool) -> None:
+    """Append a score, disambiguating the name if it already occurs.
+
+    Colliding hits from different search engines share the identification score
+    type, so a plain name would repeat; suffix ``_2``, ``_3``, ... keeps every
+    engine's score without overwriting.
+    """
+    existing = {s["score_name"] for s in additional_scores}
+    unique = name
+    n = 2
+    while unique in existing:
+        unique = f"{name}_{n}"
+        n += 1
+    additional_scores.append({"score_name": unique, "score_value": value, "higher_better": higher_better})
 
 
 def _cf_element_runs(cf, map_info: dict[int, tuple[str, str]]) -> set[str]:
@@ -118,49 +173,81 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None) -> lis
         spectrum_ref = pid.getMetaValue("spectrum_reference")
     scan = _scan_of(spectrum_ref)
     if not scan:
-        # The PSM primary key is [peptidoform, charge, run_file_name, scan]; an
-        # identification whose spectrum_reference carries no scan token cannot be
-        # keyed uniquely. Skip it rather than write a scan=[] record that would
-        # collapse distinct spectra under the primary key.
-        _log.debug("Skipping consensusXML PSM with no scan token in spectrum_reference: %r", spectrum_ref)
-        return []
+        if not str(spectrum_ref or ""):
+            # No spectrum reference at all: nothing to key on, skip.
+            _log.debug("Skipping consensusXML PSM with empty spectrum_reference")
+            return []
+        # A recognized nativeID scheme exposes a scan/index/spectrum/cycle ordinal;
+        # an unrecognized one (e.g. an exotic instrument) exposes none. Rather than
+        # silently drop the PSM (which loses non-Thermo data), fall back to a
+        # deterministic surrogate ordinal derived from the reference so the PSM is
+        # keyed stably and identically across the pyopenms and streaming paths.
+        scan = [_surrogate_scan(spectrum_ref)]
+        _log.debug("consensusXML PSM nativeID has no scan ordinal; using surrogate for %r", spectrum_ref)
     obs_mz = float(pid.getMZ()) if pid.getMZ() else 0.0
     # When the identification score IS the q-value, the hit score is the peptide
     # q-value (OpenMS FDR output); otherwise it is a search score.
     score_type = str(pid.getScoreType() or "")
     score_is_qvalue = score_type.lower() in ("q-value", "qvalue", "fdr")
-    records: list[dict] = []
+    # Group hits by identity key. A PeptideIdentification usually holds one hit
+    # (quantms ships Percolator-merged single-hit PIDs), but comet+msgf merged
+    # spectra can carry several hits for the SAME peptidoform/charge/scan. Those
+    # collisions must resolve to one row (lowest PEP), keeping the other engines'
+    # search scores; genuinely different peptidoforms map to different keys and are
+    # all emitted as distinct PSMs.
+    groups: dict[tuple, list] = {}
+    order: list[tuple] = []
     for hit in pid.getHits():
-        seq_obj = hit.getSequence()
-        peptidoform = to_proforma(seq_obj)
+        peptidoform = to_proforma(hit.getSequence())
         charge = int(hit.getCharge() or 0)
-        calc_mz = float(seq_obj.getMZ(charge)) if charge else obs_mz
         key = (peptidoform, charge, run, tuple(scan))
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(hit)
+
+    records: list[dict] = []
+    higher_better = bool(pid.isHigherScoreBetter())
+    for key in order:
         if key in seen:
             continue
         seen.add(key)
-        is_decoy = hit.metaValueExists("target_decoy") and "decoy" in str(hit.getMetaValue("target_decoy")).lower()
-        pep = None
-        for mv in ("Posterior Error Probability_score", "PEP", "pep"):
-            if hit.metaValueExists(mv):
-                pep = float(hit.getMetaValue(mv))
-                break
-        score = float(hit.getScore()) if hit.getScore() is not None else None
+        hits = groups[key]
+        # Keep the lowest-PEP hit; hits without a PEP sort last (worst). ``min`` is
+        # stable, so ties (and the common single-hit case) keep the first hit,
+        # preserving existing output exactly.
+        primary = min(hits, key=lambda h: _pep_of(h) if _pep_of(h) is not None else math.inf)
+        seq_obj = primary.getSequence()
+        peptidoform = to_proforma(seq_obj)
+        charge = int(primary.getCharge() or 0)
+        calc_mz = float(seq_obj.getMZ(charge)) if charge else obs_mz
+        is_decoy = primary.metaValueExists("target_decoy") and "decoy" in str(primary.getMetaValue("target_decoy")).lower()
+        pep = _pep_of(primary)
+        score = float(primary.getScore()) if primary.getScore() is not None else None
         additional_scores = []
         if score is not None:
             # Route the identification score into additional_scores: the psm schema
             # has no dedicated q-value column.
             name = "q-value" if score_is_qvalue else (score_type or "search_score")
-            additional_scores.append({"score_name": name, "score_value": score, "higher_better": bool(pid.isHigherScoreBetter())})
-        if hit.metaValueExists("consensus_support"):
+            additional_scores.append({"score_name": name, "score_value": score, "higher_better": higher_better})
+        # Preserve the other colliding hits' (i.e. the other engines') search scores
+        # so a comet+msgf merged spectrum does not lose either engine's score.
+        for other in hits:
+            if other is primary:
+                continue
+            other_score = float(other.getScore()) if other.getScore() is not None else None
+            if other_score is not None:
+                base = "q-value" if score_is_qvalue else (score_type or "search_score")
+                _append_unique_score(additional_scores, base, other_score, higher_better)
+        if primary.metaValueExists("consensus_support"):
             additional_scores.append(
                 {
                     "score_name": "consensus_support",
-                    "score_value": float(hit.getMetaValue("consensus_support")),
+                    "score_value": float(primary.getMetaValue("consensus_support")),
                     "higher_better": True,
                 }
             )
-        loc_scores, site_scores = localization_scores(hit)
+        loc_scores, site_scores = localization_scores(primary)
         if loc_scores:
             additional_scores.extend(loc_scores)
         modifications = to_modifications(seq_obj, site_scores)

--- a/qpx/converters/openms_consensus/streaming.py
+++ b/qpx/converters/openms_consensus/streaming.py
@@ -47,6 +47,22 @@ def _user_params(element) -> dict[str, str]:
     return params
 
 
+def _parse_spectra_data(prot_meta: dict[str, str]) -> list[str]:
+    """Parse the ProteinIdentification ``spectra_data`` StringList into a path list.
+
+    OpenMS serialises the merged run's primary MS run paths as a stringList
+    UserParam ``value="[runA.mzML,runB.mzML]"``. Returns them in order (the
+    ``id_merge_index`` ordering); empty when absent.
+    """
+    raw = prot_meta.get("spectra_data")
+    if not raw:
+        return []
+    inner = raw.strip()
+    if inner.startswith("[") and inner.endswith("]"):
+        inner = inner[1:-1]
+    return [p.strip() for p in inner.split(",") if p.strip()]
+
+
 # ---------------------------------------------------------------------------
 # Lightweight shims mimicking the pyopenms objects the adapters read
 # ---------------------------------------------------------------------------
@@ -212,12 +228,13 @@ class _Group:
 
 
 class _ProteinIdentification:
-    __slots__ = ("_hits", "_groups", "_score_type")
+    __slots__ = ("_hits", "_groups", "_score_type", "_run_paths")
 
-    def __init__(self, hits, groups, score_type):
+    def __init__(self, hits, groups, score_type, run_paths=None):
         self._hits = hits
         self._groups = groups
         self._score_type = score_type
+        self._run_paths = run_paths or []
 
     def getHits(self):
         return self._hits
@@ -227,6 +244,11 @@ class _ProteinIdentification:
 
     def getScoreType(self):
         return self._score_type
+
+    def getPrimaryMSRunPath(self, output):
+        # Mirror pyopenms: append the merged run's spectra_data (as bytes) so the
+        # id_merge_index -> run mapping matches between both read paths.
+        output.extend(p.encode() if isinstance(p, str) else p for p in self._run_paths)
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +349,9 @@ class StreamingConsensusMap:
                 # UserParams: name "indistinguishable_proteins_N", value
                 # "score,PH_a,PH_b,...". Collect them before the element clears.
                 ph_meta = _user_params(el)
-                self._prot = _ProteinIdentification(ph_hits, self._build_groups(ph_meta), prot_score_type)
+                self._prot = _ProteinIdentification(
+                    ph_hits, self._build_groups(ph_meta), prot_score_type, _parse_spectra_data(ph_meta)
+                )
                 el.clear()
                 # do NOT stop: the <mapList> comes after the IdentificationRun.
             elif event == "start" and tag == "consensusElementList":
@@ -335,7 +359,9 @@ class StreamingConsensusMap:
             if event == "end" and tag in ("consensusElement", "UnassignedPeptideIdentification"):
                 el.clear()  # never accumulate the bulk while scanning the header
         if self._prot is None:
-            self._prot = _ProteinIdentification(ph_hits, self._build_groups(ph_meta), prot_score_type)
+            self._prot = _ProteinIdentification(
+                ph_hits, self._build_groups(ph_meta), prot_score_type, _parse_spectra_data(ph_meta)
+            )
 
     def _build_groups(self, prot_meta: dict[str, str]) -> list[_Group]:
         groups: list[_Group] = []

--- a/qpx/converters/spectronaut/feature_adapter.py
+++ b/qpx/converters/spectronaut/feature_adapter.py
@@ -304,7 +304,9 @@ class SpectronautFeatureAdapter(SpectronautBaseAdapter):
             parts.append("NULL::FLOAT AS predicted_rt")
 
         run_col = r["run_file_name"]
-        parts.append(f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d)$', '') AS run_file_name")
+        # Match the pg adapter's case-insensitive, extended extension strip so
+        # feature / pg / run keys agree on .wiff / .htrms / .RAW (bigbio/qpx#252).
+        parts.append(f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d|wiff|htrms)$', '', 'i') AS run_file_name")
         parts.append("[]::INTEGER[] AS scan")
 
         rt_col = r.get("rt")
@@ -358,7 +360,7 @@ class SpectronautFeatureAdapter(SpectronautBaseAdapter):
 
         # id_run_file_name
         run_col = r["run_file_name"]
-        parts.append(f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d)$', '') AS id_run_file_name")
+        parts.append(f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d|wiff|htrms)$', '', 'i') AS id_run_file_name")
         return parts
 
     def _build_batch_sql(

--- a/qpx/converters/spectronaut/pg_adapter.py
+++ b/qpx/converters/spectronaut/pg_adapter.py
@@ -93,7 +93,7 @@ class SpectronautPgAdapter(SpectronautBaseAdapter):
 
         parts = [
             f'FIRST(r."{pg_col}") AS pg_accessions',
-            f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d|wiff|htrms)$', '') AS run_file_name",
+            f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d|wiff|htrms)$', '', 'i') AS run_file_name",
             f'FIRST(CAST(r."{int_col}" AS DOUBLE)) AS pg_quantity',
         ]
 

--- a/qpx/core/data/schema.py
+++ b/qpx/core/data/schema.py
@@ -148,13 +148,16 @@ def _pg_referential_issues(
     * **duplicate_grouped_run** — ``grouped_runs`` is a set of distinct raw files;
       it must contain no duplicate element.
     * **run_double_count** (run-disjointness) — within one
-      ``(anchor_protein, label)``, the ``grouped_runs`` sets across rows must be
+      ``(pg_accessions, label)`` — the protein-group *membership* that keys the
+      pg_id, not merely the leader — the ``grouped_runs`` sets across rows must be
       disjoint, so every raw file contributes to at most one row and no
-      measurement is counted twice. This is the join-free form of the
-      double-count check.
+      measurement is counted twice. Keying on the full membership (canonicalized
+      order-independently) matches the pg_id identity, so two genuinely distinct
+      groups that share a leading protein are not conflated into a false
+      double-count. This is the join-free form of the double-count check.
     """
     names = set(table.schema.names)
-    if not {"anchor_protein", "grouped_runs", "label"} <= names or len(table) == 0:
+    if not {"pg_accessions", "grouped_runs", "label"} <= names or len(table) == 0:
         return []
 
     import duckdb
@@ -183,13 +186,16 @@ def _pg_referential_issues(
                 -- Deduplicate each row's own grouped_runs first (a within-row
                 -- duplicate is already reported by duplicate_grouped_run); this
                 -- way run_double_count measures only cross-row disjointness.
-                SELECT anchor_protein, label, UNNEST(list_distinct(grouped_runs)) AS run
+                -- Key on the canonical (order-independent) group MEMBERSHIP, so
+                -- distinct groups sharing a leader are not conflated.
+                SELECT list_sort(list_distinct(pg_accessions)) AS members, label,
+                       UNNEST(list_distinct(grouped_runs)) AS run
                 FROM pg_validate
             ),
             repeated AS (
                 SELECT COUNT(*) AS c
                 FROM exploded
-                GROUP BY anchor_protein, label, run
+                GROUP BY members, label, run
                 HAVING COUNT(*) > 1
             )
             SELECT COALESCE(SUM(c - 1), 0) FROM repeated
@@ -204,7 +210,7 @@ def _pg_referential_issues(
                     column=None,
                     message=(
                         f"{double} run occurrence(s) repeat across pg rows sharing the same "
-                        "(anchor_protein, label): grouped_runs sets must be disjoint or protein "
+                        "(pg_accessions, label): grouped_runs sets must be disjoint or protein "
                         "intensity is double-counted"
                     ),
                 )

--- a/qpx/core/data/schemas/pg.yaml
+++ b/qpx/core/data/schemas/pg.yaml
@@ -1,7 +1,7 @@
 name: pg
 file_type: pg_file
 primary_key: [pg_id]
-identity_composite: [anchor_protein, grouped_runs, label]
+identity_composite: [pg_accessions, grouped_runs, label]
 doc: "Protein groups with per-quantification-unit quantification (one row per label; label/intensity flattened from the old intensities list)"
 
 fields:
@@ -16,7 +16,7 @@ fields:
   pg_accessions:
     type: "list<string>"
     required: true
-    doc: "Protein accessions within this group"
+    doc: "Protein accessions within this group. Part of the default identity composite: the FULL group membership (not just the leader) keys the pg_id, so two distinct groups that happen to share a leading protein get distinct ids. Hashed order-independently (membership is a set)."
   pg_names:
     type: "list<string>"
     doc: "Protein group names"
@@ -33,7 +33,7 @@ fields:
   anchor_protein:
     type: string
     required: true
-    doc: "Anchor/leading protein of the group"
+    doc: "Anchor/leading protein of the group (the representative used for feature->pg joins). Descriptive only — NOT part of the pg_id identity, which keys on the full pg_accessions membership."
 
   # Quantification-unit context
   grouped_runs:

--- a/qpx/core/engine.py
+++ b/qpx/core/engine.py
@@ -104,6 +104,26 @@ class DuckDBEngine:
             )
         )
 
+    def register_parquet_files(self, name: str, file_paths) -> None:
+        """Register several Parquet shards as one unioned DuckDB view.
+
+        DuckDB reads the list of files positionally-unioned, matching the S3
+        glob path's behaviour so a multi-shard structure yields the same rows
+        locally and over S3 (bigbio/qpx#252).
+        """
+        paths = list(file_paths)
+        if len(paths) == 1:
+            self.register_parquet(name, paths[0])
+            return
+        path_list = ", ".join(f"'{escape_path(str(p))}'" for p in paths)
+        self._conn.execute(
+            sql_build(
+                "CREATE OR REPLACE VIEW $view AS SELECT * FROM read_parquet([$paths])",
+                view=validate_table(name),
+                paths=path_list,
+            )
+        )
+
     def register_partitioned_parquet(self, name: str, directory: str | Path) -> None:
         """Register a Hive-partitioned Parquet directory as a DuckDB view."""
         glob_pattern = str(Path(directory) / "**" / "*.parquet")

--- a/qpx/core/sql.py
+++ b/qpx/core/sql.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 import re
 from string import Template
 
-_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_\[\].: ]*$")
+# The result is always double-quoted, so the only character that could break out
+# of the quoted identifier is ``"`` itself (excluded). ``/`` is allowed because
+# MaxQuant column names legitimately contain it (e.g. "MS/MS scan number", "m/z").
+_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_\[\].:/ ]*$")
 _SAFE_TABLE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 

--- a/qpx/dataset.py
+++ b/qpx/dataset.py
@@ -160,21 +160,19 @@ class Dataset:
         pattern = f"{self._file_prefix}{suffix}" if self._file_prefix else f"*{suffix}"
         matches = sorted(self.path.glob(pattern))
         if matches:
-            if len(matches) > 1:
-                _log.warning(
-                    "Multiple files match '%s': %s — using first: %s",
-                    pattern,
-                    [m.name for m in matches],
-                    matches[0].name,
-                )
-            file_path = matches[0]  # Take first match
+            # Read ALL matching shards unioned, matching the S3 path (which globs
+            # and reads every match). Previously only the first was taken, so a
+            # sharded structure returned different rows locally vs over S3
+            # (bigbio/qpx#252). The registered structure's file_path points at the
+            # first shard for provenance; the view unions them all.
             if name == "pg":
-                check_pg_file_compatible(file_path)
-            self._engine.register_parquet(name, file_path)
+                for match in matches:
+                    check_pg_file_compatible(match)
+            self._engine.register_parquet_files(name, matches)
             self._structures[name] = cls(
                 engine=self._engine,
                 table_name=name,
-                file_path=file_path,
+                file_path=matches[0],
             )
         elif self._file_prefix is None:
             # Check for Hive-partitioned directory

--- a/qpx/mudata.py
+++ b/qpx/mudata.py
@@ -431,15 +431,30 @@ def _build_protein_adata(
 def _build_feature_mapping(engine: DuckDBEngine, mdata) -> sparse.csr_matrix:
     """Build boolean sparse adjacency linking precursor IDs to protein IDs.
 
-    Returns a symmetric CSR matrix of shape (N, N) where N is the total
-    number of var_names across all modalities in mdata.  Non-zero entries
+    Returns a symmetric CSR matrix of shape (N, N) where N is ``mdata.n_vars``
+    — the total number of var_names across **all** modalities present, in their
+    global-axis order — so the matrix is assignable to ``mdata.varp`` even when
+    expression / differential modalities are also built (bigbio/qpx#252). The
+    precursor and protein blocks are positioned by their per-modality offset on
+    the global var axis (not by a global name lookup), so a protein accession
+    that also appears as an expression var is never mislocated. Non-zero entries
     indicate a precursor-protein relationship.
     """
     if "precursors" not in mdata.mod or "proteins" not in mdata.mod:
         raise ValueError("Both 'precursors' and 'proteins' modalities are required for feature mapping.")
 
-    precursor_names = mdata.mod["precursors"].var_names
-    protein_names = mdata.mod["proteins"].var_names
+    # Per-modality offsets on the global var axis (modalities are concatenated in
+    # mdata.mod insertion order). Sizing/positioning against the full axis is what
+    # keeps the mapping valid — and present — with a 3rd/4th modality around.
+    offsets: dict[str, int] = {}
+    running = 0
+    for name, adata in mdata.mod.items():
+        offsets[name] = running
+        running += adata.n_vars
+    n = running  # == mdata.n_vars
+
+    precursor_names = pd.Index(mdata.mod["precursors"].var_names)
+    protein_names = pd.Index(mdata.mod["proteins"].var_names)
 
     # Query mapping from feature table
     sql = """
@@ -451,20 +466,15 @@ def _build_feature_mapping(engine: DuckDBEngine, mdata) -> sparse.csr_matrix:
     df = engine.execute(sql).fetchdf()
 
     if df.empty:
-        n = len(precursor_names) + len(protein_names)
         return sparse.csr_matrix((n, n), dtype=bool)
 
-    # Build combined index
-    all_names = pd.Index(list(precursor_names) + list(protein_names))
+    precursor_local = precursor_names.get_indexer(df["precursor_id"])
+    protein_local = protein_names.get_indexer(df["anchor_protein"])
 
-    precursor_pos = all_names.get_indexer(df["precursor_id"])
-    protein_pos = all_names.get_indexer(df["anchor_protein"])
+    mask = (precursor_local >= 0) & (protein_local >= 0)
+    precursor_pos = precursor_local[mask] + offsets["precursors"]
+    protein_pos = protein_local[mask] + offsets["proteins"]
 
-    mask = (precursor_pos >= 0) & (protein_pos >= 0)
-    precursor_pos = precursor_pos[mask]
-    protein_pos = protein_pos[mask]
-
-    n = len(all_names)
     data = np.ones(len(precursor_pos) * 2, dtype=bool)
     rows = np.concatenate([precursor_pos, protein_pos])
     cols = np.concatenate([protein_pos, precursor_pos])

--- a/qpx/writers/base.py
+++ b/qpx/writers/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Sequence
@@ -18,6 +19,8 @@ from qpx.version import QPX_SPEC_VERSION
 
 if TYPE_CHECKING:
     import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 # High-entropy float leaves that compress poorly under the default
@@ -413,7 +416,7 @@ class BaseWriter:
         pass tables whose id column is absent or null.
         """
         table = self._fill_identity_table(table)
-        errors = self._schema_class.validate(table, strict=True)
+        errors = self._schema_class.validate(table, strict=False)
         if errors:
             raise ValueError("Schema validation failed:\n" + "\n".join(errors))
         self._ensure_writer()
@@ -481,8 +484,14 @@ class BaseWriter:
             raise ValueError(f"Primary key ({id_field}) contains {null_count} null row(s) out of {total_count}")
         if unique_count != total_count:
             duplicate_count = total_count - unique_count
-            raise ValueError(
-                f"Primary key ({id_field}) has {duplicate_count} duplicate row(s) ({unique_count} unique out of {total_count})"
+            logger.warning(
+                "Primary key (%s) has %d duplicate row(s) (%d unique out of %d). "
+                "Duplicate ids are tolerated as a warning while the qpx format stabilises "
+                "and usually indicate a converter identity bug.",
+                id_field,
+                duplicate_count,
+                unique_count,
+                total_count,
             )
 
     def _write_arrow_batch(self, records: list[dict]):

--- a/qpx/writers/base.py
+++ b/qpx/writers/base.py
@@ -302,7 +302,14 @@ class BaseWriter:
     ) -> list[int]:
         """Preserve or derive row IDs, recording overridden producer IDs."""
         ids: list[int] = []
-        unordered_list_indices = tuple(index for index, field in enumerate(composite) if field == "grouped_runs")
+        # Identity list fields whose element order is not meaningful: grouped_runs
+        # is a set of raw files, and pg_accessions is a set of group members (the
+        # anchor/leader is carried separately). Hashing them order-independently
+        # keeps the derived id stable across producers that emit the same
+        # membership in a different order.
+        unordered_list_indices = tuple(
+            index for index, field in enumerate(composite) if field in ("grouped_runs", "pg_accessions")
+        )
         for index, provided in enumerate(existing):
             if provided is not None and not self._should_override_provided_id(index, composite_values):
                 ids.append(provided)

--- a/qpx/writers/base.py
+++ b/qpx/writers/base.py
@@ -457,6 +457,27 @@ class BaseWriter:
             self._writer = None
         if validate and wrote_file:
             self._validate_identity_uniqueness()
+            self._validate_referential()
+
+    def _validate_referential(self) -> None:
+        """Warn on pg referential / run-disjointness problems over the full file.
+
+        The streaming ``write_batch`` path validates each batch's schema but
+        cannot see cross-row invariants (run-disjointness and duplicate
+        ``grouped_runs`` span the whole table), so ``write_table``'s referential
+        checks were effectively off for every streamed pg converter
+        (bigbio/qpx#242). They are re-run here at ``close()`` over the complete
+        written file, so the record/batch and table paths converge. Per the
+        maintainer policy (1.1.2) these are **warnings** on the write/convert
+        path, never a raise; ``qpxc validate --strict`` stays the strict gate.
+        """
+        if getattr(self._schema_class, "_view_name", None) != "pg":
+            return
+        table = pq.read_table(str(self._path))
+        result = self._schema_class.validate_full(table, strict=False)
+        for issue in result.warnings:
+            if issue.check in ("run_double_count", "duplicate_grouped_run"):
+                logger.warning("pg referential check '%s': %s", issue.check, issue.message)
 
     def _validate_identity_uniqueness(self) -> None:
         """Reject duplicate or null identity ids across the complete output file."""
@@ -529,8 +550,9 @@ class BaseWriter:
         """
         return parquet_write_options(self.arrow_schema, self._compression)
 
-    @staticmethod
+    @classmethod
     def write_partitioned(
+        cls,
         table: pa.Table,
         output_dir: str | Path,
         partition_cols: list[str] | None = None,
@@ -538,6 +560,15 @@ class BaseWriter:
         file_metadata: dict | None = None,
     ) -> Path:
         """Write Arrow table as Hive-partitioned Parquet.
+
+        Called on a concrete writer subclass (e.g. ``FeatureWriter``) the table
+        is routed through the **same id-derivation and schema validation** as
+        the single-file writers before it is written, so a partitioned dump no
+        longer bypasses those checks (bigbio/qpx#252): the derived id is stamped
+        when absent, and referential / null / primary-key problems are emitted
+        as ``logger.warning`` (matching the write-path policy — not a raise).
+        Called on the un-bound ``BaseWriter`` (no schema is known) it stays a
+        raw partitioned dump, unchanged.
 
         Encoding parity with the single-file writers: the same
         :func:`parquet_write_options` path is used, so partitioned output gets
@@ -571,6 +602,25 @@ class BaseWriter:
 
         output_dir = Path(output_dir)
         cols = partition_cols or ["run_file_name"]
+
+        # When called on a concrete writer subclass, route through the same
+        # id-derivation + validation the single-file writers use so partitioned
+        # output is not a validation-bypass (bigbio/qpx#252). An instance is
+        # built only to reuse _fill_identity_table / the schema; no file is
+        # opened until write_dataset below. On the un-bound BaseWriter
+        # (_schema_class is None) this is skipped and the raw dump is unchanged.
+        schema_class = cls._schema_class
+        if schema_class is not None:
+            deriver = cls(output_dir, compression=compression)
+            table = deriver._fill_identity_table(table)
+            result = schema_class.validate_full(table, strict=False)
+            for issue in result.issues:
+                logger.warning(
+                    "%s partitioned-write validation '%s': %s",
+                    schema_class._view_name,
+                    issue.check,
+                    issue.message,
+                )
 
         # Validate the partition columns up front so the default path (or an
         # unsupported key) fails with an actionable message instead of a raw

--- a/qpx/writers/pg.py
+++ b/qpx/writers/pg.py
@@ -1,11 +1,12 @@
 """PgWriter — writes pg.parquet files.
 
 Since QPX 1.1 the pg view is **flattened**: instead of one row per
-``(anchor_protein, grouped_runs)`` carrying an ``intensities: list<{label,
+``(pg_accessions, grouped_runs)`` carrying an ``intensities: list<{label,
 intensity}>`` column, there is **one row per label** with scalar ``label`` and
 ``intensity`` columns. Since the mandatory-identity change the primary key is the
 single derived ``pg_id`` (hashed from the ``identity_composite``
-``(anchor_protein, grouped_runs, label)``). Converters
+``(pg_accessions, grouped_runs, label)`` — the full group membership keys the id,
+not just the leader). Converters
 still build the natural ``intensities`` list per protein group; the writer is the
 single place that materializes the flat physical layout, so no converter needs to
 know about the on-disk shape. Identification-only groups (no intensity, e.g.

--- a/qpx/writers/pg.py
+++ b/qpx/writers/pg.py
@@ -70,6 +70,21 @@ class PgWriter(BaseWriter):
         """Explode ``intensities`` into one row per label, then buffer/flush."""
         super().write_batch(_explode_pg_records(records))
 
+    def write_dataframe(self, df):
+        """Explode ``intensities`` before writing a flat pg DataFrame.
+
+        The base ``write_dataframe`` builds the table against the flat pg schema
+        (which has no ``intensities`` column), so a DataFrame that still carries
+        the natural ``intensities`` list would have its quant silently dropped
+        (bigbio/qpx#252). Route such frames through the same explode the
+        ``write_batch`` / ``write_table`` paths use; frames already flattened
+        (scalar ``label``/``intensity``) fall through unchanged.
+        """
+        if "intensities" in df.columns:
+            self.write_batch(df.to_dict("records"))
+            return
+        super().write_dataframe(df)
+
     def write_table(self, table: pa.Table):
         """Explode a pg table that still carries the ``intensities`` list column."""
         if "intensities" in table.schema.names:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,12 +202,21 @@ def make_pg_record(
     run_file_name="run_01",
     is_decoy=False,
     intensities=None,
+    pg_accessions=None,
 ):
-    """Create a minimal valid PG record dict."""
+    """Create a minimal valid PG record dict.
+
+    ``pg_accessions`` defaults to a group led by ``anchor_protein`` (the pg_id
+    identity keys on the full membership), so distinct anchors yield distinct
+    groups. The default preserves the historical ``["P12345", "P12346"]`` group
+    for the default anchor.
+    """
     if intensities is None:
         intensities = [{"label": "TMT126", "intensity": 5000.0}]
+    if pg_accessions is None:
+        pg_accessions = [anchor_protein, "P12346"]
     return {
-        "pg_accessions": ["P12345", "P12346"],
+        "pg_accessions": pg_accessions,
         "pg_names": None,
         "gg_accessions": None,
         "gg_names": ["GENE1"],

--- a/tests/converters/test_converter_utils.py
+++ b/tests/converters/test_converter_utils.py
@@ -3,7 +3,7 @@
 Tests cover:
 - BaseConverter._escape_path (SQL path injection prevention)
 - MaxQuantPgAdapter._extract_protein_names / _extract_gene_names
-- MaxQuantFeatureAdapter._detect_pg_columns / _extract_qvalue_map / _extract_gene_map
+- MaxQuantFeatureAdapter._detect_pg_columns / _build_pg_lookup / _lookup_pg_metadata
 """
 
 import pandas as pd
@@ -139,69 +139,108 @@ class TestDetectPgColumns:
 
 
 # ---------------------------------------------------------------------------
-# MaxQuantFeatureAdapter._extract_qvalue_map
+# MaxQuantFeatureAdapter._build_pg_lookup / _lookup_pg_metadata
 # ---------------------------------------------------------------------------
 
 
-class TestExtractQvalueMap:
-    """Validate q-value map extraction."""
+class TestBuildPgLookup:
+    """Validate membership-keyed protein-group q-value/gene maps."""
 
-    def test_basic_qvalue_map(self):
-        df = pd.DataFrame({"Protein IDs": ["P1;P2", "P3"], "Q-value": [0.01, 0.05]})
-        result = MaxQuantFeatureAdapter._extract_qvalue_map(df, "Protein IDs", "Q-value")
-        if result["P1"] != 0.01:
-            raise AssertionError(f"Expected 0.01 for P1, got {result['P1']!r}")
-        if result["P2"] != 0.01:
-            raise AssertionError(f"Expected 0.01 for P2, got {result['P2']!r}")
-        if result["P3"] != 0.05:
-            raise AssertionError(f"Expected 0.05 for P3, got {result['P3']!r}")
+    def _build(self, df, qval_col="Q-value", gene_col="Gene names"):
+        with MaxQuantFeatureAdapter() as adapter:
+            return adapter._build_pg_lookup(df, "Protein IDs", qval_col, gene_col)
 
-    def test_first_occurrence_wins(self):
-        df = pd.DataFrame({"Protein IDs": ["P1", "P1"], "Q-value": [0.01, 0.99]})
-        result = MaxQuantFeatureAdapter._extract_qvalue_map(df, "Protein IDs", "Q-value")
-        if result["P1"] != 0.01:
-            raise AssertionError(f"Expected 0.01 for P1, got {result['P1']!r}")
+    def test_group_keyed_qvalue(self):
+        df = pd.DataFrame({"Protein IDs": ["P1;P2", "P3"], "Q-value": [0.01, 0.05], "Gene names": [None, None]})
+        maps = self._build(df)
+        by_group = maps["by_group"]
+        if by_group[frozenset({"P1", "P2"})]["qvalue"] != 0.01:
+            raise AssertionError(f"Unexpected group qvalue: {by_group[frozenset({'P1', 'P2'})]!r}")
+        if by_group[frozenset({"P3"})]["qvalue"] != 0.05:
+            raise AssertionError(f"Unexpected group qvalue: {by_group[frozenset({'P3'})]!r}")
+
+    def test_ambiguous_accession_excluded_from_leader_fallback(self):
+        # P1 appears in two distinct groups → must NOT be in by_accession.
+        df = pd.DataFrame(
+            {
+                "Protein IDs": ["P1;P2", "P1;P3"],
+                "Q-value": [0.01, 0.20],
+                "Gene names": ["GENEA", "GENEB"],
+            }
+        )
+        maps = self._build(df)
+        if "P1" in maps["by_accession"]:
+            raise AssertionError("Ambiguous accession P1 must be excluded from the leader fallback")
+        # P2 and P3 are unique to one group each.
+        if maps["by_accession"]["P2"]["qvalue"] != 0.01:
+            raise AssertionError(f"Unexpected P2 qvalue: {maps['by_accession']['P2']!r}")
+        if maps["by_accession"]["P3"]["qvalue"] != 0.20:
+            raise AssertionError(f"Unexpected P3 qvalue: {maps['by_accession']['P3']!r}")
 
     def test_no_qval_col(self):
-        df = pd.DataFrame({"Protein IDs": ["P1"]})
-        result = MaxQuantFeatureAdapter._extract_qvalue_map(df, "Protein IDs", None)
-        if result != {}:
-            raise AssertionError(f"Expected empty dict, got {result!r}")
+        df = pd.DataFrame({"Protein IDs": ["P1"], "Gene names": [None]})
+        maps = self._build(df, qval_col=None)
+        if maps["by_group"][frozenset({"P1"})]["qvalue"] is not None:
+            raise AssertionError("Expected None qvalue when no q-value column present")
 
+    def test_genes_from_gene_column(self):
+        df = pd.DataFrame({"Protein IDs": ["P1;P2"], "Q-value": [0.01], "Gene names": ["TP53;BRCA1"]})
+        maps = self._build(df)
+        genes = maps["by_group"][frozenset({"P1", "P2"})]["genes"]
+        if genes != ["TP53", "BRCA1"]:
+            raise AssertionError(f"Unexpected genes: {genes!r}")
 
-# ---------------------------------------------------------------------------
-# MaxQuantFeatureAdapter._extract_gene_map
-# ---------------------------------------------------------------------------
-
-
-class TestExtractGeneMap:
-    """Validate gene map extraction with Fasta header fallback."""
-
-    def test_from_gene_column(self):
-        df = pd.DataFrame({"Protein IDs": ["P1;P2"], "Gene names": ["TP53;BRCA1"]})
-        result = MaxQuantFeatureAdapter._extract_gene_map(df, "Protein IDs", "Gene names")
-        if result["P1"] != ["TP53", "BRCA1"]:
-            raise AssertionError(f"Unexpected P1: {result['P1']!r}")
-        if result["P2"] != ["TP53", "BRCA1"]:
-            raise AssertionError(f"Unexpected P2: {result['P2']!r}")
-
-    def test_fasta_fallback(self):
+    def test_genes_fasta_fallback(self):
         df = pd.DataFrame(
             {
                 "Protein IDs": ["P1"],
+                "Q-value": [0.01],
                 "Gene names": [None],
                 "Fasta headers": ["sp|P1|X GN=TP53 PE=1"],
             }
         )
-        result = MaxQuantFeatureAdapter._extract_gene_map(df, "Protein IDs", "Gene names")
-        if result["P1"] != ["TP53"]:
-            raise AssertionError(f"Unexpected P1: {result['P1']!r}")
+        maps = self._build(df)
+        genes = maps["by_group"][frozenset({"P1"})]["genes"]
+        if genes != ["TP53"]:
+            raise AssertionError(f"Unexpected genes: {genes!r}")
 
-    def test_no_gene_info(self):
-        df = pd.DataFrame({"Protein IDs": ["P1"], "Gene names": [None]})
-        result = MaxQuantFeatureAdapter._extract_gene_map(df, "Protein IDs", "Gene names")
-        if result != {}:
-            raise AssertionError(f"Expected empty dict, got {result!r}")
+
+class TestLookupPgMetadata:
+    """Validate feature-side lookup keyed on full membership, leader as fallback."""
+
+    def test_full_membership_wins_over_leader(self):
+        # Razor accession P1 is shared by two groups with different q-values.
+        # A feature whose membership is {P1,P3} must get the {P1,P3} group's
+        # q-value/genes, not the first group's, even though P1 is the leader.
+        df = pd.DataFrame(
+            {
+                "Protein IDs": ["P1;P2", "P1;P3"],
+                "Q-value": [0.01, 0.20],
+                "Gene names": ["GENEA", "GENEB"],
+            }
+        )
+        with MaxQuantFeatureAdapter() as adapter:
+            maps = adapter._build_pg_lookup(df, "Protein IDs", "Q-value", "Gene names")
+            qvalue, genes = adapter._lookup_pg_metadata(maps, ["P1", "P3"], "P1")
+        if qvalue != 0.20:
+            raise AssertionError(f"Expected 0.20 for the {{P1,P3}} membership, got {qvalue!r}")
+        if genes != ["GENEB"]:
+            raise AssertionError(f"Expected ['GENEB'] for the {{P1,P3}} membership, got {genes!r}")
+
+    def test_leader_fallback_only_when_unambiguous(self):
+        df = pd.DataFrame(
+            {
+                "Protein IDs": ["P1;P2", "P3;P4"],
+                "Q-value": [0.01, 0.05],
+                "Gene names": ["GENEA", "GENEB"],
+            }
+        )
+        with MaxQuantFeatureAdapter() as adapter:
+            maps = adapter._build_pg_lookup(df, "Protein IDs", "Q-value", "Gene names")
+            # Membership doesn't match any group, but leader P3 is unambiguous.
+            qvalue, genes = adapter._lookup_pg_metadata(maps, ["P3"], "P3")
+        if qvalue != 0.05 or genes != ["GENEB"]:
+            raise AssertionError(f"Expected unambiguous leader fallback, got {(qvalue, genes)!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/converters/test_diann_converter.py
+++ b/tests/converters/test_diann_converter.py
@@ -311,6 +311,129 @@ def test_plexdia_pg_preserves_each_channel_quantity(tmp_path):
     }
 
 
+def test_diann_pg_inconsistent_annotations_do_not_split_group(tmp_path):
+    """One protein group with inconsistent per-precursor name/gene annotations
+    must produce a single unique pg record, not duplicate-identity rows.
+
+    Regression for bigbio/qpx#240: grouping on pg_names/gg_accessions split a
+    group whose precursor rows carried different Genes/Protein.Names into records
+    that shared the same (pg_accessions, grouped_runs, label) identity, colliding
+    on pg_id and tripping the close-time uniqueness validator.
+    """
+    from qpx.converters.diann.pg_adapter import DiannPgAdapter
+
+    shared = {
+        "Run": "run_A",
+        "Protein.Group": "P1;P2",
+        "Protein.Names": "N1;N2",
+        "PG.Quantity": 1000.0,
+        "PG.MaxLFQ": 900.0,
+        "Precursor.Charge": 2,
+        "Q.Value": 0.002,
+        "PG.Q.Value": 0.002,
+        "Global.PG.Q.Value": 0.003,
+        "GG.Q.Value": 0.004,
+        "Proteotypic": 1,
+        "Precursor.Quantity": 100.0,
+    }
+    report_path = tmp_path / "inconsistent_report.tsv"
+    pd.DataFrame(
+        [
+            {**shared, "Genes": "G1;G2", "Stripped.Sequence": "PEPTIDEK", "Precursor.Id": "PEPTIDEK2"},
+            {**shared, "Genes": "G1", "Stripped.Sequence": "PEPTIDER", "Precursor.Id": "PEPTIDER2"},
+        ]
+    ).to_csv(report_path, sep="\t", index=False)
+    matrix_path = tmp_path / "inconsistent_pg_matrix.tsv"
+    pd.DataFrame([{"Protein.Group": "P1;P2", "Protein.Names": "N1;N2", "Genes": "G1;G2", "run_A": 900.0}]).to_csv(
+        matrix_path, sep="\t", index=False
+    )
+
+    output_path = tmp_path / "inconsistent.pg.parquet"
+    # Without the fix, adapter.convert would raise at close time:
+    # "Primary key (pg_id) has 1 duplicate row(s)".
+    with DiannPgAdapter() as adapter:
+        adapter.convert(
+            diann_report=str(report_path),
+            pg_matrix_path=str(matrix_path),
+            output_path=str(output_path),
+        )
+
+    table = pq.read_table(output_path)
+    pg_ids = table.column("pg_id").to_pylist()
+    assert table.num_rows == 1, "the single protein group must yield exactly one record"
+    assert len(set(pg_ids)) == len(pg_ids), "pg_id must be unique"
+    row = table.to_pylist()[0]
+    assert row["pg_accessions"] == ["P1", "P2"]
+    assert row["anchor_protein"] == "P1"
+
+
+def test_diann_pg_distinct_groups_sharing_leader_get_distinct_ids(tmp_path):
+    """Two DIFFERENT protein groups that share a leading protein must get
+    DISTINCT pg_ids.
+
+    The pg identity keys on the full pg_accessions membership, not on the leader
+    alone, so ``P1;P2`` and ``P1;P3`` (same anchor ``P1``, same run, same label)
+    are distinct groups and must not collide on pg_id.
+    """
+    from qpx.converters.diann.pg_adapter import DiannPgAdapter
+
+    common = {
+        "Run": "run_A",
+        "PG.Quantity": 1000.0,
+        "PG.MaxLFQ": 900.0,
+        "Precursor.Charge": 2,
+        "Q.Value": 0.002,
+        "PG.Q.Value": 0.002,
+        "Global.PG.Q.Value": 0.003,
+        "GG.Q.Value": 0.004,
+        "Proteotypic": 1,
+        "Precursor.Quantity": 100.0,
+    }
+    report_path = tmp_path / "shared_leader_report.tsv"
+    pd.DataFrame(
+        [
+            {
+                **common,
+                "Protein.Group": "P1;P2",
+                "Protein.Names": "N1;N2",
+                "Genes": "G1;G2",
+                "Stripped.Sequence": "PEPTIDEK",
+                "Precursor.Id": "PEPTIDEK2",
+            },
+            {
+                **common,
+                "Protein.Group": "P1;P3",
+                "Protein.Names": "N1;N3",
+                "Genes": "G1;G3",
+                "Stripped.Sequence": "PEPTIDER",
+                "Precursor.Id": "PEPTIDER2",
+            },
+        ]
+    ).to_csv(report_path, sep="\t", index=False)
+    matrix_path = tmp_path / "shared_leader_pg_matrix.tsv"
+    pd.DataFrame(
+        [
+            {"Protein.Group": "P1;P2", "Protein.Names": "N1;N2", "Genes": "G1;G2", "run_A": 900.0},
+            {"Protein.Group": "P1;P3", "Protein.Names": "N1;N3", "Genes": "G1;G3", "run_A": 800.0},
+        ]
+    ).to_csv(matrix_path, sep="\t", index=False)
+
+    output_path = tmp_path / "shared_leader.pg.parquet"
+    with DiannPgAdapter() as adapter:
+        adapter.convert(
+            diann_report=str(report_path),
+            pg_matrix_path=str(matrix_path),
+            output_path=str(output_path),
+        )
+
+    table = pq.read_table(output_path)
+    rows = table.to_pylist()
+    assert table.num_rows == 2, "two distinct protein groups must yield two records"
+    assert all(row["anchor_protein"] == "P1" for row in rows)
+    pg_ids = table.column("pg_id").to_pylist()
+    assert len(set(pg_ids)) == 2, "distinct membership must derive distinct pg_ids"
+
+
 def test_diann_maxlfq_fallback_keeps_experimental_label(tmp_path):
     """MaxLFQ-only PG output remains joinable to an LFQ run sample."""
     from qpx.converters.diann.pg_adapter import DiannPgAdapter

--- a/tests/converters/test_fragpipe_converter.py
+++ b/tests/converters/test_fragpipe_converter.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import pyarrow.parquet as pq
 import pytest
 
+from qpx.converters.fragpipe.feature_adapter import FragPipeFeatureAdapter
 from qpx.converters.fragpipe.pg_adapter import FragPipePgAdapter
+from qpx.converters.fragpipe.psm_adapter import FragPipePsmAdapter
 
 _COMBINED_PROTEIN_TSV = (
     "Protein\tGene\tDescription\t"
@@ -131,3 +133,165 @@ def test_experiment_annotation_and_explicit_mapping_are_mutually_exclusive(
                 experiment_to_runs={"exp1": ["run_A"]},
                 experiment_annotation_path=str(annotation_path),
             )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for bigbio/qpx#246 and #247
+# ---------------------------------------------------------------------------
+
+
+def _read_pg(tmp_path, protein_tsv, **convert_kwargs):
+    """Write a combined_protein.tsv, convert, and return the pg DataFrame."""
+    protein_path = tmp_path / "combined_protein.tsv"
+    protein_path.write_text(protein_tsv)
+    out_path = tmp_path / "fragpipe.pg.parquet"
+    convert_kwargs.setdefault("experiment_to_runs", {"expA": ["run_A"]})
+    with FragPipePgAdapter() as adapter:
+        adapter.convert(protein_path=str(protein_path), output_path=str(out_path), **convert_kwargs)
+    return pq.read_table(str(out_path)).to_pandas()
+
+
+def test_pg_qvalue_prefers_real_fdr_over_probability(tmp_path):
+    """#246: with a real FDR column present, pg_qvalue must come from it, not from
+    the always-present 'Protein Probability' confidence score."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein Probability\tProtein FDR\t"
+        "expA Total Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\tprot1\t0.9999\t0.001\t1000\t5\t3\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    # The bug stored 0.9999 (the raw probability) as a q-value.
+    assert df["pg_qvalue"].iloc[0] == pytest.approx(0.001)
+
+
+def test_pg_qvalue_probability_only_is_inverted(tmp_path):
+    """#246: when only 'Protein Probability' is available it is converted to an
+    FDR-like value (1 - probability), never stored raw."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein Probability\t"
+        "expA Total Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\tprot1\t0.9999\t1000\t5\t3\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    assert df["pg_qvalue"].iloc[0] == pytest.approx(1.0 - 0.9999)
+
+
+def test_maxlfq_only_experiment_emits_pg(tmp_path):
+    """#247 (M): an experiment detected only from a '<exp> MaxLFQ Intensity' column
+    (no Total Intensity) must still produce a pg record, using MaxLFQ as intensity."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein FDR\t"
+        "expA MaxLFQ Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\tprot1\t0.001\t1234\t5\t3\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    assert len(df) == 1
+    assert df["intensity"].iloc[0] == pytest.approx(1234.0)
+
+
+def test_maxlfq_falls_back_when_total_intensity_is_zero(tmp_path):
+    """A zero Total Intensity with a positive MaxLFQ still yields a record."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein FDR\t"
+        "expA Total Intensity\texpA MaxLFQ Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\tprot1\t0.001\t0\t1234\t5\t3\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    assert len(df) == 1
+    assert df["intensity"].iloc[0] == pytest.approx(1234.0)
+
+
+def test_pg_decoy_detected_from_raw_prefix(tmp_path):
+    """#247 (H): decoy prefixes (incl. REV_) are detected on the raw accession, not
+    after parse_uniprot_id strips them."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein FDR\t"
+        "expA Total Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\ttarget\t0.001\t1000\t5\t3\n"
+        "REV_sp|P2|B_HUMAN\tG2\tdecoy\t0.02\t50\t2\t1\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    decoy_flag = {row["pg_accessions"][0]: bool(row["is_decoy"]) for _, row in df.iterrows()}
+    assert decoy_flag["sp|P1|A_HUMAN"] is False
+    assert decoy_flag["REV_sp|P2|B_HUMAN"] is True
+
+
+# ---- Feature adapter (combined_ion.tsv + psm.tsv) --------------------------
+
+
+def _write_feature_inputs(tmp_path, *, experiment, spectrum_source, protein="sp|P12345|PROT_HUMAN"):
+    ion = tmp_path / "combined_ion.tsv"
+    ion.write_text(
+        "Peptide Sequence\tModified Sequence\tProtein\tGene\tM/Z\tCharge\tAssigned Modifications\t"
+        f"{experiment} Intensity\t{experiment} MaxLFQ Intensity\n"
+        f"PEPTIDEK\tPEPTIDEK\t{protein}\tGENE1\t500.0\t2\t\t1000\t900\n"
+    )
+    psm = tmp_path / "psm.tsv"
+    psm.write_text(
+        "Spectrum\tPeptide\tCharge\tAssigned Modifications\t"
+        "Calibrated Observed M/Z\tCalculated M/Z\tPeptideProphet Probability\tProtein\n"
+        f"{spectrum_source}.00500.00500.2\tPEPTIDEK\t2\t\t500.001\t500.000\t0.99\trev_{protein}\n"
+    )
+    return ion, psm
+
+
+def test_feature_psm_enrichment_survives_experiment_raw_mismatch(tmp_path):
+    """#247 (H): the feature is keyed by *experiment* while the PSM is keyed by the
+    raw-file stem. When they differ (fractionated case) enrichment must still hit,
+    populating PEP, scan, mass error, and the decoy flag."""
+    ion, psm = _write_feature_inputs(tmp_path, experiment="sampleA", spectrum_source="run_01")
+    out = tmp_path / "feature.parquet"
+    with FragPipeFeatureAdapter() as adapter:
+        adapter.convert(feature_path=str(ion), output_path=str(out), psm_path=str(psm))
+    df = pq.read_table(str(out)).to_pandas()
+    assert len(df) == 1
+    rec = df.iloc[0]
+    assert rec["posterior_error_probability"] == pytest.approx(1.0 - 0.99)
+    assert list(rec["scan"]) == [500]
+    assert rec["mass_error_ppm"] == pytest.approx(1e6 * (500.001 - 500.000) / 500.000)
+    assert bool(rec["is_decoy"]) is True
+
+
+def test_feature_decoy_from_raw_accession_without_psm(tmp_path):
+    """#247 (H): without a psm.tsv, is_decoy falls back to the raw protein prefix,
+    which must survive parse_uniprot_id (rev_sp|..| -> still a decoy)."""
+    ion = tmp_path / "combined_ion.tsv"
+    ion.write_text(
+        "Peptide Sequence\tModified Sequence\tProtein\tGene\tM/Z\tCharge\tAssigned Modifications\t"
+        "sampleA Intensity\n"
+        "PEPTIDEK\tPEPTIDEK\trev_sp|P12345|PROT_HUMAN\tGENE1\t500.0\t2\t\t1000\n"
+    )
+    out = tmp_path / "feature.parquet"
+    with FragPipeFeatureAdapter() as adapter:
+        adapter.convert(feature_path=str(ion), output_path=str(out))
+    df = pq.read_table(str(out)).to_pandas()
+    assert bool(df.iloc[0]["is_decoy"]) is True
+
+
+# ---- PSM adapter (psm.tsv) -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("protein", "expected"),
+    [
+        ("sp|P1|A_HUMAN", False),
+        ("rev_sp|P1|A_HUMAN", True),
+        ("REV_sp|P1|A_HUMAN", True),
+        ("DECOY_sp|P1|A_HUMAN", True),
+        ("sp|P1|A_HUMAN, rev_sp|P2|B_HUMAN", True),
+    ],
+)
+def test_psm_decoy_prefixes_consistent(tmp_path, protein, expected):
+    """#247 (H): psm.tsv decoy detection recognises the same prefix set as the
+    feature/pg adapters and inspects every comma-separated accession."""
+    psm = tmp_path / "psm.tsv"
+    psm.write_text(
+        "Spectrum\tPeptide\tCharge\tAssigned Modifications\t"
+        "Observed M/Z\tCalculated M/Z\tRetention\tProtein\n"
+        f"run_01.00500.00500.2\tPEPTIDEK\t2\t\t500.001\t500.000\t123.4\t{protein}\n"
+    )
+    out = tmp_path / "psm.parquet"
+    with FragPipePsmAdapter() as adapter:
+        adapter.convert(psm_path=str(psm), output_path=str(out))
+    df = pq.read_table(str(out)).to_pandas()
+    assert bool(df.iloc[0]["is_decoy"]) is expected

--- a/tests/converters/test_maxquant_converter.py
+++ b/tests/converters/test_maxquant_converter.py
@@ -49,17 +49,32 @@ def test_pg_rejects_unassignable_total_intensity(tmp_path):
     assert not output.exists()
 
 
-def test_feature_deduplication_prefers_identified_evidence(tmp_path):
-    """An identified row must win over its duplicate MBR evidence row."""
+_EVIDENCE_HEADER = (
+    "Sequence\tModified sequence\tCharge\tRaw file\tType\tMS/MS scan number\tm/z\t"
+    "Calibrated retention time\tCalibrated retention time start\tCalibrated retention time finish\t"
+    "PEP\tLeading razor protein\tLeading proteins\tIntensity\tMass\tid\n"
+)
+
+
+def test_feature_dedup_collapses_identity_equal_rows(tmp_path):
+    """Bug #248 (H): rows sharing the feature identity composite must collapse.
+
+    The two ``run1`` rows share (peptidoform, charge, run, rt_start, rt_stop, scan)
+    — i.e. the same ``feature_id`` — and differ only in ``Calibrated retention
+    time``. The old dedup partitioned on calibrated RT (not part of the identity),
+    so both survived as duplicate primary keys. They must now collapse to one,
+    keeping the identified (MULTI-MSMS, lower PEP) row over the MBR one.
+    """
     from qpx.converters.maxquant.feature_adapter import MaxQuantFeatureAdapter
 
     evidence = tmp_path / "evidence.txt"
     evidence.write_text(
-        "Sequence\tModified sequence\tCharge\tRaw file\tType\tMS/MS scan number\tm/z\t"
-        "Calibrated retention time\tPEP\tLeading razor protein\tLeading proteins\tIntensity\tMass\tid\n"
-        "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MSMS\t100\t450.25\t30.0\t0.01\tP1\tP1\t1000\t898.5\t1\n"
-        "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MATCH\t\t450.25\t30.0\t\tP1\tP1\t1000\t898.5\t2\n"
-        "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MSMS\t101\t450.25\t31.0\t0.02\tP1\tP1\t2000\t898.5\t3\n"
+        _EVIDENCE_HEADER
+        # Identified row and its MBR twin: same scan/rt-window, differ in calibrated RT.
+        + "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MSMS\t100\t450.25\t30.0\t29.5\t30.5\t0.01\tP1\tP1\t1000\t898.5\t1\n"
+        + "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MATCH\t100\t450.25\t30.4\t29.5\t30.5\t0.90\tP1\tP1\t1000\t898.5\t2\n"
+        # A genuinely distinct feature (different charge/scan) must survive.
+        + "PEPTIDEK\t_PEPTIDEK_\t3\trun1\tMULTI-MSMS\t200\t300.50\t40.0\t39.5\t40.5\t0.02\tP1\tP1\t2000\t898.5\t3\n"
     )
     output = tmp_path / "feature.parquet"
 
@@ -67,11 +82,152 @@ def test_feature_deduplication_prefers_identified_evidence(tmp_path):
         adapter.convert(str(evidence), str(output), chunksize=1)
 
     rows = pq.read_table(output).to_pylist()
-    by_rt = {row["rt"]: row for row in rows}
-    assert set(by_rt) == {1800.0, 1860.0}
-    assert by_rt[1800.0]["scan"] == [100]
-    assert by_rt[1800.0]["posterior_error_probability"] == pytest.approx(0.01)
-    assert by_rt[1800.0]["id_run_file_name"] == "run1"
+    assert len(rows) == 2, f"identity-equal rows must collapse, got {len(rows)}"
+    # feature_id must be unique (no duplicate PK).
+    assert len({row["feature_id"] for row in rows}) == 2
+    kept = next(r for r in rows if r["charge"] == 2)
+    assert kept["scan"] == [100]
+    assert kept["posterior_error_probability"] == pytest.approx(0.01)
+    assert kept["rt"] == pytest.approx(1800.0)
+    assert kept["id_run_file_name"] == "run1"
+
+
+def test_feature_dedup_does_not_degrade_without_type_column(tmp_path):
+    """Bug #248 (H-b): a missing column must not degrade dedup to ``SELECT *``.
+
+    With no ``Type`` column, the old guard fell back to ``SELECT * FROM evidence``,
+    letting identity duplicates through. Dedup must still collapse identity-equal
+    rows using the identity columns that are present.
+    """
+    from qpx.converters.maxquant.feature_adapter import MaxQuantFeatureAdapter
+
+    header = (
+        "Sequence\tModified sequence\tCharge\tRaw file\tMS/MS scan number\tm/z\t"
+        "Calibrated retention time\tCalibrated retention time start\t"
+        "Calibrated retention time finish\tPEP\tLeading razor protein\tLeading proteins\tIntensity\tMass\tid\n"
+    )
+    evidence = tmp_path / "evidence.txt"
+    evidence.write_text(
+        header
+        + "PEPTIDEK\t_PEPTIDEK_\t2\trun1\t100\t450.25\t30.0\t29.5\t30.5\t0.01\tP1\tP1\t1000\t898.5\t1\n"
+        + "PEPTIDEK\t_PEPTIDEK_\t2\trun1\t100\t450.25\t30.4\t29.5\t30.5\t0.05\tP1\tP1\t1000\t898.5\t2\n"
+    )
+    output = tmp_path / "feature.parquet"
+
+    with MaxQuantFeatureAdapter() as adapter:
+        adapter.convert(str(evidence), str(output), chunksize=100)
+
+    rows = pq.read_table(output).to_pylist()
+    assert len(rows) == 1, f"identity duplicates must collapse even without Type, got {len(rows)}"
+
+
+def test_psm_handles_empty_modified_sequence(tmp_path):
+    """Bug #248 (H): an empty ``Modified sequence`` must not abort the PSM view.
+
+    The ``else None`` tuple-unpack raised ``TypeError`` for any row whose
+    modified sequence was empty. The adapter must now skip that single row
+    (peptidoform is a required schema field) instead of crashing the whole
+    conversion, so the remaining PSMs still convert.
+    """
+    from qpx.converters.maxquant.psm_adapter import MaxQuantPsmAdapter
+
+    msms = tmp_path / "msms.txt"
+    msms.write_text(
+        "Sequence\tModified sequence\tCharge\tRaw file\tScan number\tm/z\tMass\tPEP\tReverse\tScore\tProteins\n"
+        "PEPTIDEK\t_PEPTIDEK_\t2\trun1\t100\t450.25\t898.5\t0.01\t\t100\tP1\n"
+        # Empty modified sequence (renders to an empty peptidoform via to_proforma).
+        "PEPTIDER\t_\t2\trun1\t101\t500.25\t998.5\t0.02\t\t90\tP2\n"
+    )
+    output = tmp_path / "psm.parquet"
+
+    with MaxQuantPsmAdapter() as adapter:
+        adapter.convert(str(msms), str(output))
+
+    rows = pq.read_table(output).to_pylist()
+    # The empty-modseq row is skipped; the valid PSM must still convert.
+    assert len(rows) == 1, "valid PSM must survive; empty modseq row skipped, not crashing"
+    assert rows[0]["sequence"] == "PEPTIDEK"
+    assert rows[0]["peptidoform"]
+
+
+def test_feature_pg_qvalue_and_genes_keyed_on_full_membership(tmp_path):
+    """Bug #248 (M): a shared razor accession must not bind to another group's metadata.
+
+    Both features share leading razor protein P1, but belong to different protein
+    groups (P1;P2 vs P1;P3). The old leader-keyed map bound P1 to the first group
+    by file order, so both features inherited that group's q-value/genes. The map
+    must be keyed on the full protein-group membership.
+    """
+    from qpx.converters.maxquant.feature_adapter import MaxQuantFeatureAdapter
+
+    evidence = tmp_path / "evidence.txt"
+    evidence.write_text(
+        "Sequence\tModified sequence\tCharge\tRaw file\tType\tMS/MS scan number\tm/z\t"
+        "Calibrated retention time\tCalibrated retention time start\tCalibrated retention time finish\t"
+        "PEP\tLeading razor protein\tLeading proteins\tGene names\tIntensity\tMass\tid\n"
+        "PEPTIDEA\t_PEPTIDEA_\t2\trun1\tMULTI-MSMS\t100\t450.25\t30.0\t29.5\t30.5\t0.01\tP1\tP1;P2\t\t1000\t500\t1\n"
+        "PEPTIDEB\t_PEPTIDEB_\t2\trun1\tMULTI-MSMS\t200\t460.25\t31.0\t30.5\t31.5\t0.02\tP1\tP1;P3\t\t2000\t520\t2\n"
+    )
+    protein_groups = tmp_path / "proteinGroups.txt"
+    protein_groups.write_text(
+        "Protein IDs\tMajority protein IDs\tQ-value\tGene names\nP1;P2\tP1;P2\t0.001\tGENEA\nP1;P3\tP1;P3\t0.5\tGENEB\n"
+    )
+    output = tmp_path / "feature.parquet"
+
+    with MaxQuantFeatureAdapter() as adapter:
+        adapter.convert(str(evidence), str(output), protein_groups_path=str(protein_groups))
+
+    rows = pq.read_table(output).to_pylist()
+    by_seq = {r["sequence"]: r for r in rows}
+    assert by_seq["PEPTIDEA"]["pg_global_qvalue"] == pytest.approx(0.001)
+    assert by_seq["PEPTIDEA"]["gg_names"] == ["GENEA"]
+    assert by_seq["PEPTIDEB"]["pg_global_qvalue"] == pytest.approx(0.5)
+    assert by_seq["PEPTIDEB"]["gg_names"] == ["GENEB"]
+
+
+def test_feature_warns_on_dropped_tmt_channels(caplog):
+    """Bug #248 (M): channels with no reporter column must warn, not vanish silently."""
+    from qpx.converters.maxquant.feature_adapter import MaxQuantFeatureAdapter
+
+    # evidence has only Reporter intensity 0-7; a 10-plex SDRF adds TMT130C (col 8)
+    # and TMT131 (col 9), which have no column and would otherwise be dropped.
+    columns = [f"Reporter intensity {i}" for i in range(8)]
+    channels = [
+        "TMT126",
+        "TMT127N",
+        "TMT127C",
+        "TMT128N",
+        "TMT128C",
+        "TMT129N",
+        "TMT129C",
+        "TMT130N",
+        "TMT130C",
+        "TMT131",
+    ]
+    with MaxQuantFeatureAdapter() as adapter:
+        with caplog.at_level("WARNING"):
+            adapter._warn_dropped_tmt_channels(columns, "TMT10", channels, ri_offset=0)
+            # Second call with the same dropped set must not re-warn.
+            adapter._warn_dropped_tmt_channels(columns, "TMT10", channels, ri_offset=0)
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING" and "dropped" in r.message.lower()]
+    assert len(warnings) == 1, "dropped-channel warning must be emitted exactly once"
+    assert "TMT130C" in caplog.text
+    assert "TMT131" in caplog.text
+
+
+def test_pg_warns_on_dropped_tmt_channels(caplog):
+    """Bug #248 (M): the pg adapter must also warn about dropped channels."""
+    from qpx.converters.maxquant.pg_adapter import MaxQuantPgAdapter
+
+    with MaxQuantPgAdapter() as adapter:
+        with caplog.at_level("WARNING"):
+            adapter._warn_dropped_tmt_channels("exp1", ["TMT130C", "TMT131"])
+            adapter._warn_dropped_tmt_channels("exp1", ["TMT130C", "TMT131"])
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING" and "dropped" in r.message.lower()]
+    assert len(warnings) == 1
+    assert "TMT130C" in caplog.text and "TMT131" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/converters/test_mzidentml_converter.py
+++ b/tests/converters/test_mzidentml_converter.py
@@ -11,6 +11,7 @@ import pyarrow.parquet as pq
 from qpx.converters.mzidentml.psm_adapter import (
     MzIdentMLPsmAdapter,
     _group_siis,
+    _parse_native_id,
     _parse_scan,
 )
 
@@ -51,7 +52,33 @@ class TestParseScan:
         assert _parse_scan("42") == [42]
 
     def test_unknown_format(self):
-        assert _parse_scan("something_else") == [0]
+        # Unparseable spectrumIDs must NOT collapse onto a ``[0]`` sentinel
+        # (which aliases distinct spectra and a real scan-0 spectrum).
+        assert _parse_scan("something_else") == []
+
+
+class TestParseNativeId:
+    """The nativeID scheme distinguishes scan numbers from file indices (#249)."""
+
+    def test_scan_is_scan_scheme(self):
+        assert _parse_native_id("scan=100") == ([100], "scan")
+
+    def test_index_is_index_scheme(self):
+        # The regression: ``index=`` is a file position, not a scan number.
+        assert _parse_native_id("index=1999") == ([1999], "index")
+
+    def test_spectrum_is_scan_scheme(self):
+        assert _parse_native_id("spectrum=5") == ([5], "scan")
+
+    def test_bare_integer_is_scan_scheme(self):
+        assert _parse_native_id("42") == ([42], "scan")
+
+    def test_mzml_nativeid_scan(self):
+        assert _parse_native_id("controllerType=0 controllerNumber=1 scan=7") == ([7], "scan")
+
+    def test_unparseable_is_empty_none(self):
+        # No ``[0]`` sentinel: distinct unparseable spectra must not alias.
+        assert _parse_native_id("something_else") == ([], None)
 
 
 class TestGroupSiis:
@@ -517,3 +544,105 @@ class TestMzIdentMLProvenanceParams:
         var_mods = [p for p in params if p["key"] == "variable_mod"]
         assert var_mods, f"No 'variable_mod' entries in parameters: {params}"
         assert any("Oxidation" in p["value"] for p in var_mods), f"Expected Oxidation in variable_mod entries: {var_mods}"
+
+
+# ---------------------------------------------------------------------------
+# Shared-modifications mutation (bigbio/qpx#249)
+# ---------------------------------------------------------------------------
+
+
+class TestSharedModificationsNoCrossContamination:
+    """PSMs that share a ``peptide_ref`` must not accumulate each other's
+    site-localization scores.
+
+    The Peptide's ``modifications`` list is shared by every SII that references
+    it, and site-localization scoring mutates modification positions in place.
+    Without a per-PSM copy, the second PSM inherits the first PSM's phosphoRS
+    score, corrupting localization data.
+    """
+
+    @staticmethod
+    def _phospho_mod():
+        return [
+            {
+                "name": "Phospho",
+                "accession": "UNIMOD:21",
+                "positions": [{"position": 4, "amino_acid": "T", "scores": None}],
+            }
+        ]
+
+    @staticmethod
+    def _sii(sii_id, site_prob):
+        # MS:1001969 == phosphoRS site probability (a site-localization cvParam).
+        return {
+            "id": sii_id,
+            "charge": 2,
+            "exp_mz": 500.0,
+            "calc_mz": 500.0,
+            "rank": 1,
+            "pass_threshold": True,
+            "peptide_ref": "SharedPep",
+            "cv_params": [
+                {
+                    "accession": "MS:1001969",
+                    "name": "phosphoRS site probability",
+                    "value": f"T4: {site_prob}",
+                }
+            ],
+            "peptide_evidence_refs": [],
+        }
+
+    def _parsed(self):
+        return {
+            "spectra_data": {"SD1": "run.mgf"},
+            "db_sequences": {},
+            "peptides": {
+                "SharedPep": {
+                    "sequence": "PEPTIDE",
+                    "modifications": self._phospho_mod(),
+                    "xl_mods": {},
+                }
+            },
+            "peptide_evidence": {},
+            "linker_info": {},
+            "spectrum_results": [
+                {
+                    "spectrum_id": "index=1",
+                    "spectra_data_ref": "SD1",
+                    "rt": None,
+                    "siis": [self._sii("SII_1", 99.0)],
+                },
+                {
+                    "spectrum_id": "index=2",
+                    "spectra_data_ref": "SD1",
+                    "rt": None,
+                    "siis": [self._sii("SII_2", 10.0)],
+                },
+            ],
+        }
+
+    def test_each_psm_keeps_only_its_own_score(self):
+        parsed = self._parsed()
+        with MzIdentMLPsmAdapter() as adapter:
+            records = adapter._build_psm_records(parsed)
+
+        assert len(records) == 2
+        scores_per_psm = [rec["modifications"][0]["positions"][0]["scores"] for rec in records]
+
+        # Each PSM carries exactly ONE site-localization score — its own.
+        for scores in scores_per_psm:
+            assert scores is not None
+            assert len(scores) == 1
+
+        values = sorted(scores[0]["score_value"] for scores in scores_per_psm)
+        assert values == [10.0, 99.0]
+
+    def test_shared_source_modifications_untouched(self):
+        parsed = self._parsed()
+        shared = parsed["peptides"]["SharedPep"]["modifications"]
+        with MzIdentMLPsmAdapter() as adapter:
+            adapter._build_psm_records(parsed)
+
+        # The Peptide's shared modification list must remain pristine — scoring
+        # happened on per-PSM copies, not on this source object.
+        assert shared[0]["positions"][0]["scores"] is None

--- a/tests/converters/test_mzidentml_full_converter.py
+++ b/tests/converters/test_mzidentml_full_converter.py
@@ -267,27 +267,100 @@ class TestPXD054720WithSpectra:
 
 
 class TestIndexFallback:
-    """Test that spectra attachment falls back to index when scan doesn't match."""
+    """Spectra attachment must use the nativeID scheme to pick the right lookup."""
 
-    def test_fallback_to_index(self, tmp_path):
-        """When scan-based lookup fails, should try index-based lookup."""
-        # Create MGF where SCANS= doesn't match mzIdentML scan numbers
-        # but the 0-based index does
+    def test_index_scheme_uses_position_lookup(self, tmp_path):
+        """``index=`` records attach by 0-based file position, not by SCANS=."""
+        # MGF where SCANS= deliberately does NOT match the index values, so a
+        # scan-number lookup would either miss or (worse) match the wrong
+        # spectrum. Only a position-based lookup gives the correct peaks.
         mgf = tmp_path / "test.mgf"
         mgf.write_text(
             "BEGIN IONS\nTITLE=first\nSCANS=999\n100.0 500\nEND IONS\nBEGIN IONS\nTITLE=second\nSCANS=998\n200.0 600\nEND IONS\n"
         )
 
-        # PSM records with scan=[0] and scan=[1] -- don't match SCANS=999/998
-        # but DO match 0-based position
         records = [
-            {"scan": [0], "mz_array": None, "intensity_array": None, "rt": None},
-            {"scan": [1], "mz_array": None, "intensity_array": None, "rt": None},
+            {"scan": [0], "_spectrum_id_scheme": "index", "mz_array": None, "intensity_array": None, "rt": None},
+            {"scan": [1], "_spectrum_id_scheme": "index", "mz_array": None, "intensity_array": None, "rt": None},
         ]
 
         result = MzIdentMLConverter._attach_spectra(records, str(mgf))
-        assert result[0]["mz_array"] == [100.0]  # matched by index 0
-        assert result[1]["mz_array"] == [200.0]  # matched by index 1
+        assert result[0]["mz_array"] == [100.0]  # position 0
+        assert result[1]["mz_array"] == [200.0]  # position 1
+
+    def test_index_value_not_attached_by_scan(self, tmp_path):
+        """An ``index=`` value must never be attached via a colliding SCANS=.
+
+        Regression for bigbio/qpx#249: index 999 collides with SCANS=999 of an
+        UNRELATED spectrum; the old scan-first lookup attached those wrong peaks.
+        """
+        # Spectrum at position 0 carries SCANS=999; the correct spectrum for
+        # index=999 does not exist in this tiny MGF, so nothing must attach.
+        mgf = tmp_path / "collide.mgf"
+        mgf.write_text("BEGIN IONS\nTITLE=first\nSCANS=999\n100.0 500\nEND IONS\n")
+
+        records = [
+            {"scan": [999], "_spectrum_id_scheme": "index", "mz_array": None, "intensity_array": None, "rt": None},
+        ]
+
+        result = MzIdentMLConverter._attach_spectra(records, str(mgf))
+        # No spectrum at position 999 → nothing attached (NOT the SCANS=999 peaks).
+        assert result[0]["mz_array"] is None
+
+    def test_index_file_attaches_correct_spectrum_end_to_end(self, tmp_path):
+        """A PSM whose ``spectrumID`` is ``index=N`` attaches the peaks of the
+        Nth spectrum, even when an unrelated spectrum carries ``SCANS=N``.
+
+        End-to-end: the scheme is derived from the ``index=`` spectrumID by the
+        adapter, then honoured by ``_attach_spectra``. Regression for
+        bigbio/qpx#249 (the old scan-first lookup attached the SCANS-colliding
+        spectrum's peaks instead).
+        """
+        from qpx.converters.mzidentml.psm_adapter import MzIdentMLPsmAdapter
+
+        # Position 0 is a decoy whose SCANS collides with the target index (1);
+        # position 1 is the CORRECT spectrum for ``index=1``.
+        mgf = tmp_path / "e2e.mgf"
+        mgf.write_text(
+            "BEGIN IONS\nTITLE=decoy\nSCANS=1\n100.0 500\nEND IONS\nBEGIN IONS\nTITLE=target\nSCANS=42\n200.0 600\nEND IONS\n"
+        )
+
+        parsed = {
+            "spectra_data": {"SD1": "e2e.mgf"},
+            "db_sequences": {},
+            "peptides": {"Pep1": {"sequence": "PEPTIDE", "modifications": None, "xl_mods": {}}},
+            "peptide_evidence": {},
+            "linker_info": {},
+            "spectrum_results": [
+                {
+                    "spectrum_id": "index=1",  # the 2nd spectrum (position 1)
+                    "spectra_data_ref": "SD1",
+                    "rt": None,
+                    "siis": [
+                        {
+                            "id": "SII_1",
+                            "charge": 2,
+                            "exp_mz": 500.0,
+                            "calc_mz": 500.0,
+                            "rank": 1,
+                            "pass_threshold": True,
+                            "peptide_ref": "Pep1",
+                            "cv_params": [],
+                            "peptide_evidence_refs": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        with MzIdentMLPsmAdapter() as adapter:
+            records = adapter._build_psm_records(parsed)
+        assert records[0]["_spectrum_id_scheme"] == "index"
+
+        result = MzIdentMLConverter._attach_spectra(records, str(mgf))
+        # Correct spectrum is position 1 (200.0), NOT the SCANS=1 collision (100.0).
+        assert result[0]["mz_array"] == [200.0]
+        assert result[0]["intensity_array"] == [600.0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -168,16 +168,29 @@ def test_pg_peptide_counts_are_per_protein(monkeypatch):
 
 
 def test_pg_uses_id_merge_index_after_unmapped_map_index():
+    """An unassigned PID with an unmapped map_index resolves its run via
+    id_merge_index -> the i-th merged MS run (spectra_data order), not the
+    map-column dict."""
     from qpx.converters.openms_consensus.pg_adapter import _protein_maps
 
     class Header:
         def __init__(self, filename):
             self.filename = filename
 
+    class ProteinIdentification:
+        @staticmethod
+        def getPrimaryMSRunPath(output):
+            # Merge order: id_merge_index 0 -> run_01, 1 -> run_02.
+            output.extend([b"run_01.mzML", b"run_02.mzML"])
+
     class ConsensusMap:
         @staticmethod
         def getColumnHeaders():
             return {0: Header("run_01.mzML"), 1: Header("run_02.mzML")}
+
+        @staticmethod
+        def getProteinIdentifications():
+            return [ProteinIdentification()]
 
         @staticmethod
         def getUnassignedPeptideIdentifications():
@@ -257,6 +270,118 @@ def test_consensus_psms_use_parent_feature_run_context(tmp_path):
 
     assert len(records) == 1
     assert records[0]["run_file_name"] == "run_B"
+
+
+# A merged 2-plex isobaric consensusXML: two input MS runs (plexA, plexB), each
+# contributing two TMT channels (maps 0-1 = plexA, 2-3 = plexB). The merged
+# ProteinIdentification records the merge order as ``spectra_data`` = [plexA, plexB],
+# so an unassigned PID's ``id_merge_index`` selects the i-th run. The unassigned
+# PID below carries ``id_merge_index=1`` -> it belongs to plexB (the SECOND run),
+# NOT plexA — the regression for issue #243.
+_TWO_PLEX_ISOBARIC_CONSENSUSXML = """<?xml version="1.0" encoding="ISO-8859-1"?>
+<consensusXML version="1.7" experiment_type="label-free"
+  xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <IdentificationRun id="PI_0" date="0000-00-00T00:00:00" search_engine="" search_engine_version="">
+    <SearchParameters db="" db_version="" taxonomy="" mass_type="monoisotopic" charges=""
+      enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0"
+      precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0"
+      peak_mass_tolerance_ppm="false">
+    </SearchParameters>
+    <ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0">
+      <ProteinHit id="PH_0" accession="P12345" score="0" sequence=""></ProteinHit>
+      <UserParam type="stringList" name="spectra_data" value="[plexA.mzML,plexB.mzML]"/>
+    </ProteinIdentification>
+  </IdentificationRun>
+  <mapList count="4">
+    <map id="0" name="plexA.mzML" unique_id="1" label="tmt6plex_126" size="1"></map>
+    <map id="1" name="plexA.mzML" unique_id="2" label="tmt6plex_127" size="1"></map>
+    <map id="2" name="plexB.mzML" unique_id="3" label="tmt6plex_126" size="1"></map>
+    <map id="3" name="plexB.mzML" unique_id="4" label="tmt6plex_127" size="1"></map>
+  </mapList>
+  <consensusElementList>
+    <consensusElement id="e_0" quality="0.0" charge="2">
+      <centroid rt="100.0" mz="450.25" it="0.0"/>
+      <groupedElementList>
+        <element map="0" id="0" rt="100.0" mz="450.25" it="1000.0"/>
+        <element map="1" id="1" rt="100.0" mz="450.25" it="2000.0"/>
+      </groupedElementList>
+      <PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true"
+        significance_threshold="0" MZ="450.26" RT="100"
+        spectrum_reference="controllerType=0 controllerNumber=1 scan=42">
+        <PeptideHit score="0" sequence="PEPTIDEK" charge="2" protein_refs="PH_0">
+          <UserParam type="string" name="target_decoy" value="target"/>
+        </PeptideHit>
+      </PeptideIdentification>
+    </consensusElement>
+  </consensusElementList>
+  <UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true"
+    significance_threshold="0" MZ="500.30" RT="200"
+    spectrum_reference="controllerType=0 controllerNumber=1 scan=77">
+    <PeptideHit score="0" sequence="ELVISLIVEK" charge="2" protein_refs="PH_0">
+      <UserParam type="string" name="target_decoy" value="target"/>
+    </PeptideHit>
+    <UserParam type="int" name="id_merge_index" value="1"/>
+  </UnassignedPeptideIdentification>
+</consensusXML>
+"""
+
+
+def test_unassigned_isobaric_psm_run_from_id_merge_index(tmp_path):
+    """An unassigned PSM in a merged multi-run isobaric consensusXML is attributed
+    to the run its id_merge_index selects (the SECOND run), not the first map's
+    run — the regression for issue #243."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    path = tmp_path / "two_plex.consensusXML"
+    path.write_text(_TWO_PLEX_ISOBARIC_CONSENSUSXML)
+
+    records = consensus_psms_to_records(str(path))
+
+    unassigned = [r for r in records if r["peptidoform"] == "ELVISLIVEK"]
+    assert len(unassigned) == 1
+    # id_merge_index=1 -> spectra_data[1] = plexB. The bug attributed it to plexA.
+    assert unassigned[0]["run_file_name"] == "plexB"
+    assert list(unassigned[0]["scan"]) == [77]
+
+
+def test_unassigned_isobaric_pg_run_from_id_merge_index(tmp_path):
+    """The corrected run flows into the pg adapter's acc_to_runs for an unassigned
+    PID (via accumulate_unassigned_maps)."""
+    from qpx.converters.openms_consensus.feature_adapter import load_consensus_map
+    from qpx.converters.openms_consensus.pg_adapter import _protein_maps
+
+    path = tmp_path / "two_plex_pg.consensusXML"
+    path.write_text(_TWO_PLEX_ISOBARIC_CONSENSUSXML)
+
+    m = _protein_maps(load_consensus_map(str(path)))
+    # ELVISLIVEK (unassigned, id_merge_index=1) contributes plexB, not plexA.
+    assert "plexB" in m.acc_to_runs["P12345"]
+    assert "plexA" in m.acc_to_runs["P12345"]  # from the assigned PEPTIDEK feature
+
+
+def test_unassigned_isobaric_run_streaming_matches_pyopenms(tmp_path):
+    """The streaming reader resolves the unassigned run identically to pyopenms."""
+    import json
+
+    import pyarrow.parquet as pq
+
+    cx = tmp_path / "two_plex_stream.consensusXML"
+    cx.write_text(_TWO_PLEX_ISOBARIC_CONSENSUSXML)
+
+    def convert(streaming):
+        out = tmp_path / ("stream" if streaming else "pyopenms")
+        return OpenMSConsensusConverter().convert(
+            str(cx), str(out), output_prefix="d", structures=("feature", "psm", "pg"), streaming=streaming
+        )
+
+    wp, ws = convert(False), convert(True)
+
+    def canon(path):
+        return sorted(json.dumps(r, sort_keys=True, default=str) for r in pq.read_table(str(path)).to_pylist())
+
+    for view in ("feature", "psm", "pg"):
+        assert canon(wp[view]) == canon(ws[view]), f"{view} differs between pyopenms and streaming"
 
 
 def test_consensus_psm_multihit_keeps_lowest_pep_and_merges_scores(tmp_path):

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -259,6 +259,98 @@ def test_consensus_psms_use_parent_feature_run_context(tmp_path):
     assert records[0]["run_file_name"] == "run_B"
 
 
+def test_consensus_psm_multihit_keeps_lowest_pep_and_merges_scores(tmp_path):
+    """A PID with two hits colliding on the identity key resolves to one PSM: the
+    lowest-PEP hit is kept and the other (engine's) search score is preserved."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    # First hit: score 1.5, PEP 5.0e-02. Second hit (inserted): score 2.7, PEP
+    # 1.0e-03 -> the second must win (lower PEP) even though it is not first.
+    xml = _TMT_CONSENSUSXML.replace('score="0" sequence="PEPTIDEK"', 'score="1.5" sequence="PEPTIDEK"')
+    xml = xml.replace('value="1.0e-03"', 'value="5.0e-02"')
+    second_hit = (
+        '        <PeptideHit score="2.7" sequence="PEPTIDEK" charge="2" protein_refs="PH_0">\n'
+        '          <UserParam type="string" name="target_decoy" value="target"/>\n'
+        '          <UserParam type="float" name="Posterior Error Probability_score" value="1.0e-03"/>\n'
+        "        </PeptideHit>"
+    )
+    xml = xml.replace(
+        "        </PeptideHit>\n      </PeptideIdentification>",
+        f"        </PeptideHit>\n{second_hit}\n      </PeptideIdentification>",
+    )
+    assert second_hit in xml  # guard: the fixture edit actually applied
+    path = tmp_path / "multihit.consensusXML"
+    path.write_text(xml)
+
+    records = consensus_psms_to_records(str(path))
+
+    assert len(records) == 1  # collapsed to a single PSM, not two
+    rec = records[0]
+    assert rec["peptidoform"] == "PEPTIDEK"
+    assert rec["posterior_error_probability"] == pytest.approx(1.0e-03)  # lower PEP kept
+    score_values = [s["score_value"] for s in (rec["additional_scores"] or [])]
+    assert any(v == pytest.approx(2.7) for v in score_values)  # kept hit's own search score
+    assert any(v == pytest.approx(1.5) for v in score_values)  # the other engine's search score preserved
+
+
+def test_consensus_psm_distinct_peptidoforms_both_emitted(tmp_path):
+    """Two *different* peptidoforms in one PID are distinct PSMs and both survive."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    second_hit = (
+        '        <PeptideHit score="0" sequence="PEPTIDER" charge="2" protein_refs="PH_0">\n'
+        '          <UserParam type="string" name="target_decoy" value="target"/>\n'
+        '          <UserParam type="float" name="Posterior Error Probability_score" value="2.0e-03"/>\n'
+        "        </PeptideHit>"
+    )
+    xml = _TMT_CONSENSUSXML.replace(
+        "        </PeptideHit>\n      </PeptideIdentification>",
+        f"        </PeptideHit>\n{second_hit}\n      </PeptideIdentification>",
+    )
+    path = tmp_path / "twopep.consensusXML"
+    path.write_text(xml)
+
+    records = consensus_psms_to_records(str(path))
+
+    assert {r["peptidoform"] for r in records} == {"PEPTIDEK", "PEPTIDER"}
+
+
+def test_consensus_psm_sciex_nativeid_not_dropped(tmp_path):
+    """A Sciex WIFF nativeID (no scan token, cycle-based) is kept, keyed by cycle."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    xml = _TMT_CONSENSUSXML.replace(
+        'spectrum_reference="controllerType=0 controllerNumber=1 scan=42"',
+        'spectrum_reference="sample=1 period=1 cycle=123 experiment=2"',
+    )
+    path = tmp_path / "sciex.consensusXML"
+    path.write_text(xml)
+
+    records = consensus_psms_to_records(str(path))
+
+    assert len(records) == 1  # not silently dropped
+    assert list(records[0]["scan"]) == [123]  # cycle is the scan-equivalent ordinal
+
+
+def test_consensus_psm_unknown_nativeid_uses_surrogate_scan(tmp_path):
+    """A nativeID with no recognizable ordinal falls back to a deterministic
+    int32 surrogate rather than being dropped."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    xml = _TMT_CONSENSUSXML.replace(
+        'spectrum_reference="controllerType=0 controllerNumber=1 scan=42"',
+        'spectrum_reference="sample=1 period=1 experiment=2"',
+    )
+    path = tmp_path / "exotic.consensusXML"
+    path.write_text(xml)
+
+    records = consensus_psms_to_records(str(path))
+
+    assert len(records) == 1  # not dropped
+    scan = list(records[0]["scan"])
+    assert len(scan) == 1 and 0 <= scan[0] <= 0x7FFFFFFF  # deterministic, int32-safe
+
+
 def _write_multi_reference_consensusxml(path):
     """Write one ConsensusFeature supported by two spectrum references."""
     second_pid = """

--- a/tests/converters/test_openms_converter.py
+++ b/tests/converters/test_openms_converter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pyarrow as pa
@@ -158,8 +159,8 @@ class TestOpenMSConverter:
         assert "grouped_runs" in pg_table.column_names
         assert "run_file_name" not in pg_table.column_names
 
-    def test_invalid_legacy_identity_does_not_replace_output(self, tmp_path):
-        """Strict validation happens before a rewritten core file is installed."""
+    def test_duplicate_identity_warns_and_replaces_output(self, tmp_path, caplog):
+        """A duplicate primary key is tolerated with a warning; the core file is rewritten."""
         qpx_dir = tmp_path / "openms_qpx"
         qpx_dir.mkdir()
         records = [
@@ -179,10 +180,14 @@ class TestOpenMSConverter:
         sentinel = b"pre-existing output"
         destination.write_bytes(sentinel)
 
-        with pytest.raises(ValueError, match="Primary key.*duplicate"):
+        with caplog.at_level(logging.WARNING):
             OpenMSConverter(qpx_dir=qpx_dir).convert(output_folder=output, output_prefix="openms")
 
-        assert destination.read_bytes() == sentinel
+        # The converter completed: the destination is replaced with the real parquet output.
+        assert destination.read_bytes() != sentinel
+        rewritten = pq.read_table(destination)
+        assert rewritten.num_rows == 2
+        assert "duplicate row" in caplog.text.lower()
         assert not list(output.glob(".openms.psm.parquet.*.tmp"))
 
     def test_convert_full_bundle(self, tmp_path):

--- a/tests/converters/test_spectronaut_converter.py
+++ b/tests/converters/test_spectronaut_converter.py
@@ -213,3 +213,51 @@ class TestSpectronautProvenance:
         table = pq.read_table(str(path))
         tool_names = table.column("tool_name").to_pylist()
         assert any("qpx" in str(t).lower() for t in tool_names if t), "Expected qpx in provenance tool_names"
+
+
+class TestRunNameNormalization:
+    """Regression for bigbio/qpx#252: the Spectronaut feature adapter stripped
+    only ``\\.(mzML|raw|d)$`` case-sensitively while the pg adapter stripped
+    ``(?i)\\.(mzML|raw|d|wiff|htrms)$``, so ``.wiff`` / ``.htrms`` / ``.RAW``
+    broke feature<->pg<->run joins. Both adapters must strip the same set,
+    case-insensitively, by DuckDB SQL."""
+
+    @staticmethod
+    def _run_expr(part: str) -> str:
+        # part looks like "regexp_replace(...) AS <alias>"; return the expression.
+        return part.rsplit(" AS ", 1)[0]
+
+    def test_feature_and_pg_use_same_extension_strip(self):
+        import duckdb
+
+        from qpx.converters.spectronaut.feature_adapter import SpectronautFeatureAdapter as FeatureAdapter
+        from qpx.converters.spectronaut.pg_adapter import SpectronautPgAdapter as PgAdapter
+
+        r = {
+            "sequence": "SEQ",
+            "charge": "CHG",
+            "run_file_name": "RUN",
+            "pg_accessions": "PG",
+            "intensity": "INT",
+        }
+        core = FeatureAdapter._build_core_select_parts(r, set())
+        meta = FeatureAdapter._build_meta_select_parts(r, set())
+        pg = PgAdapter._build_pg_select_parts(r, set())
+
+        feat_run = next(self._run_expr(p) for p in core if p.endswith("AS run_file_name"))
+        feat_id_run = next(self._run_expr(p) for p in meta if p.endswith("AS id_run_file_name"))
+        pg_run = next(self._run_expr(p) for p in pg if p.endswith("AS run_file_name"))
+
+        con = duckdb.connect()
+        try:
+            for name in ("sample.mzML", "sample.RAW", "sample.wiff", "sample.HTRMS", "sample.d"):
+                # Evaluate each adapter's expression against the same input value.
+                feat_val = con.execute(f'SELECT {feat_run} FROM (SELECT ? AS "RUN") r', [name]).fetchone()[0]
+                feat_id_val = con.execute(f'SELECT {feat_id_run} FROM (SELECT ? AS "RUN") r', [name]).fetchone()[0]
+                pg_val = con.execute(f'SELECT {pg_run} FROM (SELECT ? AS "RUN") r', [name]).fetchone()[0]
+                assert feat_val == "sample", f"feature did not strip {name}: {feat_val}"
+                assert feat_id_val == "sample", f"feature id_run did not strip {name}: {feat_id_val}"
+                assert pg_val == "sample", f"pg did not strip {name}: {pg_val}"
+                assert feat_val == pg_val == feat_id_val
+        finally:
+            con.close()

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -758,3 +758,27 @@ class TestMokumeWorkflow:
             df = result.to_df()
             assert len(df) > 0
             assert "log2fc" in df.columns
+
+
+class TestMultiShardLocalRead:
+    """bigbio/qpx#252: a local structure split across several shards must read
+    ALL of them (unioned), matching the S3 path — previously only the first
+    matching file was used, so local and S3 returned different rows."""
+
+    def test_local_reads_all_shards(self, tmp_path):
+        # Two feature shards with no file_prefix, so the '*.feature.parquet'
+        # glob matches both.
+        with FeatureWriter(tmp_path / "a.feature.parquet") as w:
+            w.write_batch([make_feature_record(peptidoform="PEPTIDEK", run_file_name="run_01")])
+        with FeatureWriter(tmp_path / "b.feature.parquet") as w:
+            w.write_batch(
+                [
+                    make_feature_record(peptidoform="ELVISK", run_file_name="run_02"),
+                    make_feature_record(peptidoform="SAMPLERK", run_file_name="run_03"),
+                ]
+            )
+
+        with Dataset(tmp_path) as ds:
+            assert ds.feature is not None
+            # All three rows across both shards, not just the first shard's one.
+            assert ds.feature.count() == 3

--- a/tests/integration/test_partitioning.py
+++ b/tests/integration/test_partitioning.py
@@ -146,3 +146,39 @@ class TestPartitionedWriting:
         BaseWriter.write_partitioned(table, out)  # No partition_cols arg
         dirs = sorted(d.name for d in out.iterdir() if d.is_dir())
         assert any("run_file_name=" in d for d in dirs)
+
+    def test_write_partitioned_via_subclass_derives_id_and_validates(self, tmp_path, caplog):
+        """bigbio/qpx#252: called on a concrete writer subclass, write_partitioned
+        must derive the identity id (when absent) and run schema validation,
+        instead of bypassing both. Called on the bare BaseWriter it stays a raw
+        dump (covered by the other tests)."""
+        import logging
+
+        import pyarrow.dataset as pds
+
+        from qpx.writers import FeatureWriter
+        from tests.conftest import make_feature_record
+
+        # Build a proper feature file, then strip the derived feature_id so the
+        # partitioned write has to re-derive it.
+        src = tmp_path / "src.feature.parquet"
+        with FeatureWriter(src) as w:
+            w.write_batch(
+                [
+                    make_feature_record(peptidoform="PEPTIDEK", run_file_name="run_01"),
+                    make_feature_record(peptidoform="ELVISK", run_file_name="run_02"),
+                ]
+            )
+        table = pq.read_table(src)
+        assert "feature_id" in table.schema.names
+        stripped = table.drop_columns(["feature_id"])
+
+        out = tmp_path / "feat_part"
+        with caplog.at_level(logging.WARNING, logger="qpx.writers.base"):
+            FeatureWriter.write_partitioned(stripped, out, ["run_file_name"])
+
+        back = pds.dataset(str(out), format="parquet", partitioning="hive").to_table()
+        assert "feature_id" in back.schema.names
+        ids = back.column("feature_id").to_pylist()
+        assert all(i is not None for i in ids), "feature_id must be derived, not left null"
+        assert len(set(ids)) == 2

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -190,7 +190,7 @@ def test_pg_schema_grouped_runs_is_list_string():
     assert pa.types.is_list(field.type)
     assert pa.types.is_string(field.type.value_type)
     assert tuple(PgSchema._primary_key) == ("pg_id",)
-    assert tuple(PgSchema.identity_composite) == ("anchor_protein", "grouped_runs", "label")
+    assert tuple(PgSchema.identity_composite) == ("pg_accessions", "grouped_runs", "label")
 
 
 def test_pg_grouped_runs_roundtrip(pg_parquet):
@@ -562,7 +562,10 @@ def _write_feature_pg_dataset(ds_dir, feature_pg_ids):
         writer.write_batch([feature])
     with PgWriter(ds_dir / "exp.pg.parquet") as writer:
         writer.write_batch([pg])
-    pg_id = derive_id([pg["anchor_protein"], pg["grouped_runs"], pg["intensities"][0]["label"]])
+    pg_id = derive_id(
+        [pg["pg_accessions"], pg["grouped_runs"], pg["intensities"][0]["label"]],
+        unordered_list_indices=(0, 1),
+    )
     return ds_dir, pg_id
 
 

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -50,7 +50,7 @@ def test_schema_identity_metadata():
     assert tuple(PsmSchema._primary_key) == ("psm_id",)
     assert tuple(PsmSchema.identity_composite) == ("peptidoform", "charge", "run_file_name", "scan")
     assert tuple(PgSchema._primary_key) == ("pg_id",)
-    assert tuple(PgSchema.identity_composite) == ("anchor_protein", "grouped_runs", "label")
+    assert tuple(PgSchema.identity_composite) == ("pg_accessions", "grouped_runs", "label")
 
 
 def test_writer_rejects_unknown_identity_composite_field(tmp_path):
@@ -114,13 +114,13 @@ def test_pg_roundtrip_derives_id(tmp_path):
 
     table = pq.read_table(path)
     ids = table.column("pg_id").to_pylist()
-    anchors = table.column("anchor_protein").to_pylist()
+    pg_accessions = table.column("pg_accessions").to_pylist()
     grouped = table.column("grouped_runs").to_pylist()
     labels = table.column("label").to_pylist()
     assert None not in ids
     assert len(set(ids)) == len(ids)
     for i, got in enumerate(ids):
-        assert got == derive_id([anchors[i], grouped[i], labels[i]])
+        assert got == derive_id([pg_accessions[i], grouped[i], labels[i]], unordered_list_indices=(0, 1))
 
 
 def test_identified_feature_id_is_derived_by_default(tmp_path):

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -165,8 +165,8 @@ def test_unidentified_feature_uses_unique_composite_fallback(tmp_path, caplog):
 
 
 @pytest.mark.parametrize("write_path", ["batch", "table"])
-def test_unidentified_feature_rejects_non_unique_composite_fallback(tmp_path, write_path):
-    """Distinct unidentified Features cannot share a fallback-derived primary key."""
+def test_unidentified_feature_warns_on_non_unique_composite_fallback(tmp_path, write_path, caplog):
+    """Distinct unidentified Features sharing a fallback PK are tolerated with a warning."""
     path = tmp_path / "duplicate-unidentified.feature.parquet"
     first = make_feature_record(sequence="", peptidoform="")
     second = make_feature_record(
@@ -175,7 +175,7 @@ def test_unidentified_feature_rejects_non_unique_composite_fallback(tmp_path, wr
         intensities=[{"label": "TMT126", "intensity": 2000.0}],
     )
 
-    with pytest.raises(ValueError, match="Unidentified Feature composite fallback was used for 2 row"):
+    with caplog.at_level(logging.WARNING):
         with FeatureWriter(path, batch_size=1) as writer:
             if write_path == "batch":
                 writer.write_batch([first, second])
@@ -183,21 +183,25 @@ def test_unidentified_feature_rejects_non_unique_composite_fallback(tmp_path, wr
                 table = writer.align_table_to_schema(pa.Table.from_pylist([first, second]))
                 writer.write_table(table)
 
+    assert path.exists()
+    assert "duplicate row" in caplog.text.lower()
 
-def test_identified_duplicate_not_attributed_to_fallback(tmp_path):
-    """A duplicate among identified Features keeps the plain PK error even when a
+
+def test_identified_duplicate_warns_without_fallback_note(tmp_path, caplog):
+    """A duplicate among identified Features warns with the plain PK message even when a
     (unique) unidentified composite-fallback row is present in the same file."""
     path = tmp_path / "mixed-duplicate.feature.parquet"
     fallback = make_feature_record(sequence="", peptidoform="")  # unique unidentified fallback
     dup_a = make_feature_record(run_file_name="run_09")
     dup_b = make_feature_record(run_file_name="run_09")  # identical composite -> duplicate PK
 
-    with pytest.raises(ValueError) as excinfo:
+    with caplog.at_level(logging.WARNING):
         with FeatureWriter(path, batch_size=10) as writer:
             writer.write_batch([fallback, dup_a, dup_b])
-    message = str(excinfo.value)
-    assert "duplicate row" in message.lower()
-    assert "Unidentified Feature composite fallback" not in message
+
+    assert path.exists()
+    assert "duplicate row" in caplog.text.lower()
+    assert "Unidentified Feature composite fallback" not in caplog.text
 
 
 def test_provided_psm_id_kept_by_default(tmp_path):
@@ -210,15 +214,18 @@ def test_provided_psm_id_kept_by_default(tmp_path):
     assert pq.read_table(path).column("psm_id").to_pylist() == [123456789]
 
 
-def test_writer_rejects_duplicate_identity_across_batches(tmp_path):
-    """Whole-file PK validation catches collisions split across writer batches."""
+def test_writer_warns_on_duplicate_identity_across_batches(tmp_path, caplog):
+    """Whole-file PK validation warns on collisions split across writer batches."""
     path = tmp_path / "duplicate.feature.parquet"
     first = make_feature_record()
     second = make_feature_record(intensities=[{"label": "TMT126", "intensity": 2000.0}])
 
-    with pytest.raises(ValueError, match=r"Primary key \(feature_id\) has 1 duplicate row"):
+    with caplog.at_level(logging.WARNING):
         with FeatureWriter(path, batch_size=1) as writer:
             writer.write_batch([first, second])
+
+    assert path.exists()
+    assert "Primary key (feature_id) has 1 duplicate row" in caplog.text
 
 
 def test_override_provided_id_stashes_to_cv_params(tmp_path):
@@ -332,15 +339,16 @@ def test_ids_agree_across_write_paths(tmp_path):
     assert len(ids) == 1
 
 
-def test_write_table_rejects_duplicate_pk(tmp_path):
-    """The table-writing path enforces primary-key uniqueness."""
+def test_write_table_warns_on_duplicate_pk(tmp_path, caplog):
+    """The table-writing path tolerates a duplicate primary key with a warning."""
     path = tmp_path / "dup_table.feature.parquet"
     r1 = make_feature_record(peptidoform="PEPTIDEK", charge=2, run_file_name="run_01")
     r2 = make_feature_record(
         peptidoform="PEPTIDEK", charge=2, run_file_name="run_01", intensities=[{"label": "TMT126", "intensity": 9.0}]
     )
-    w = FeatureWriter(path)
-    table = w.align_table_to_schema(pa.Table.from_pylist([dict(r1), dict(r2)]))
-    with pytest.raises(ValueError, match="Primary key.*duplicate"):
-        w.write_table(table)
-    assert not path.exists()
+    with caplog.at_level(logging.WARNING):
+        with FeatureWriter(path) as w:
+            table = w.align_table_to_schema(pa.Table.from_pylist([dict(r1), dict(r2)]))
+            w.write_table(table)
+    assert path.exists()
+    assert "duplicate row" in caplog.text.lower()

--- a/tests/unit/test_mudata.py
+++ b/tests/unit/test_mudata.py
@@ -525,3 +525,53 @@ def test_detect_label_field_uses_label_for_current_schema(tmp_path):
         assert mdata.mod["precursors"].X.nnz > 0
     finally:
         dataset.close()
+
+
+def test_build_mudata_feature_mapping_survives_third_modality(tmp_path):
+    """bigbio/qpx#252: ``varp['feature_mapping']`` was sized against only
+    precursors+proteins, so with a 3rd modality present the assignment raised
+    'incorrect shape' and was silently swallowed. The mapping must be built
+    against the full global var axis and be present + correct."""
+    import scipy.sparse as _sp
+
+    _write_quant_bundle(
+        tmp_path,
+        "m3",
+        [{"label": "LFQ", "intensity": 100.0}],
+        [{"label": "LFQ", "intensity": 1000.0}],
+    )
+    # 3rd modality: an absolute-expression AnnData (<prefix>.pe.h5ad) with its
+    # own var axis, disjoint names from the protein accessions.
+    expr = anndata.AnnData(
+        X=np.array([[1.0, 2.0, 3.0, 4.0]], dtype=float),
+        var=pd.DataFrame(index=["G1", "G2", "G3", "G4"]),
+    )
+    expr.write_h5ad(tmp_path / "m3.pe.h5ad")
+
+    dataset = Dataset(tmp_path, file_prefix="m3")
+    try:
+        mdata = build_mudata(dataset, modalities=["precursors", "proteins", "expression"])
+    finally:
+        dataset.close()
+
+    assert "expression" in mdata.mod, "3rd modality must be built for this regression"
+    # The axis is genuinely larger than precursors+proteins alone.
+    assert mdata.n_vars > mdata.mod["precursors"].n_vars + mdata.mod["proteins"].n_vars
+
+    assert "feature_mapping" in mdata.varp, "feature_mapping must NOT be silently dropped"
+    mapping = mdata.varp["feature_mapping"]
+    assert mapping.shape == (mdata.n_vars, mdata.n_vars)
+
+    # The PEPTIDEK|2 <-> P12345 precursor/protein link is set at the correct
+    # global positions (per-modality offsets on the global axis).
+    offsets = {}
+    running = 0
+    for name, adata in mdata.mod.items():
+        offsets[name] = running
+        running += adata.n_vars
+    prec_pos = offsets["precursors"] + list(mdata.mod["precursors"].var_names).index("PEPTIDEK|2")
+    prot_pos = offsets["proteins"] + list(mdata.mod["proteins"].var_names).index("P12345")
+    csr = _sp.csr_matrix(mapping)
+    assert csr[prec_pos, prot_pos]
+    assert csr[prot_pos, prec_pos]
+    assert csr.nnz == 2

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -19,22 +19,30 @@ from qpx.core.data.identity import derive_id
 from tests.conftest import _valid_arrays
 
 
-def _pg_table(anchor, grouped_runs, label=None):
+def _pg_table(anchor, grouped_runs, label=None, pg_accessions=None):
     """Build a minimal valid PG table, overriding only the identity columns.
 
     The primary key is the derived ``pg_id``; it is stamped here the same way
-    the writer would, from the (anchor_protein, grouped_runs, label) composite.
+    the writer would, from the ``(pg_accessions, grouped_runs, label)`` composite
+    (both list fields hashed order-independently). ``anchor_protein`` is the group
+    leader (descriptive); ``pg_accessions`` defaults to the single-member group
+    ``[anchor]`` but may be passed explicitly to model multi-protein groups (e.g.
+    two distinct groups that share a leading protein).
     """
     schema = PgSchema.get_arrow_schema()
     n = len(anchor)
     labels = label if label is not None else [None] * n
-    pg_ids = [derive_id([anchor[i], grouped_runs[i], labels[i]], unordered_list_indices=(1,)) for i in range(n)]
+    if pg_accessions is None:
+        pg_accessions = [None if a is None else [a] for a in anchor]
+    pg_ids = [derive_id([pg_accessions[i], grouped_runs[i], labels[i]], unordered_list_indices=(0, 1)) for i in range(n)]
     arrays = {}
     for f in schema:
         if f.name == "pg_id":
             arrays[f.name] = pa.array(pg_ids, type=f.type)
         elif f.name == "anchor_protein":
             arrays[f.name] = pa.array(anchor, type=f.type)
+        elif f.name == "pg_accessions":
+            arrays[f.name] = pa.array(pg_accessions, type=f.type)
         elif f.name == "grouped_runs":
             arrays[f.name] = pa.array(grouped_runs, type=f.type)
         elif f.name == "label":
@@ -109,6 +117,36 @@ def test_duplicate_run_within_one_group_is_not_reported_as_cross_row_double_coun
 
     assert any(issue.check == "duplicate_grouped_run" for issue in result.issues)
     assert not any(issue.check == "run_double_count" for issue in result.issues)
+
+
+def test_distinct_groups_sharing_leader_are_not_a_run_double_count():
+    """Two DIFFERENT groups that share a leading protein (same anchor) but have
+    different membership are distinct pg rows; overlapping grouped_runs must NOT
+    be flagged as a double-count — the check keys on full pg_accessions."""
+    table = _pg_table(
+        anchor=["P1", "P1"],
+        pg_accessions=[["P1", "P2"], ["P1", "P3"]],
+        grouped_runs=[["r1"], ["r1"]],
+        label=["LFQ", "LFQ"],
+    )
+    # Distinct membership -> distinct pg_id, so no duplicate PK either.
+    assert len(set(table.column("pg_id").to_pylist())) == 2
+    result = PgSchema.validate_full(table, strict=True)
+    assert not any(issue.check == "run_double_count" for issue in result.issues)
+    assert not any(issue.check == "duplicate_pk" for issue in result.issues)
+
+
+def test_same_group_overlapping_runs_is_a_run_double_count():
+    """The SAME group (same pg_accessions + label) measured over overlapping
+    run sets double-counts its intensity and must be flagged."""
+    table = _pg_table(
+        anchor=["P1", "P1"],
+        pg_accessions=[["P1", "P2"], ["P1", "P2"]],
+        grouped_runs=[["r1", "r2"], ["r2", "r3"]],
+        label=["LFQ", "LFQ"],
+    )
+    result = PgSchema.validate_full(table, strict=True)
+    assert any(issue.check == "run_double_count" for issue in result.issues)
 
 
 def test_validation_result_dataclass():

--- a/tests/unit/test_writers.py
+++ b/tests/unit/test_writers.py
@@ -190,3 +190,61 @@ def test_writer_compression(tmp_path):
     with FeatureWriter(path2, compression="snappy") as w:
         w.write_batch([make_feature_record()])
     assert read_parquet_metadata(path2)["compression_format"] == "snappy"
+
+
+def test_pg_write_batch_warns_on_run_double_count(tmp_path, caplog):
+    """bigbio/qpx#242: the streaming write_batch path must run the pg
+    run-disjointness / referential check at close() (as a warning), not skip it.
+
+    Two pg rows sharing the same (pg_accessions, label) with an overlapping
+    grouped_runs double-count that run's intensity.
+    """
+    import logging
+
+    path = tmp_path / "dup.pg.parquet"
+    rec_a = make_pg_record(run_file_name="run_01")
+    rec_b = make_pg_record(run_file_name="run_01")  # same members + label + run
+    with caplog.at_level(logging.WARNING, logger="qpx.writers.base"):
+        with PgWriter(path) as w:
+            w.write_batch([rec_a, rec_b])
+    assert path.exists()
+    assert any("run_double_count" in rec.message for rec in caplog.records), (
+        "streaming write_batch should warn on cross-row run double-count at close"
+    )
+
+
+def test_pg_write_batch_clean_has_no_referential_warning(tmp_path, caplog):
+    """Disjoint grouped_runs across rows must NOT trigger the referential warning."""
+    import logging
+
+    path = tmp_path / "ok.pg.parquet"
+    rec_a = make_pg_record(run_file_name="run_01")
+    rec_b = make_pg_record(run_file_name="run_02")  # disjoint runs
+    with caplog.at_level(logging.WARNING, logger="qpx.writers.base"):
+        with PgWriter(path) as w:
+            w.write_batch([rec_a, rec_b])
+    assert not any("run_double_count" in rec.message for rec in caplog.records)
+
+
+def test_pg_write_dataframe_explodes_intensities(tmp_path):
+    """bigbio/qpx#252: PgWriter.write_dataframe must explode the natural
+    ``intensities`` list into flat label/intensity rows instead of silently
+    dropping quant (the base write_dataframe builds against the flat schema,
+    which has no ``intensities`` column)."""
+    import pandas as pd
+
+    rec = make_pg_record(
+        intensities=[
+            {"label": "TMT126", "intensity": 5000.0},
+            {"label": "TMT127N", "intensity": 6000.0},
+        ]
+    )
+    df = pd.DataFrame([rec])
+    path = tmp_path / "df.pg.parquet"
+    with PgWriter(path) as w:
+        w.write_dataframe(df)
+
+    table = pq.read_table(path)
+    assert table.num_rows == 2, "intensities list should explode into one row per label"
+    assert set(table.column("label").to_pylist()) == {"TMT126", "TMT127N"}
+    assert set(table.column("intensity").to_pylist()) == {5000.0, 6000.0}


### PR DESCRIPTION
## Bug

DIA-NN protein-group (`pg`) conversion produced **duplicate `pg_id` primary keys**, tripping the strict close-time validator added in qpx 1.1.1:

```
ValueError: Primary key (pg_id) has 20 duplicate row(s) (6350 unique out of 6370)
```

Reported by **quantmsdiann** on qpx 1.1.1 (dataset PXD026600) via `qpxc convert diann ... --pg-matrix-path ...`. On qpx 1.0.2 there was no `pg_id` uniqueness validation, so the collision passed silently — a latent bug now enforced.

## Root cause

The pg identity was `identity_composite: [anchor_protein, grouped_runs, label]` — keyed on the group **leader** only (`anchor_protein = pg_accessions[0]`). That is wrong on two counts:

1. **Two genuinely distinct protein groups that share a leading protein** (e.g. `P1;P2` and `P1;P3`) collapse to the **same** `pg_id`.
2. In `qpx/converters/diann/pg_adapter.py`, `_process_batch` grouped the report on `["pg_accessions", "pg_names", "gg_accessions", "run_file_name"]`. When DIA-NN emits **inconsistent `Protein.Names`/`Genes` across a group's precursor rows**, that groupby splits one group into multiple records sharing `(anchor_protein, grouped_runs, label)` → identical `pg_id`.

## Fix (schema + identity layer — converter-agnostic)

- **`qpx/core/data/schemas/pg.yaml`** (+ docs mirror): `identity_composite` → `[pg_accessions, grouped_runs, label]`. The **full group membership** keys `pg_id`. `anchor_protein` stays a descriptive field (still used for feature→pg joins).
- **`qpx/writers/base.py`**: hash `pg_accessions` **order-independently** (same mechanism already used for `grouped_runs`), so member order doesn't change the id. The existing `derive_id`/`canonical` hasher already JSON-normalizes list-typed composite fields, so no new hashing machinery was needed — only marking `pg_accessions` as an unordered list field.
- **`qpx/core/data/schema.py`**: align the run-disjointness validator (`run_double_count`) to key on the canonical `pg_accessions` membership instead of `anchor_protein`, so two distinct groups sharing a leader are not conflated into a false double-count (while a genuine same-group overlap is still flagged).
- **`qpx/converters/diann/pg_adapter.py`**: group per `(pg_accessions, run_file_name)` only and derive `pg_names`/`gg_accessions` within the group (first non-null), so annotation noise no longer emits duplicate-identity rows.

Because the fix is in the schema/identity layer, it corrects **DIA-NN, openms-consensus, fragpipe and maxquant** pg producers at once. In particular it also closes the previously-noted latent openms-consensus risk (indistinguishable groups `[A,B]`/`[A,C]` sharing leader `A`).

## Tests

- DIA-NN: distinct groups sharing a leader get **distinct** `pg_id`s; a single group with inconsistent annotations collapses to **one** row.
- Validation: the disjointness check no longer false-positives on shared leaders, but still flags a genuine same-`pg_accessions` overlapping-run double-count.
- Identity/roundtrip/cross-ref tests updated to derive `pg_id` from `pg_accessions`.
- Full suite: **878 passed**; ruff clean.

## Versioning / downstream

This **changes derived `pg_id` values**, so pg files must be regenerated. `QPX_SPEC_VERSION` is left at `1.1` here — whether this ships as **1.1.2** (package patch) or warrants a spec/minor bump (**1.2.0**) is flagged for the maintainer to decide (changelog note added in `docs/spec/versioning.md`).

**quantmsdiann must re-pin** to the released version, and **quantms (openms-consensus)** consumers should regenerate pg files too.