### PR TITLE
fix(mzidentml): honour nativeID scheme for spectra attach; drop [0] sentinel; copy shared mods

### DIFF
--- a/qpx/converters/mzidentml/converter.py
+++ b/qpx/converters/mzidentml/converter.py
@@ -154,15 +154,22 @@ class MzIdentMLConverter(BaseOrchestrator):
             scans = rec.get("scan") or []
             if not scans:
                 continue
-            scan = scans[0]
-            spectrum = mgf_index.get_spectrum(scan)
-            if spectrum is None:
-                # Fallback: try 0-based index lookup
-                spectrum = mgf_index.get_spectrum_by_index(scan)
+            value = scans[0]
+            # Honour the nativeID scheme: an ``index=`` value is a 0-based file
+            # position, NOT a scan number. Looking it up by scan number would
+            # match an unrelated spectrum whose ``SCANS=`` equals the index and
+            # attach the wrong peaks/RT. A ``scan=`` value must never be treated
+            # as an index either — use the lookup that matches the scheme only.
+            scheme = rec.get("_spectrum_id_scheme")
+            if scheme == "index":
+                spectrum = mgf_index.get_spectrum_by_index(value)
                 if spectrum is not None:
                     matched_by_index += 1
             else:
-                matched_by_scan += 1
+                # "scan" (or a legacy record without a recorded scheme)
+                spectrum = mgf_index.get_spectrum(value)
+                if spectrum is not None:
+                    matched_by_scan += 1
 
             if spectrum is not None:
                 rec["mz_array"] = spectrum["mz_array"]

--- a/qpx/converters/mzidentml/psm_adapter.py
+++ b/qpx/converters/mzidentml/psm_adapter.py
@@ -8,6 +8,7 @@ crosslinking modifications (``crosslink donor``, ``crosslink acceptor``).
 
 from __future__ import annotations
 
+import copy
 import gzip
 import logging
 import re
@@ -329,7 +330,7 @@ class MzIdentMLPsmAdapter(BaseConverter):
 
         records = []
         for sir in spectrum_results:
-            scan = _parse_scan(sir["spectrum_id"])
+            scan, scan_scheme = _parse_native_id(sir["spectrum_id"])
             run_file = spectra_data.get(sir["spectra_data_ref"], "unknown")
             rt = sir.get("rt")
             siis = sir["siis"]
@@ -349,6 +350,10 @@ class MzIdentMLPsmAdapter(BaseConverter):
                     rt=rt,
                 )
                 if record is not None:
+                    # Transient hint (dropped by the writer) telling
+                    # ``_attach_spectra`` whether ``scan`` is an acquisition scan
+                    # number or a 0-based file index, so it fetches by the right key.
+                    record["_spectrum_id_scheme"] = scan_scheme
                     records.append(record)
 
         return records
@@ -409,9 +414,13 @@ class MzIdentMLPsmAdapter(BaseConverter):
         # Build peptidoform from sequence and parsed modifications
         peptidoform = _build_peptidoform(sequence, alpha_pep.get("modifications"))
 
-        # Enrich modifications with site localization scores from SII cvParams
+        # Enrich modifications with site localization scores from SII cvParams.
+        # ``alpha_pep["modifications"]`` is shared by every PSM that references
+        # this Peptide id, and site-localization scoring mutates positions in
+        # place — deep-copy first so PSMs sharing a peptide_ref do not accumulate
+        # each other's phosphoRS/Ascore values.
         modifications = _attach_site_localization_scores(
-            alpha_pep.get("modifications"),
+            copy.deepcopy(alpha_pep.get("modifications")),
             alpha_sii["cv_params"],
         )
 
@@ -654,20 +663,47 @@ def _source_sii_identity(run_file: str, alpha_sii: dict, beta_sii: dict | None) 
     return derive_id([run_file, source_ids]), cv_params
 
 
-def _parse_scan(spectrum_id: str) -> list[int]:
-    """Extract scan number(s) from mzIdentML spectrumID string.
+def _parse_native_id(spectrum_id: str) -> tuple[list[int], str | None]:
+    """Extract the numeric spectrum reference and its nativeID scheme.
 
-    Handles formats: ``scan=100``, ``index=7483``, ``spectrum=5``.
-    Falls back to 0 if no numeric value is found.
+    Returns ``(values, scheme)`` where ``scheme`` is one of:
+
+    * ``"scan"``  — the value is an acquisition scan number
+      (``scan=N``, ``spectrum=N``, or a bare integer);
+    * ``"index"`` — the value is a 0-based position in the spectrum file
+      (``index=N``). This is NOT a scan number: it must be looked up by
+      position, never by scan number, or peaks/RT from an unrelated spectrum
+      whose ``SCANS=`` happens to equal the index get attached;
+    * ``None``    — no numeric reference could be parsed.
+
+    The scheme is what lets spectra attachment fetch the CORRECT spectrum.
     """
-    m = re.search(r"(?:scan|index|spectrum)=(\d+)", spectrum_id)
+    m = re.search(r"scan=(\d+)", spectrum_id)
     if m:
-        return [int(m.group(1))]
-    # Try bare integer
+        return [int(m.group(1))], "scan"
+    m = re.search(r"index=(\d+)", spectrum_id)
+    if m:
+        return [int(m.group(1))], "index"
+    m = re.search(r"spectrum=(\d+)", spectrum_id)
+    if m:
+        return [int(m.group(1))], "scan"
+    # Bare integer spectrumID — historically treated as a scan number.
     m = re.match(r"^(\d+)$", spectrum_id.strip())
     if m:
-        return [int(m.group(1))]
-    return [0]
+        return [int(m.group(1))], "scan"
+    # Unparseable: return an empty marker (NOT ``[0]``) so a spectrum with no
+    # parseable id does not alias onto a real scan-0 spectrum, and two distinct
+    # unparseable spectra are not silently collapsed onto the same sentinel.
+    return [], None
+
+
+def _parse_scan(spectrum_id: str) -> list[int]:
+    """Return the scan/index value(s) from a spectrumID, without the scheme.
+
+    Prefer :func:`_parse_native_id` when the nativeID scheme matters (e.g. to
+    attach the correct spectrum). Returns an empty list when nothing parses.
+    """
+    return _parse_native_id(spectrum_id)[0]
 
 
 def _group_siis(siis: list[dict]) -> list[dict]:

--- a/tests/converters/test_mzidentml_converter.py
+++ b/tests/converters/test_mzidentml_converter.py
@@ -11,6 +11,7 @@ import pyarrow.parquet as pq
 from qpx.converters.mzidentml.psm_adapter import (
     MzIdentMLPsmAdapter,
     _group_siis,
+    _parse_native_id,
     _parse_scan,
 )
 
@@ -51,7 +52,33 @@ class TestParseScan:
         assert _parse_scan("42") == [42]
 
     def test_unknown_format(self):
-        assert _parse_scan("something_else") == [0]
+        # Unparseable spectrumIDs must NOT collapse onto a ``[0]`` sentinel
+        # (which aliases distinct spectra and a real scan-0 spectrum).
+        assert _parse_scan("something_else") == []
+
+
+class TestParseNativeId:
+    """The nativeID scheme distinguishes scan numbers from file indices (#249)."""
+
+    def test_scan_is_scan_scheme(self):
+        assert _parse_native_id("scan=100") == ([100], "scan")
+
+    def test_index_is_index_scheme(self):
+        # The regression: ``index=`` is a file position, not a scan number.
+        assert _parse_native_id("index=1999") == ([1999], "index")
+
+    def test_spectrum_is_scan_scheme(self):
+        assert _parse_native_id("spectrum=5") == ([5], "scan")
+
+    def test_bare_integer_is_scan_scheme(self):
+        assert _parse_native_id("42") == ([42], "scan")
+
+    def test_mzml_nativeid_scan(self):
+        assert _parse_native_id("controllerType=0 controllerNumber=1 scan=7") == ([7], "scan")
+
+    def test_unparseable_is_empty_none(self):
+        # No ``[0]`` sentinel: distinct unparseable spectra must not alias.
+        assert _parse_native_id("something_else") == ([], None)
 
 
 class TestGroupSiis:
@@ -517,3 +544,105 @@ class TestMzIdentMLProvenanceParams:
         var_mods = [p for p in params if p["key"] == "variable_mod"]
         assert var_mods, f"No 'variable_mod' entries in parameters: {params}"
         assert any("Oxidation" in p["value"] for p in var_mods), f"Expected Oxidation in variable_mod entries: {var_mods}"
+
+
+# ---------------------------------------------------------------------------
+# Shared-modifications mutation (bigbio/qpx#249)
+# ---------------------------------------------------------------------------
+
+
+class TestSharedModificationsNoCrossContamination:
+    """PSMs that share a ``peptide_ref`` must not accumulate each other's
+    site-localization scores.
+
+    The Peptide's ``modifications`` list is shared by every SII that references
+    it, and site-localization scoring mutates modification positions in place.
+    Without a per-PSM copy, the second PSM inherits the first PSM's phosphoRS
+    score, corrupting localization data.
+    """
+
+    @staticmethod
+    def _phospho_mod():
+        return [
+            {
+                "name": "Phospho",
+                "accession": "UNIMOD:21",
+                "positions": [{"position": 4, "amino_acid": "T", "scores": None}],
+            }
+        ]
+
+    @staticmethod
+    def _sii(sii_id, site_prob):
+        # MS:1001969 == phosphoRS site probability (a site-localization cvParam).
+        return {
+            "id": sii_id,
+            "charge": 2,
+            "exp_mz": 500.0,
+            "calc_mz": 500.0,
+            "rank": 1,
+            "pass_threshold": True,
+            "peptide_ref": "SharedPep",
+            "cv_params": [
+                {
+                    "accession": "MS:1001969",
+                    "name": "phosphoRS site probability",
+                    "value": f"T4: {site_prob}",
+                }
+            ],
+            "peptide_evidence_refs": [],
+        }
+
+    def _parsed(self):
+        return {
+            "spectra_data": {"SD1": "run.mgf"},
+            "db_sequences": {},
+            "peptides": {
+                "SharedPep": {
+                    "sequence": "PEPTIDE",
+                    "modifications": self._phospho_mod(),
+                    "xl_mods": {},
+                }
+            },
+            "peptide_evidence": {},
+            "linker_info": {},
+            "spectrum_results": [
+                {
+                    "spectrum_id": "index=1",
+                    "spectra_data_ref": "SD1",
+                    "rt": None,
+                    "siis": [self._sii("SII_1", 99.0)],
+                },
+                {
+                    "spectrum_id": "index=2",
+                    "spectra_data_ref": "SD1",
+                    "rt": None,
+                    "siis": [self._sii("SII_2", 10.0)],
+                },
+            ],
+        }
+
+    def test_each_psm_keeps_only_its_own_score(self):
+        parsed = self._parsed()
+        with MzIdentMLPsmAdapter() as adapter:
+            records = adapter._build_psm_records(parsed)
+
+        assert len(records) == 2
+        scores_per_psm = [rec["modifications"][0]["positions"][0]["scores"] for rec in records]
+
+        # Each PSM carries exactly ONE site-localization score — its own.
+        for scores in scores_per_psm:
+            assert scores is not None
+            assert len(scores) == 1
+
+        values = sorted(scores[0]["score_value"] for scores in scores_per_psm)
+        assert values == [10.0, 99.0]
+
+    def test_shared_source_modifications_untouched(self):
+        parsed = self._parsed()
+        shared = parsed["peptides"]["SharedPep"]["modifications"]
+        with MzIdentMLPsmAdapter() as adapter:
+            adapter._build_psm_records(parsed)
+
+        # The Peptide's shared modification list must remain pristine — scoring
+        # happened on per-PSM copies, not on this source object.
+        assert shared[0]["positions"][0]["scores"] is None

--- a/tests/converters/test_mzidentml_full_converter.py
+++ b/tests/converters/test_mzidentml_full_converter.py
@@ -267,27 +267,100 @@ class TestPXD054720WithSpectra:
 
 
 class TestIndexFallback:
-    """Test that spectra attachment falls back to index when scan doesn't match."""
+    """Spectra attachment must use the nativeID scheme to pick the right lookup."""
 
-    def test_fallback_to_index(self, tmp_path):
-        """When scan-based lookup fails, should try index-based lookup."""
-        # Create MGF where SCANS= doesn't match mzIdentML scan numbers
-        # but the 0-based index does
+    def test_index_scheme_uses_position_lookup(self, tmp_path):
+        """``index=`` records attach by 0-based file position, not by SCANS=."""
+        # MGF where SCANS= deliberately does NOT match the index values, so a
+        # scan-number lookup would either miss or (worse) match the wrong
+        # spectrum. Only a position-based lookup gives the correct peaks.
         mgf = tmp_path / "test.mgf"
         mgf.write_text(
             "BEGIN IONS\nTITLE=first\nSCANS=999\n100.0 500\nEND IONS\nBEGIN IONS\nTITLE=second\nSCANS=998\n200.0 600\nEND IONS\n"
         )
 
-        # PSM records with scan=[0] and scan=[1] -- don't match SCANS=999/998
-        # but DO match 0-based position
         records = [
-            {"scan": [0], "mz_array": None, "intensity_array": None, "rt": None},
-            {"scan": [1], "mz_array": None, "intensity_array": None, "rt": None},
+            {"scan": [0], "_spectrum_id_scheme": "index", "mz_array": None, "intensity_array": None, "rt": None},
+            {"scan": [1], "_spectrum_id_scheme": "index", "mz_array": None, "intensity_array": None, "rt": None},
         ]
 
         result = MzIdentMLConverter._attach_spectra(records, str(mgf))
-        assert result[0]["mz_array"] == [100.0]  # matched by index 0
-        assert result[1]["mz_array"] == [200.0]  # matched by index 1
+        assert result[0]["mz_array"] == [100.0]  # position 0
+        assert result[1]["mz_array"] == [200.0]  # position 1
+
+    def test_index_value_not_attached_by_scan(self, tmp_path):
+        """An ``index=`` value must never be attached via a colliding SCANS=.
+
+        Regression for bigbio/qpx#249: index 999 collides with SCANS=999 of an
+        UNRELATED spectrum; the old scan-first lookup attached those wrong peaks.
+        """
+        # Spectrum at position 0 carries SCANS=999; the correct spectrum for
+        # index=999 does not exist in this tiny MGF, so nothing must attach.
+        mgf = tmp_path / "collide.mgf"
+        mgf.write_text("BEGIN IONS\nTITLE=first\nSCANS=999\n100.0 500\nEND IONS\n")
+
+        records = [
+            {"scan": [999], "_spectrum_id_scheme": "index", "mz_array": None, "intensity_array": None, "rt": None},
+        ]
+
+        result = MzIdentMLConverter._attach_spectra(records, str(mgf))
+        # No spectrum at position 999 → nothing attached (NOT the SCANS=999 peaks).
+        assert result[0]["mz_array"] is None
+
+    def test_index_file_attaches_correct_spectrum_end_to_end(self, tmp_path):
+        """A PSM whose ``spectrumID`` is ``index=N`` attaches the peaks of the
+        Nth spectrum, even when an unrelated spectrum carries ``SCANS=N``.
+
+        End-to-end: the scheme is derived from the ``index=`` spectrumID by the
+        adapter, then honoured by ``_attach_spectra``. Regression for
+        bigbio/qpx#249 (the old scan-first lookup attached the SCANS-colliding
+        spectrum's peaks instead).
+        """
+        from qpx.converters.mzidentml.psm_adapter import MzIdentMLPsmAdapter
+
+        # Position 0 is a decoy whose SCANS collides with the target index (1);
+        # position 1 is the CORRECT spectrum for ``index=1``.
+        mgf = tmp_path / "e2e.mgf"
+        mgf.write_text(
+            "BEGIN IONS\nTITLE=decoy\nSCANS=1\n100.0 500\nEND IONS\nBEGIN IONS\nTITLE=target\nSCANS=42\n200.0 600\nEND IONS\n"
+        )
+
+        parsed = {
+            "spectra_data": {"SD1": "e2e.mgf"},
+            "db_sequences": {},
+            "peptides": {"Pep1": {"sequence": "PEPTIDE", "modifications": None, "xl_mods": {}}},
+            "peptide_evidence": {},
+            "linker_info": {},
+            "spectrum_results": [
+                {
+                    "spectrum_id": "index=1",  # the 2nd spectrum (position 1)
+                    "spectra_data_ref": "SD1",
+                    "rt": None,
+                    "siis": [
+                        {
+                            "id": "SII_1",
+                            "charge": 2,
+                            "exp_mz": 500.0,
+                            "calc_mz": 500.0,
+                            "rank": 1,
+                            "pass_threshold": True,
+                            "peptide_ref": "Pep1",
+                            "cv_params": [],
+                            "peptide_evidence_refs": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        with MzIdentMLPsmAdapter() as adapter:
+            records = adapter._build_psm_records(parsed)
+        assert records[0]["_spectrum_id_scheme"] == "index"
+
+        result = MzIdentMLConverter._attach_spectra(records, str(mgf))
+        # Correct spectrum is position 1 (200.0), NOT the SCANS=1 collision (100.0).
+        assert result[0]["mz_array"] == [200.0]
+        assert result[0]["intensity_array"] == [600.0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes three mzIdentML converter bugs from the pre-release audit (#249). Library-only paths; not on either quantms pipeline.

### 1. HIGH — `index=` spectrumIDs attached the wrong spectrum
`_parse_scan` collapsed `scan=`/`index=`/`spectrum=` into one int stored as `scan`, and `_attach_spectra` tried a scan-number lookup first with an index-based fallback. For files using `spectrumID="index=N"` (e.g. PXD054720), `N` is a **file position**, not a scan number — so when some MGF spectrum carried `SCANS=N`, its peaks/RT were attached to the wrong PSM.

- New `_parse_native_id()` returns `(values, scheme)` where `scheme ∈ {"scan", "index", None}`.
- The scheme rides on each record as a transient `_spectrum_id_scheme` hint (dropped by the writer via the schema projection).
- `_attach_spectra` now looks up `index=` values **by position only** and `scan=` values **by scan number only** — never cross-scheme, so a colliding `SCANS=` can no longer attach the wrong peaks.

### 2. MED — `scan=[0]` sentinel collapsed distinct unparseable spectra
Unparseable spectrumIDs returned `[0]`, aliasing distinct spectra (and a real scan-0 spectrum) onto the same value. Now returns an empty `([], None)` marker — unambiguous, and `_attach_spectra` already skips empty scans.

### 3. MED — shared `modifications` list mutated across PSMs
A Peptide's `modifications` list is shared by every SII referencing it, and site-localization scoring mutates positions in place. PSMs sharing a `peptide_ref` accumulated each other's phosphoRS/Ascore values. Fixed by deep-copying the mods per PSM before scoring; the source list stays pristine.

## Tests

- `TestParseNativeId` — scheme classification for `scan=`/`index=`/`spectrum=`/bare-int/mzML-nativeID/unparseable.
- `test_index_file_attaches_correct_spectrum_end_to_end` — an `index=` PSM attaches the Nth spectrum's peaks even when an unrelated spectrum carries a colliding `SCANS=`.
- `test_index_value_not_attached_by_scan` — an `index=` value never attaches via a colliding `SCANS=`.
- `TestSharedModificationsNoCrossContamination` — PSMs sharing a `peptide_ref` keep only their own localization score; the shared source list is untouched.
- Updated two existing tests that encoded the old (buggy) `[0]`-sentinel and scan-first-fallback behaviour.

`ruff check` + `ruff format` clean. Full suite: **888 passed**.

Closes #249
