### PR TITLE
Fix/mzidentml converter

### DIFF
--- a/docs/spec/data-model.md
+++ b/docs/spec/data-model.md
@@ -27,7 +27,7 @@ Define these once; the rest of the spec uses them consistently.
 | **label** | The **canonical name of a channel** (`LFQ`, `TMT126`, `iTRAQ114`, …). This is the string that ties a quantity to a sample. For LFQ there is exactly one label, `"LFQ"`. For TMT/iTRAQ/plexDIA each channel is a distinct label mapping to a distinct sample. | `run.samples[].label`, `feature.intensities[].label`, `pg.label` |
 | **fraction** | A fractionated portion of one sample. Fractions of one sample share the same (source, biological replicate, technical replicate) and differ **only** in `run.fraction`. Each fraction is a separate run/raw file. | `run.fraction` |
 | **grouped_runs** | The **set of raw files aggregated into one quantification unit** — the fractions of one sample+channel context, aggregated together. `list<string>` of `run_file_name`. Single-element for unfractionated or DIA data. | `pg.grouped_runs` |
-| **quantification unit** | The thing a protein quantity is measured *over*: one `grouped_runs` set. A protein abundance exists per quantification unit, **not** per single raw file, because a protein quantity only emerges after aggregating its peptides across the sample's fractions. | `pg` (one row per `(anchor_protein, grouped_runs, label)`) |
+| **quantification unit** | The thing a protein quantity is measured *over*: one `grouped_runs` set. A protein abundance exists per quantification unit, **not** per single raw file, because a protein quantity only emerges after aggregating its peptides across the sample's fractions. | `pg` (one row per `(pg_accessions, grouped_runs, label)`) |
 | **peptidoform** | Peptide sequence + modifications in ProForma notation. The identity thread linking PSM ↔ feature ↔ pepmap. | `psm`, `feature`, `pepmap` |
 | **entity ID** | Mandatory opaque primary key for a PSM, Feature, or protein-group row: `psm_id`, `feature_id`, or `pg_id`. It may be supplied by the producer or derived by QPX from the file's footer-declared `identity_composite`. | `psm`, `feature`, `pg` |
 | **anchor_protein** | The representative (leading) protein of a protein group. On `feature` it is an annotation used for semantic protein mapping; an explicit Feature-to-PG link uses `feature.pg_ids[]` → `pg.pg_id`. On `pg` it participates in the default identity composite. | `feature`, `pg` |
@@ -67,7 +67,7 @@ graph LR
   override for their producer's Feature entity. Covers DDA **and** DIA.
 - **pg** — a protein group quantified over one **quantification unit**
   (`grouped_runs`) for one **label**. PK `pg_id`; schema-default identity
-  composite `[anchor_protein, grouped_runs, label]`. There is **one row per
+  composite `[pg_accessions, grouped_runs, label]`. There is **one row per
   label** (flattened since QPX 1.1).
 
 !!! note "Granularity shifts at each step"
@@ -213,7 +213,7 @@ graph TD
 
 !!! note "Fractionated TMT combines both"
     Fractionated TMT has `grouped_runs` with several files **and** N labels: one
-    pg row per `(anchor_protein, grouped_runs, label)` — the fractions collapse
+    pg row per `(pg_accessions, grouped_runs, label)` — the fractions collapse
     into the set, the channels stay as separate rows.
 
 ## Label / channel → sample resolution

--- a/docs/spec/intensities.md
+++ b/docs/spec/intensities.md
@@ -126,7 +126,7 @@ additional_intensities: array[struct{
     The `intensities: list<{label, intensity}>` struct on this page describes the
     **feature** view. Since QPX 1.1 the protein-group view is **flattened**: each
     row carries scalar `label` + `intensity` columns and there is one row per
-    `(anchor_protein, grouped_runs, label)`. `label`/`intensity` are null for
+    `(pg_accessions, grouped_runs, label)`. `label`/`intensity` are null for
     identification-only groups. See [Protein Group](pg.md) and the
     [Data Model](data-model.md).
 

--- a/docs/spec/pg.md
+++ b/docs/spec/pg.md
@@ -14,7 +14,7 @@ This view is analogous to outputs from tools such as MaxQuant (`proteinGroups.tx
 ## Schema
 
 `pg_id` is the non-null primary key. The schema-default `identity_composite` is
-`[anchor_protein, grouped_runs, label]`; `label` is null only for
+`[pg_accessions, grouped_runs, label]`; `label` is null only for
 identification-only protein groups that carry no quantity. Fields marked with
 **(nullable)** may have null values. See the full YAML schema in
 [`pg.yaml`](schemas/pg.yaml).
@@ -68,7 +68,7 @@ identification-only protein groups that carry no quantity. Fields marked with
 | `additional_intensities` | Pre-computed intensity values from the upstream tool (normalized, LFQ, iBAQ, etc.) for this row's label. See [Intensities](intensities.md) | `array[struct]` | No |
 | `additional_scores` | Additional scores and metrics (posterior error probability, confidence, etc.). See [Scores](scores.md) | `array[struct]` | No |
 
-Since QPX 1.1 the protein-group quantification is **flattened**: instead of an `intensities` list, each row carries a scalar `label` + `intensity`, so there is one row per `(anchor_protein, grouped_runs, label)`. Identification-only groups (no quantity) have null `label`/`intensity`.
+Since QPX 1.1 the protein-group quantification is **flattened**: instead of an `intensities` list, each row carries a scalar `label` + `intensity`, so there is one row per `(pg_accessions, grouped_runs, label)`. Identification-only groups (no quantity) have null `label`/`intensity`.
 
 Each entry in `additional_intensities` contains:
 

--- a/docs/spec/schemas/pg.yaml
+++ b/docs/spec/schemas/pg.yaml
@@ -1,7 +1,7 @@
 name: pg
 file_type: pg_file
 primary_key: [pg_id]
-identity_composite: [anchor_protein, grouped_runs, label]
+identity_composite: [pg_accessions, grouped_runs, label]
 doc: "Protein groups with per-quantification-unit quantification (one row per label; label/intensity flattened from the old intensities list)"
 
 fields:
@@ -16,7 +16,7 @@ fields:
   pg_accessions:
     type: "list<string>"
     required: true
-    doc: "Protein accessions within this group"
+    doc: "Protein accessions within this group. Part of the default identity composite: the FULL group membership (not just the leader) keys the pg_id, so two distinct groups that happen to share a leading protein get distinct ids. Hashed order-independently (membership is a set)."
   pg_names:
     type: "list<string>"
     doc: "Protein group names"
@@ -33,7 +33,7 @@ fields:
   anchor_protein:
     type: string
     required: true
-    doc: "Anchor/leading protein of the group"
+    doc: "Anchor/leading protein of the group (the representative used for feature->pg joins). Descriptive only — NOT part of the pg_id identity, which keys on the full pg_accessions membership."
 
   # Quantification-unit context
   grouped_runs:

--- a/docs/spec/versioning.md
+++ b/docs/spec/versioning.md
@@ -52,17 +52,28 @@ This version defines all core serialized views (PSM, Feature, PG, MZ), the deriv
 
 ### Changelog
 
-- **PG identity now keys on full group membership** (backward-incompatible for
-  `pg_id` values): the PG schema-default `identity_composite` changed from
-  `[anchor_protein, grouped_runs, label]` to `[pg_accessions, grouped_runs, label]`.
-  Keying on only the group **leader** (`anchor_protein`) gave two genuinely distinct
-  protein groups that share a leading protein the **same** `pg_id`, and split a
-  single group with inconsistent per-precursor annotations into duplicate-identity
-  rows. The identity now hashes the full `pg_accessions` membership
-  (order-independently, like `grouped_runs`), so distinct groups get distinct ids.
-  `anchor_protein` remains a descriptive field. This changes derived `pg_id`
-  values, so pg files must be regenerated. (Whether this ships as a spec-version
-  bump is deferred to the maintainer; `QPX_SPEC_VERSION` is unchanged here.)
+- **1.1.2** (on-disk spec version stays `1.1`): two related fixes to identity
+  handling.
+    - **PG identity now keys on full group membership** (backward-incompatible for
+      `pg_id` values): the PG schema-default `identity_composite` changed from
+      `[anchor_protein, grouped_runs, label]` to
+      `[pg_accessions, grouped_runs, label]`. Keying on only the group **leader**
+      (`anchor_protein`) gave two genuinely distinct protein groups that share a
+      leading protein the **same** `pg_id`, and split a single group with
+      inconsistent per-precursor annotations into duplicate-identity rows. The
+      identity now hashes the full `pg_accessions` membership (order-independently,
+      like `grouped_runs`), so distinct groups get distinct ids. `anchor_protein`
+      remains a descriptive field.
+    - **Duplicate primary keys on the write/convert path are now a warning, not a
+      hard error.** While the format stabilises, writers and converters persist
+      source data as-produced and log a warning on a duplicate identity id rather
+      than crashing (a duplicate usually signals a converter identity bug worth
+      investigating). A **NULL primary key remains a fatal error**, and
+      `qpxc validate --strict` (the audit/CI path) still reports a duplicate
+      primary key as an **error**.
+    - **No in-place migration.** These changes affect derived `pg_id` values and
+      identity handling; regenerate qpx files by **re-converting from the original
+      source files** — there is no on-disk migration.
 - **1.1** (backward-incompatible, pre-2.0 stabilisation): the PG view now keys on
   `grouped_runs` (`list<string>`) instead of the scalar `run_file_name`. A
   protein-group quantity applies to the set of raw files (fractions) aggregated

--- a/docs/spec/versioning.md
+++ b/docs/spec/versioning.md
@@ -52,6 +52,17 @@ This version defines all core serialized views (PSM, Feature, PG, MZ), the deriv
 
 ### Changelog
 
+- **PG identity now keys on full group membership** (backward-incompatible for
+  `pg_id` values): the PG schema-default `identity_composite` changed from
+  `[anchor_protein, grouped_runs, label]` to `[pg_accessions, grouped_runs, label]`.
+  Keying on only the group **leader** (`anchor_protein`) gave two genuinely distinct
+  protein groups that share a leading protein the **same** `pg_id`, and split a
+  single group with inconsistent per-precursor annotations into duplicate-identity
+  rows. The identity now hashes the full `pg_accessions` membership
+  (order-independently, like `grouped_runs`), so distinct groups get distinct ids.
+  `anchor_protein` remains a descriptive field. This changes derived `pg_id`
+  values, so pg files must be regenerated. (Whether this ships as a spec-version
+  bump is deferred to the maintainer; `QPX_SPEC_VERSION` is unchanged here.)
 - **1.1** (backward-incompatible, pre-2.0 stabilisation): the PG view now keys on
   `grouped_runs` (`list<string>`) instead of the scalar `run_file_name`. A
   protein-group quantity applies to the set of raw files (fractions) aggregated

--- a/qpx/converters/diann/pg_adapter.py
+++ b/qpx/converters/diann/pg_adapter.py
@@ -45,6 +45,19 @@ _PG_EXTRA_COLS = [
 _DECOY_PREFIXES = ("DECOY_", "decoy_", "rev_", "REV_")
 
 
+def _first_non_null(series: pd.Series):
+    """Return the first non-null, non-empty value in *series* (else None).
+
+    Used to collapse a protein group's per-precursor name/gene annotations to a
+    single representative value so inconsistent annotations do not split the
+    group into duplicate-identity records.
+    """
+    for value in series:
+        if pd.notna(value) and value != "":
+            return value
+    return None
+
+
 class DiannPgAdapter(DiaNNBaseAdapter):
     """Convert DIA-NN report + PG matrix to ``pg.parquet``.
 
@@ -233,17 +246,23 @@ class DiannPgAdapter(DiaNNBaseAdapter):
         report_df["run_file_name"] = report_df["run_file_name_clean"]
         report_df.drop(columns=["run_file_name_clean"], inplace=True)
 
-        # Aggregate per protein group per run — single groupby over the whole batch
+        # Aggregate per protein group per run — one record per (pg_accessions, run).
+        # Grouping additionally on pg_names/gg_accessions would split a single
+        # protein group into multiple records when DIA-NN emits inconsistent
+        # name/gene annotations across a group's precursor rows; those records
+        # share the same (pg_accessions, grouped_runs, label) identity and would
+        # collide on pg_id. Names/genes are instead derived within the group
+        # below (first non-null), so annotation noise no longer splits a group.
         pg_groups = report_df.groupby(
-            ["pg_accessions", "pg_names", "gg_accessions", "run_file_name"],
+            ["pg_accessions", "run_file_name"],
             dropna=False,
         )
 
-        for (pg_acc, pg_nm, gg_acc, ref), group in pg_groups:
+        for (pg_acc, ref), group in pg_groups:
             rec = self._build_pg_record(
                 pg_acc=str(pg_acc),
-                pg_names_raw=pg_nm,
-                gg_acc_raw=gg_acc,
+                pg_names_raw=_first_non_null(group["pg_names"]),
+                gg_acc_raw=_first_non_null(group["gg_accessions"]),
                 run_file_name=str(ref),
                 group=group,
                 pg_matrix_indexed=pg_matrix_indexed,

--- a/qpx/converters/mzidentml/converter.py
+++ b/qpx/converters/mzidentml/converter.py
@@ -154,15 +154,22 @@ class MzIdentMLConverter(BaseOrchestrator):
             scans = rec.get("scan") or []
             if not scans:
                 continue
-            scan = scans[0]
-            spectrum = mgf_index.get_spectrum(scan)
-            if spectrum is None:
-                # Fallback: try 0-based index lookup
-                spectrum = mgf_index.get_spectrum_by_index(scan)
+            value = scans[0]
+            # Honour the nativeID scheme: an ``index=`` value is a 0-based file
+            # position, NOT a scan number. Looking it up by scan number would
+            # match an unrelated spectrum whose ``SCANS=`` equals the index and
+            # attach the wrong peaks/RT. A ``scan=`` value must never be treated
+            # as an index either — use the lookup that matches the scheme only.
+            scheme = rec.get("_spectrum_id_scheme")
+            if scheme == "index":
+                spectrum = mgf_index.get_spectrum_by_index(value)
                 if spectrum is not None:
                     matched_by_index += 1
             else:
-                matched_by_scan += 1
+                # "scan" (or a legacy record without a recorded scheme)
+                spectrum = mgf_index.get_spectrum(value)
+                if spectrum is not None:
+                    matched_by_scan += 1
 
             if spectrum is not None:
                 rec["mz_array"] = spectrum["mz_array"]

--- a/qpx/converters/mzidentml/psm_adapter.py
+++ b/qpx/converters/mzidentml/psm_adapter.py
@@ -8,6 +8,7 @@ crosslinking modifications (``crosslink donor``, ``crosslink acceptor``).
 
 from __future__ import annotations
 
+import copy
 import gzip
 import logging
 import re
@@ -329,7 +330,7 @@ class MzIdentMLPsmAdapter(BaseConverter):
 
         records = []
         for sir in spectrum_results:
-            scan = _parse_scan(sir["spectrum_id"])
+            scan, scan_scheme = _parse_native_id(sir["spectrum_id"])
             run_file = spectra_data.get(sir["spectra_data_ref"], "unknown")
             rt = sir.get("rt")
             siis = sir["siis"]
@@ -349,6 +350,10 @@ class MzIdentMLPsmAdapter(BaseConverter):
                     rt=rt,
                 )
                 if record is not None:
+                    # Transient hint (dropped by the writer) telling
+                    # ``_attach_spectra`` whether ``scan`` is an acquisition scan
+                    # number or a 0-based file index, so it fetches by the right key.
+                    record["_spectrum_id_scheme"] = scan_scheme
                     records.append(record)
 
         return records
@@ -409,9 +414,13 @@ class MzIdentMLPsmAdapter(BaseConverter):
         # Build peptidoform from sequence and parsed modifications
         peptidoform = _build_peptidoform(sequence, alpha_pep.get("modifications"))
 
-        # Enrich modifications with site localization scores from SII cvParams
+        # Enrich modifications with site localization scores from SII cvParams.
+        # ``alpha_pep["modifications"]`` is shared by every PSM that references
+        # this Peptide id, and site-localization scoring mutates positions in
+        # place — deep-copy first so PSMs sharing a peptide_ref do not accumulate
+        # each other's phosphoRS/Ascore values.
         modifications = _attach_site_localization_scores(
-            alpha_pep.get("modifications"),
+            copy.deepcopy(alpha_pep.get("modifications")),
             alpha_sii["cv_params"],
         )
 
@@ -654,20 +663,47 @@ def _source_sii_identity(run_file: str, alpha_sii: dict, beta_sii: dict | None) 
     return derive_id([run_file, source_ids]), cv_params
 
 
-def _parse_scan(spectrum_id: str) -> list[int]:
-    """Extract scan number(s) from mzIdentML spectrumID string.
+def _parse_native_id(spectrum_id: str) -> tuple[list[int], str | None]:
+    """Extract the numeric spectrum reference and its nativeID scheme.
 
-    Handles formats: ``scan=100``, ``index=7483``, ``spectrum=5``.
-    Falls back to 0 if no numeric value is found.
+    Returns ``(values, scheme)`` where ``scheme`` is one of:
+
+    * ``"scan"``  — the value is an acquisition scan number
+      (``scan=N``, ``spectrum=N``, or a bare integer);
+    * ``"index"`` — the value is a 0-based position in the spectrum file
+      (``index=N``). This is NOT a scan number: it must be looked up by
+      position, never by scan number, or peaks/RT from an unrelated spectrum
+      whose ``SCANS=`` happens to equal the index get attached;
+    * ``None``    — no numeric reference could be parsed.
+
+    The scheme is what lets spectra attachment fetch the CORRECT spectrum.
     """
-    m = re.search(r"(?:scan|index|spectrum)=(\d+)", spectrum_id)
+    m = re.search(r"scan=(\d+)", spectrum_id)
     if m:
-        return [int(m.group(1))]
-    # Try bare integer
+        return [int(m.group(1))], "scan"
+    m = re.search(r"index=(\d+)", spectrum_id)
+    if m:
+        return [int(m.group(1))], "index"
+    m = re.search(r"spectrum=(\d+)", spectrum_id)
+    if m:
+        return [int(m.group(1))], "scan"
+    # Bare integer spectrumID — historically treated as a scan number.
     m = re.match(r"^(\d+)$", spectrum_id.strip())
     if m:
-        return [int(m.group(1))]
-    return [0]
+        return [int(m.group(1))], "scan"
+    # Unparseable: return an empty marker (NOT ``[0]``) so a spectrum with no
+    # parseable id does not alias onto a real scan-0 spectrum, and two distinct
+    # unparseable spectra are not silently collapsed onto the same sentinel.
+    return [], None
+
+
+def _parse_scan(spectrum_id: str) -> list[int]:
+    """Return the scan/index value(s) from a spectrumID, without the scheme.
+
+    Prefer :func:`_parse_native_id` when the nativeID scheme matters (e.g. to
+    attach the correct spectrum). Returns an empty list when nothing parses.
+    """
+    return _parse_native_id(spectrum_id)[0]
 
 
 def _group_siis(siis: list[dict]) -> list[dict]:

--- a/qpx/converters/openms/converter.py
+++ b/qpx/converters/openms/converter.py
@@ -153,11 +153,19 @@ def _collect_score_names(table_path: Path) -> set[str]:
 
 
 def _validate_core(discovered: dict[str, Path]) -> None:
-    """Validate each discovered parquet file against its QPX schema."""
+    """Validate each discovered parquet file against its QPX schema.
+
+    Uses ``strict=False`` so the convert path persists source data as-produced:
+    a duplicate primary key (and a null in a non-nullable column) is a warning,
+    not a blocking error, while the format stabilises. Missing columns and type
+    mismatches remain errors regardless of ``strict``. Null primary keys are
+    still fatal — the writer rejects them at close time before this runs. The
+    ``qpxc validate --strict`` audit/CI path stays strict and is unaffected.
+    """
     for view, path in discovered.items():
         schema = load_schema(_VIEW_SCHEMAS[view])
         table = pq.read_table(str(path))
-        result = schema.validate_full(table, strict=True)
+        result = schema.validate_full(table, strict=False)
         if not result.is_valid:
             errors = "; ".join(i.message for i in result.errors)
             raise ValueError(f"Validation failed for {path.name}: {errors}")

--- a/qpx/core/data/schema.py
+++ b/qpx/core/data/schema.py
@@ -148,13 +148,16 @@ def _pg_referential_issues(
     * **duplicate_grouped_run** — ``grouped_runs`` is a set of distinct raw files;
       it must contain no duplicate element.
     * **run_double_count** (run-disjointness) — within one
-      ``(anchor_protein, label)``, the ``grouped_runs`` sets across rows must be
+      ``(pg_accessions, label)`` — the protein-group *membership* that keys the
+      pg_id, not merely the leader — the ``grouped_runs`` sets across rows must be
       disjoint, so every raw file contributes to at most one row and no
-      measurement is counted twice. This is the join-free form of the
-      double-count check.
+      measurement is counted twice. Keying on the full membership (canonicalized
+      order-independently) matches the pg_id identity, so two genuinely distinct
+      groups that share a leading protein are not conflated into a false
+      double-count. This is the join-free form of the double-count check.
     """
     names = set(table.schema.names)
-    if not {"anchor_protein", "grouped_runs", "label"} <= names or len(table) == 0:
+    if not {"pg_accessions", "grouped_runs", "label"} <= names or len(table) == 0:
         return []
 
     import duckdb
@@ -183,13 +186,16 @@ def _pg_referential_issues(
                 -- Deduplicate each row's own grouped_runs first (a within-row
                 -- duplicate is already reported by duplicate_grouped_run); this
                 -- way run_double_count measures only cross-row disjointness.
-                SELECT anchor_protein, label, UNNEST(list_distinct(grouped_runs)) AS run
+                -- Key on the canonical (order-independent) group MEMBERSHIP, so
+                -- distinct groups sharing a leader are not conflated.
+                SELECT list_sort(list_distinct(pg_accessions)) AS members, label,
+                       UNNEST(list_distinct(grouped_runs)) AS run
                 FROM pg_validate
             ),
             repeated AS (
                 SELECT COUNT(*) AS c
                 FROM exploded
-                GROUP BY anchor_protein, label, run
+                GROUP BY members, label, run
                 HAVING COUNT(*) > 1
             )
             SELECT COALESCE(SUM(c - 1), 0) FROM repeated
@@ -204,7 +210,7 @@ def _pg_referential_issues(
                     column=None,
                     message=(
                         f"{double} run occurrence(s) repeat across pg rows sharing the same "
-                        "(anchor_protein, label): grouped_runs sets must be disjoint or protein "
+                        "(pg_accessions, label): grouped_runs sets must be disjoint or protein "
                         "intensity is double-counted"
                     ),
                 )

--- a/qpx/core/data/schemas/pg.yaml
+++ b/qpx/core/data/schemas/pg.yaml
@@ -1,7 +1,7 @@
 name: pg
 file_type: pg_file
 primary_key: [pg_id]
-identity_composite: [anchor_protein, grouped_runs, label]
+identity_composite: [pg_accessions, grouped_runs, label]
 doc: "Protein groups with per-quantification-unit quantification (one row per label; label/intensity flattened from the old intensities list)"
 
 fields:
@@ -16,7 +16,7 @@ fields:
   pg_accessions:
     type: "list<string>"
     required: true
-    doc: "Protein accessions within this group"
+    doc: "Protein accessions within this group. Part of the default identity composite: the FULL group membership (not just the leader) keys the pg_id, so two distinct groups that happen to share a leading protein get distinct ids. Hashed order-independently (membership is a set)."
   pg_names:
     type: "list<string>"
     doc: "Protein group names"
@@ -33,7 +33,7 @@ fields:
   anchor_protein:
     type: string
     required: true
-    doc: "Anchor/leading protein of the group"
+    doc: "Anchor/leading protein of the group (the representative used for feature->pg joins). Descriptive only — NOT part of the pg_id identity, which keys on the full pg_accessions membership."
 
   # Quantification-unit context
   grouped_runs:

--- a/qpx/writers/base.py
+++ b/qpx/writers/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Sequence
@@ -18,6 +19,8 @@ from qpx.version import QPX_SPEC_VERSION
 
 if TYPE_CHECKING:
     import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 # High-entropy float leaves that compress poorly under the default
@@ -413,7 +416,7 @@ class BaseWriter:
         pass tables whose id column is absent or null.
         """
         table = self._fill_identity_table(table)
-        errors = self._schema_class.validate(table, strict=True)
+        errors = self._schema_class.validate(table, strict=False)
         if errors:
             raise ValueError("Schema validation failed:\n" + "\n".join(errors))
         self._ensure_writer()
@@ -481,8 +484,14 @@ class BaseWriter:
             raise ValueError(f"Primary key ({id_field}) contains {null_count} null row(s) out of {total_count}")
         if unique_count != total_count:
             duplicate_count = total_count - unique_count
-            raise ValueError(
-                f"Primary key ({id_field}) has {duplicate_count} duplicate row(s) ({unique_count} unique out of {total_count})"
+            logger.warning(
+                "Primary key (%s) has %d duplicate row(s) (%d unique out of %d). "
+                "Duplicate ids are tolerated as a warning while the qpx format stabilises "
+                "and usually indicate a converter identity bug.",
+                id_field,
+                duplicate_count,
+                unique_count,
+                total_count,
             )
 
     def _write_arrow_batch(self, records: list[dict]):

--- a/qpx/writers/base.py
+++ b/qpx/writers/base.py
@@ -302,7 +302,14 @@ class BaseWriter:
     ) -> list[int]:
         """Preserve or derive row IDs, recording overridden producer IDs."""
         ids: list[int] = []
-        unordered_list_indices = tuple(index for index, field in enumerate(composite) if field == "grouped_runs")
+        # Identity list fields whose element order is not meaningful: grouped_runs
+        # is a set of raw files, and pg_accessions is a set of group members (the
+        # anchor/leader is carried separately). Hashing them order-independently
+        # keeps the derived id stable across producers that emit the same
+        # membership in a different order.
+        unordered_list_indices = tuple(
+            index for index, field in enumerate(composite) if field in ("grouped_runs", "pg_accessions")
+        )
         for index, provided in enumerate(existing):
             if provided is not None and not self._should_override_provided_id(index, composite_values):
                 ids.append(provided)

--- a/qpx/writers/pg.py
+++ b/qpx/writers/pg.py
@@ -1,11 +1,12 @@
 """PgWriter — writes pg.parquet files.
 
 Since QPX 1.1 the pg view is **flattened**: instead of one row per
-``(anchor_protein, grouped_runs)`` carrying an ``intensities: list<{label,
+``(pg_accessions, grouped_runs)`` carrying an ``intensities: list<{label,
 intensity}>`` column, there is **one row per label** with scalar ``label`` and
 ``intensity`` columns. Since the mandatory-identity change the primary key is the
 single derived ``pg_id`` (hashed from the ``identity_composite``
-``(anchor_protein, grouped_runs, label)``). Converters
+``(pg_accessions, grouped_runs, label)`` — the full group membership keys the id,
+not just the leader). Converters
 still build the natural ``intensities`` list per protein group; the writer is the
 single place that materializes the flat physical layout, so no converter needs to
 know about the on-disk shape. Identification-only groups (no intensity, e.g.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,12 +202,21 @@ def make_pg_record(
     run_file_name="run_01",
     is_decoy=False,
     intensities=None,
+    pg_accessions=None,
 ):
-    """Create a minimal valid PG record dict."""
+    """Create a minimal valid PG record dict.
+
+    ``pg_accessions`` defaults to a group led by ``anchor_protein`` (the pg_id
+    identity keys on the full membership), so distinct anchors yield distinct
+    groups. The default preserves the historical ``["P12345", "P12346"]`` group
+    for the default anchor.
+    """
     if intensities is None:
         intensities = [{"label": "TMT126", "intensity": 5000.0}]
+    if pg_accessions is None:
+        pg_accessions = [anchor_protein, "P12346"]
     return {
-        "pg_accessions": ["P12345", "P12346"],
+        "pg_accessions": pg_accessions,
         "pg_names": None,
         "gg_accessions": None,
         "gg_names": ["GENE1"],

--- a/tests/converters/test_diann_converter.py
+++ b/tests/converters/test_diann_converter.py
@@ -311,6 +311,129 @@ def test_plexdia_pg_preserves_each_channel_quantity(tmp_path):
     }
 
 
+def test_diann_pg_inconsistent_annotations_do_not_split_group(tmp_path):
+    """One protein group with inconsistent per-precursor name/gene annotations
+    must produce a single unique pg record, not duplicate-identity rows.
+
+    Regression for bigbio/qpx#240: grouping on pg_names/gg_accessions split a
+    group whose precursor rows carried different Genes/Protein.Names into records
+    that shared the same (pg_accessions, grouped_runs, label) identity, colliding
+    on pg_id and tripping the close-time uniqueness validator.
+    """
+    from qpx.converters.diann.pg_adapter import DiannPgAdapter
+
+    shared = {
+        "Run": "run_A",
+        "Protein.Group": "P1;P2",
+        "Protein.Names": "N1;N2",
+        "PG.Quantity": 1000.0,
+        "PG.MaxLFQ": 900.0,
+        "Precursor.Charge": 2,
+        "Q.Value": 0.002,
+        "PG.Q.Value": 0.002,
+        "Global.PG.Q.Value": 0.003,
+        "GG.Q.Value": 0.004,
+        "Proteotypic": 1,
+        "Precursor.Quantity": 100.0,
+    }
+    report_path = tmp_path / "inconsistent_report.tsv"
+    pd.DataFrame(
+        [
+            {**shared, "Genes": "G1;G2", "Stripped.Sequence": "PEPTIDEK", "Precursor.Id": "PEPTIDEK2"},
+            {**shared, "Genes": "G1", "Stripped.Sequence": "PEPTIDER", "Precursor.Id": "PEPTIDER2"},
+        ]
+    ).to_csv(report_path, sep="\t", index=False)
+    matrix_path = tmp_path / "inconsistent_pg_matrix.tsv"
+    pd.DataFrame([{"Protein.Group": "P1;P2", "Protein.Names": "N1;N2", "Genes": "G1;G2", "run_A": 900.0}]).to_csv(
+        matrix_path, sep="\t", index=False
+    )
+
+    output_path = tmp_path / "inconsistent.pg.parquet"
+    # Without the fix, adapter.convert would raise at close time:
+    # "Primary key (pg_id) has 1 duplicate row(s)".
+    with DiannPgAdapter() as adapter:
+        adapter.convert(
+            diann_report=str(report_path),
+            pg_matrix_path=str(matrix_path),
+            output_path=str(output_path),
+        )
+
+    table = pq.read_table(output_path)
+    pg_ids = table.column("pg_id").to_pylist()
+    assert table.num_rows == 1, "the single protein group must yield exactly one record"
+    assert len(set(pg_ids)) == len(pg_ids), "pg_id must be unique"
+    row = table.to_pylist()[0]
+    assert row["pg_accessions"] == ["P1", "P2"]
+    assert row["anchor_protein"] == "P1"
+
+
+def test_diann_pg_distinct_groups_sharing_leader_get_distinct_ids(tmp_path):
+    """Two DIFFERENT protein groups that share a leading protein must get
+    DISTINCT pg_ids.
+
+    The pg identity keys on the full pg_accessions membership, not on the leader
+    alone, so ``P1;P2`` and ``P1;P3`` (same anchor ``P1``, same run, same label)
+    are distinct groups and must not collide on pg_id.
+    """
+    from qpx.converters.diann.pg_adapter import DiannPgAdapter
+
+    common = {
+        "Run": "run_A",
+        "PG.Quantity": 1000.0,
+        "PG.MaxLFQ": 900.0,
+        "Precursor.Charge": 2,
+        "Q.Value": 0.002,
+        "PG.Q.Value": 0.002,
+        "Global.PG.Q.Value": 0.003,
+        "GG.Q.Value": 0.004,
+        "Proteotypic": 1,
+        "Precursor.Quantity": 100.0,
+    }
+    report_path = tmp_path / "shared_leader_report.tsv"
+    pd.DataFrame(
+        [
+            {
+                **common,
+                "Protein.Group": "P1;P2",
+                "Protein.Names": "N1;N2",
+                "Genes": "G1;G2",
+                "Stripped.Sequence": "PEPTIDEK",
+                "Precursor.Id": "PEPTIDEK2",
+            },
+            {
+                **common,
+                "Protein.Group": "P1;P3",
+                "Protein.Names": "N1;N3",
+                "Genes": "G1;G3",
+                "Stripped.Sequence": "PEPTIDER",
+                "Precursor.Id": "PEPTIDER2",
+            },
+        ]
+    ).to_csv(report_path, sep="\t", index=False)
+    matrix_path = tmp_path / "shared_leader_pg_matrix.tsv"
+    pd.DataFrame(
+        [
+            {"Protein.Group": "P1;P2", "Protein.Names": "N1;N2", "Genes": "G1;G2", "run_A": 900.0},
+            {"Protein.Group": "P1;P3", "Protein.Names": "N1;N3", "Genes": "G1;G3", "run_A": 800.0},
+        ]
+    ).to_csv(matrix_path, sep="\t", index=False)
+
+    output_path = tmp_path / "shared_leader.pg.parquet"
+    with DiannPgAdapter() as adapter:
+        adapter.convert(
+            diann_report=str(report_path),
+            pg_matrix_path=str(matrix_path),
+            output_path=str(output_path),
+        )
+
+    table = pq.read_table(output_path)
+    rows = table.to_pylist()
+    assert table.num_rows == 2, "two distinct protein groups must yield two records"
+    assert all(row["anchor_protein"] == "P1" for row in rows)
+    pg_ids = table.column("pg_id").to_pylist()
+    assert len(set(pg_ids)) == 2, "distinct membership must derive distinct pg_ids"
+
+
 def test_diann_maxlfq_fallback_keeps_experimental_label(tmp_path):
     """MaxLFQ-only PG output remains joinable to an LFQ run sample."""
     from qpx.converters.diann.pg_adapter import DiannPgAdapter

--- a/tests/converters/test_mzidentml_converter.py
+++ b/tests/converters/test_mzidentml_converter.py
@@ -11,6 +11,7 @@ import pyarrow.parquet as pq
 from qpx.converters.mzidentml.psm_adapter import (
     MzIdentMLPsmAdapter,
     _group_siis,
+    _parse_native_id,
     _parse_scan,
 )
 
@@ -51,7 +52,33 @@ class TestParseScan:
         assert _parse_scan("42") == [42]
 
     def test_unknown_format(self):
-        assert _parse_scan("something_else") == [0]
+        # Unparseable spectrumIDs must NOT collapse onto a ``[0]`` sentinel
+        # (which aliases distinct spectra and a real scan-0 spectrum).
+        assert _parse_scan("something_else") == []
+
+
+class TestParseNativeId:
+    """The nativeID scheme distinguishes scan numbers from file indices (#249)."""
+
+    def test_scan_is_scan_scheme(self):
+        assert _parse_native_id("scan=100") == ([100], "scan")
+
+    def test_index_is_index_scheme(self):
+        # The regression: ``index=`` is a file position, not a scan number.
+        assert _parse_native_id("index=1999") == ([1999], "index")
+
+    def test_spectrum_is_scan_scheme(self):
+        assert _parse_native_id("spectrum=5") == ([5], "scan")
+
+    def test_bare_integer_is_scan_scheme(self):
+        assert _parse_native_id("42") == ([42], "scan")
+
+    def test_mzml_nativeid_scan(self):
+        assert _parse_native_id("controllerType=0 controllerNumber=1 scan=7") == ([7], "scan")
+
+    def test_unparseable_is_empty_none(self):
+        # No ``[0]`` sentinel: distinct unparseable spectra must not alias.
+        assert _parse_native_id("something_else") == ([], None)
 
 
 class TestGroupSiis:
@@ -517,3 +544,105 @@ class TestMzIdentMLProvenanceParams:
         var_mods = [p for p in params if p["key"] == "variable_mod"]
         assert var_mods, f"No 'variable_mod' entries in parameters: {params}"
         assert any("Oxidation" in p["value"] for p in var_mods), f"Expected Oxidation in variable_mod entries: {var_mods}"
+
+
+# ---------------------------------------------------------------------------
+# Shared-modifications mutation (bigbio/qpx#249)
+# ---------------------------------------------------------------------------
+
+
+class TestSharedModificationsNoCrossContamination:
+    """PSMs that share a ``peptide_ref`` must not accumulate each other's
+    site-localization scores.
+
+    The Peptide's ``modifications`` list is shared by every SII that references
+    it, and site-localization scoring mutates modification positions in place.
+    Without a per-PSM copy, the second PSM inherits the first PSM's phosphoRS
+    score, corrupting localization data.
+    """
+
+    @staticmethod
+    def _phospho_mod():
+        return [
+            {
+                "name": "Phospho",
+                "accession": "UNIMOD:21",
+                "positions": [{"position": 4, "amino_acid": "T", "scores": None}],
+            }
+        ]
+
+    @staticmethod
+    def _sii(sii_id, site_prob):
+        # MS:1001969 == phosphoRS site probability (a site-localization cvParam).
+        return {
+            "id": sii_id,
+            "charge": 2,
+            "exp_mz": 500.0,
+            "calc_mz": 500.0,
+            "rank": 1,
+            "pass_threshold": True,
+            "peptide_ref": "SharedPep",
+            "cv_params": [
+                {
+                    "accession": "MS:1001969",
+                    "name": "phosphoRS site probability",
+                    "value": f"T4: {site_prob}",
+                }
+            ],
+            "peptide_evidence_refs": [],
+        }
+
+    def _parsed(self):
+        return {
+            "spectra_data": {"SD1": "run.mgf"},
+            "db_sequences": {},
+            "peptides": {
+                "SharedPep": {
+                    "sequence": "PEPTIDE",
+                    "modifications": self._phospho_mod(),
+                    "xl_mods": {},
+                }
+            },
+            "peptide_evidence": {},
+            "linker_info": {},
+            "spectrum_results": [
+                {
+                    "spectrum_id": "index=1",
+                    "spectra_data_ref": "SD1",
+                    "rt": None,
+                    "siis": [self._sii("SII_1", 99.0)],
+                },
+                {
+                    "spectrum_id": "index=2",
+                    "spectra_data_ref": "SD1",
+                    "rt": None,
+                    "siis": [self._sii("SII_2", 10.0)],
+                },
+            ],
+        }
+
+    def test_each_psm_keeps_only_its_own_score(self):
+        parsed = self._parsed()
+        with MzIdentMLPsmAdapter() as adapter:
+            records = adapter._build_psm_records(parsed)
+
+        assert len(records) == 2
+        scores_per_psm = [rec["modifications"][0]["positions"][0]["scores"] for rec in records]
+
+        # Each PSM carries exactly ONE site-localization score — its own.
+        for scores in scores_per_psm:
+            assert scores is not None
+            assert len(scores) == 1
+
+        values = sorted(scores[0]["score_value"] for scores in scores_per_psm)
+        assert values == [10.0, 99.0]
+
+    def test_shared_source_modifications_untouched(self):
+        parsed = self._parsed()
+        shared = parsed["peptides"]["SharedPep"]["modifications"]
+        with MzIdentMLPsmAdapter() as adapter:
+            adapter._build_psm_records(parsed)
+
+        # The Peptide's shared modification list must remain pristine — scoring
+        # happened on per-PSM copies, not on this source object.
+        assert shared[0]["positions"][0]["scores"] is None

--- a/tests/converters/test_mzidentml_full_converter.py
+++ b/tests/converters/test_mzidentml_full_converter.py
@@ -267,27 +267,100 @@ class TestPXD054720WithSpectra:
 
 
 class TestIndexFallback:
-    """Test that spectra attachment falls back to index when scan doesn't match."""
+    """Spectra attachment must use the nativeID scheme to pick the right lookup."""
 
-    def test_fallback_to_index(self, tmp_path):
-        """When scan-based lookup fails, should try index-based lookup."""
-        # Create MGF where SCANS= doesn't match mzIdentML scan numbers
-        # but the 0-based index does
+    def test_index_scheme_uses_position_lookup(self, tmp_path):
+        """``index=`` records attach by 0-based file position, not by SCANS=."""
+        # MGF where SCANS= deliberately does NOT match the index values, so a
+        # scan-number lookup would either miss or (worse) match the wrong
+        # spectrum. Only a position-based lookup gives the correct peaks.
         mgf = tmp_path / "test.mgf"
         mgf.write_text(
             "BEGIN IONS\nTITLE=first\nSCANS=999\n100.0 500\nEND IONS\nBEGIN IONS\nTITLE=second\nSCANS=998\n200.0 600\nEND IONS\n"
         )
 
-        # PSM records with scan=[0] and scan=[1] -- don't match SCANS=999/998
-        # but DO match 0-based position
         records = [
-            {"scan": [0], "mz_array": None, "intensity_array": None, "rt": None},
-            {"scan": [1], "mz_array": None, "intensity_array": None, "rt": None},
+            {"scan": [0], "_spectrum_id_scheme": "index", "mz_array": None, "intensity_array": None, "rt": None},
+            {"scan": [1], "_spectrum_id_scheme": "index", "mz_array": None, "intensity_array": None, "rt": None},
         ]
 
         result = MzIdentMLConverter._attach_spectra(records, str(mgf))
-        assert result[0]["mz_array"] == [100.0]  # matched by index 0
-        assert result[1]["mz_array"] == [200.0]  # matched by index 1
+        assert result[0]["mz_array"] == [100.0]  # position 0
+        assert result[1]["mz_array"] == [200.0]  # position 1
+
+    def test_index_value_not_attached_by_scan(self, tmp_path):
+        """An ``index=`` value must never be attached via a colliding SCANS=.
+
+        Regression for bigbio/qpx#249: index 999 collides with SCANS=999 of an
+        UNRELATED spectrum; the old scan-first lookup attached those wrong peaks.
+        """
+        # Spectrum at position 0 carries SCANS=999; the correct spectrum for
+        # index=999 does not exist in this tiny MGF, so nothing must attach.
+        mgf = tmp_path / "collide.mgf"
+        mgf.write_text("BEGIN IONS\nTITLE=first\nSCANS=999\n100.0 500\nEND IONS\n")
+
+        records = [
+            {"scan": [999], "_spectrum_id_scheme": "index", "mz_array": None, "intensity_array": None, "rt": None},
+        ]
+
+        result = MzIdentMLConverter._attach_spectra(records, str(mgf))
+        # No spectrum at position 999 → nothing attached (NOT the SCANS=999 peaks).
+        assert result[0]["mz_array"] is None
+
+    def test_index_file_attaches_correct_spectrum_end_to_end(self, tmp_path):
+        """A PSM whose ``spectrumID`` is ``index=N`` attaches the peaks of the
+        Nth spectrum, even when an unrelated spectrum carries ``SCANS=N``.
+
+        End-to-end: the scheme is derived from the ``index=`` spectrumID by the
+        adapter, then honoured by ``_attach_spectra``. Regression for
+        bigbio/qpx#249 (the old scan-first lookup attached the SCANS-colliding
+        spectrum's peaks instead).
+        """
+        from qpx.converters.mzidentml.psm_adapter import MzIdentMLPsmAdapter
+
+        # Position 0 is a decoy whose SCANS collides with the target index (1);
+        # position 1 is the CORRECT spectrum for ``index=1``.
+        mgf = tmp_path / "e2e.mgf"
+        mgf.write_text(
+            "BEGIN IONS\nTITLE=decoy\nSCANS=1\n100.0 500\nEND IONS\nBEGIN IONS\nTITLE=target\nSCANS=42\n200.0 600\nEND IONS\n"
+        )
+
+        parsed = {
+            "spectra_data": {"SD1": "e2e.mgf"},
+            "db_sequences": {},
+            "peptides": {"Pep1": {"sequence": "PEPTIDE", "modifications": None, "xl_mods": {}}},
+            "peptide_evidence": {},
+            "linker_info": {},
+            "spectrum_results": [
+                {
+                    "spectrum_id": "index=1",  # the 2nd spectrum (position 1)
+                    "spectra_data_ref": "SD1",
+                    "rt": None,
+                    "siis": [
+                        {
+                            "id": "SII_1",
+                            "charge": 2,
+                            "exp_mz": 500.0,
+                            "calc_mz": 500.0,
+                            "rank": 1,
+                            "pass_threshold": True,
+                            "peptide_ref": "Pep1",
+                            "cv_params": [],
+                            "peptide_evidence_refs": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        with MzIdentMLPsmAdapter() as adapter:
+            records = adapter._build_psm_records(parsed)
+        assert records[0]["_spectrum_id_scheme"] == "index"
+
+        result = MzIdentMLConverter._attach_spectra(records, str(mgf))
+        # Correct spectrum is position 1 (200.0), NOT the SCANS=1 collision (100.0).
+        assert result[0]["mz_array"] == [200.0]
+        assert result[0]["intensity_array"] == [600.0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/converters/test_openms_converter.py
+++ b/tests/converters/test_openms_converter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pyarrow as pa
@@ -158,8 +159,8 @@ class TestOpenMSConverter:
         assert "grouped_runs" in pg_table.column_names
         assert "run_file_name" not in pg_table.column_names
 
-    def test_invalid_legacy_identity_does_not_replace_output(self, tmp_path):
-        """Strict validation happens before a rewritten core file is installed."""
+    def test_duplicate_identity_warns_and_replaces_output(self, tmp_path, caplog):
+        """A duplicate primary key is tolerated with a warning; the core file is rewritten."""
         qpx_dir = tmp_path / "openms_qpx"
         qpx_dir.mkdir()
         records = [
@@ -179,10 +180,14 @@ class TestOpenMSConverter:
         sentinel = b"pre-existing output"
         destination.write_bytes(sentinel)
 
-        with pytest.raises(ValueError, match="Primary key.*duplicate"):
+        with caplog.at_level(logging.WARNING):
             OpenMSConverter(qpx_dir=qpx_dir).convert(output_folder=output, output_prefix="openms")
 
-        assert destination.read_bytes() == sentinel
+        # The converter completed: the destination is replaced with the real parquet output.
+        assert destination.read_bytes() != sentinel
+        rewritten = pq.read_table(destination)
+        assert rewritten.num_rows == 2
+        assert "duplicate row" in caplog.text.lower()
         assert not list(output.glob(".openms.psm.parquet.*.tmp"))
 
     def test_convert_full_bundle(self, tmp_path):

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -190,7 +190,7 @@ def test_pg_schema_grouped_runs_is_list_string():
     assert pa.types.is_list(field.type)
     assert pa.types.is_string(field.type.value_type)
     assert tuple(PgSchema._primary_key) == ("pg_id",)
-    assert tuple(PgSchema.identity_composite) == ("anchor_protein", "grouped_runs", "label")
+    assert tuple(PgSchema.identity_composite) == ("pg_accessions", "grouped_runs", "label")
 
 
 def test_pg_grouped_runs_roundtrip(pg_parquet):
@@ -562,7 +562,10 @@ def _write_feature_pg_dataset(ds_dir, feature_pg_ids):
         writer.write_batch([feature])
     with PgWriter(ds_dir / "exp.pg.parquet") as writer:
         writer.write_batch([pg])
-    pg_id = derive_id([pg["anchor_protein"], pg["grouped_runs"], pg["intensities"][0]["label"]])
+    pg_id = derive_id(
+        [pg["pg_accessions"], pg["grouped_runs"], pg["intensities"][0]["label"]],
+        unordered_list_indices=(0, 1),
+    )
     return ds_dir, pg_id
 
 

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -50,7 +50,7 @@ def test_schema_identity_metadata():
     assert tuple(PsmSchema._primary_key) == ("psm_id",)
     assert tuple(PsmSchema.identity_composite) == ("peptidoform", "charge", "run_file_name", "scan")
     assert tuple(PgSchema._primary_key) == ("pg_id",)
-    assert tuple(PgSchema.identity_composite) == ("anchor_protein", "grouped_runs", "label")
+    assert tuple(PgSchema.identity_composite) == ("pg_accessions", "grouped_runs", "label")
 
 
 def test_writer_rejects_unknown_identity_composite_field(tmp_path):
@@ -114,13 +114,13 @@ def test_pg_roundtrip_derives_id(tmp_path):
 
     table = pq.read_table(path)
     ids = table.column("pg_id").to_pylist()
-    anchors = table.column("anchor_protein").to_pylist()
+    pg_accessions = table.column("pg_accessions").to_pylist()
     grouped = table.column("grouped_runs").to_pylist()
     labels = table.column("label").to_pylist()
     assert None not in ids
     assert len(set(ids)) == len(ids)
     for i, got in enumerate(ids):
-        assert got == derive_id([anchors[i], grouped[i], labels[i]])
+        assert got == derive_id([pg_accessions[i], grouped[i], labels[i]], unordered_list_indices=(0, 1))
 
 
 def test_identified_feature_id_is_derived_by_default(tmp_path):

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -165,8 +165,8 @@ def test_unidentified_feature_uses_unique_composite_fallback(tmp_path, caplog):
 
 
 @pytest.mark.parametrize("write_path", ["batch", "table"])
-def test_unidentified_feature_rejects_non_unique_composite_fallback(tmp_path, write_path):
-    """Distinct unidentified Features cannot share a fallback-derived primary key."""
+def test_unidentified_feature_warns_on_non_unique_composite_fallback(tmp_path, write_path, caplog):
+    """Distinct unidentified Features sharing a fallback PK are tolerated with a warning."""
     path = tmp_path / "duplicate-unidentified.feature.parquet"
     first = make_feature_record(sequence="", peptidoform="")
     second = make_feature_record(
@@ -175,7 +175,7 @@ def test_unidentified_feature_rejects_non_unique_composite_fallback(tmp_path, wr
         intensities=[{"label": "TMT126", "intensity": 2000.0}],
     )
 
-    with pytest.raises(ValueError, match="Unidentified Feature composite fallback was used for 2 row"):
+    with caplog.at_level(logging.WARNING):
         with FeatureWriter(path, batch_size=1) as writer:
             if write_path == "batch":
                 writer.write_batch([first, second])
@@ -183,21 +183,25 @@ def test_unidentified_feature_rejects_non_unique_composite_fallback(tmp_path, wr
                 table = writer.align_table_to_schema(pa.Table.from_pylist([first, second]))
                 writer.write_table(table)
 
+    assert path.exists()
+    assert "duplicate row" in caplog.text.lower()
 
-def test_identified_duplicate_not_attributed_to_fallback(tmp_path):
-    """A duplicate among identified Features keeps the plain PK error even when a
+
+def test_identified_duplicate_warns_without_fallback_note(tmp_path, caplog):
+    """A duplicate among identified Features warns with the plain PK message even when a
     (unique) unidentified composite-fallback row is present in the same file."""
     path = tmp_path / "mixed-duplicate.feature.parquet"
     fallback = make_feature_record(sequence="", peptidoform="")  # unique unidentified fallback
     dup_a = make_feature_record(run_file_name="run_09")
     dup_b = make_feature_record(run_file_name="run_09")  # identical composite -> duplicate PK
 
-    with pytest.raises(ValueError) as excinfo:
+    with caplog.at_level(logging.WARNING):
         with FeatureWriter(path, batch_size=10) as writer:
             writer.write_batch([fallback, dup_a, dup_b])
-    message = str(excinfo.value)
-    assert "duplicate row" in message.lower()
-    assert "Unidentified Feature composite fallback" not in message
+
+    assert path.exists()
+    assert "duplicate row" in caplog.text.lower()
+    assert "Unidentified Feature composite fallback" not in caplog.text
 
 
 def test_provided_psm_id_kept_by_default(tmp_path):
@@ -210,15 +214,18 @@ def test_provided_psm_id_kept_by_default(tmp_path):
     assert pq.read_table(path).column("psm_id").to_pylist() == [123456789]
 
 
-def test_writer_rejects_duplicate_identity_across_batches(tmp_path):
-    """Whole-file PK validation catches collisions split across writer batches."""
+def test_writer_warns_on_duplicate_identity_across_batches(tmp_path, caplog):
+    """Whole-file PK validation warns on collisions split across writer batches."""
     path = tmp_path / "duplicate.feature.parquet"
     first = make_feature_record()
     second = make_feature_record(intensities=[{"label": "TMT126", "intensity": 2000.0}])
 
-    with pytest.raises(ValueError, match=r"Primary key \(feature_id\) has 1 duplicate row"):
+    with caplog.at_level(logging.WARNING):
         with FeatureWriter(path, batch_size=1) as writer:
             writer.write_batch([first, second])
+
+    assert path.exists()
+    assert "Primary key (feature_id) has 1 duplicate row" in caplog.text
 
 
 def test_override_provided_id_stashes_to_cv_params(tmp_path):
@@ -332,15 +339,16 @@ def test_ids_agree_across_write_paths(tmp_path):
     assert len(ids) == 1
 
 
-def test_write_table_rejects_duplicate_pk(tmp_path):
-    """The table-writing path enforces primary-key uniqueness."""
+def test_write_table_warns_on_duplicate_pk(tmp_path, caplog):
+    """The table-writing path tolerates a duplicate primary key with a warning."""
     path = tmp_path / "dup_table.feature.parquet"
     r1 = make_feature_record(peptidoform="PEPTIDEK", charge=2, run_file_name="run_01")
     r2 = make_feature_record(
         peptidoform="PEPTIDEK", charge=2, run_file_name="run_01", intensities=[{"label": "TMT126", "intensity": 9.0}]
     )
-    w = FeatureWriter(path)
-    table = w.align_table_to_schema(pa.Table.from_pylist([dict(r1), dict(r2)]))
-    with pytest.raises(ValueError, match="Primary key.*duplicate"):
-        w.write_table(table)
-    assert not path.exists()
+    with caplog.at_level(logging.WARNING):
+        with FeatureWriter(path) as w:
+            table = w.align_table_to_schema(pa.Table.from_pylist([dict(r1), dict(r2)]))
+            w.write_table(table)
+    assert path.exists()
+    assert "duplicate row" in caplog.text.lower()

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -19,22 +19,30 @@ from qpx.core.data.identity import derive_id
 from tests.conftest import _valid_arrays
 
 
-def _pg_table(anchor, grouped_runs, label=None):
+def _pg_table(anchor, grouped_runs, label=None, pg_accessions=None):
     """Build a minimal valid PG table, overriding only the identity columns.
 
     The primary key is the derived ``pg_id``; it is stamped here the same way
-    the writer would, from the (anchor_protein, grouped_runs, label) composite.
+    the writer would, from the ``(pg_accessions, grouped_runs, label)`` composite
+    (both list fields hashed order-independently). ``anchor_protein`` is the group
+    leader (descriptive); ``pg_accessions`` defaults to the single-member group
+    ``[anchor]`` but may be passed explicitly to model multi-protein groups (e.g.
+    two distinct groups that share a leading protein).
     """
     schema = PgSchema.get_arrow_schema()
     n = len(anchor)
     labels = label if label is not None else [None] * n
-    pg_ids = [derive_id([anchor[i], grouped_runs[i], labels[i]], unordered_list_indices=(1,)) for i in range(n)]
+    if pg_accessions is None:
+        pg_accessions = [None if a is None else [a] for a in anchor]
+    pg_ids = [derive_id([pg_accessions[i], grouped_runs[i], labels[i]], unordered_list_indices=(0, 1)) for i in range(n)]
     arrays = {}
     for f in schema:
         if f.name == "pg_id":
             arrays[f.name] = pa.array(pg_ids, type=f.type)
         elif f.name == "anchor_protein":
             arrays[f.name] = pa.array(anchor, type=f.type)
+        elif f.name == "pg_accessions":
+            arrays[f.name] = pa.array(pg_accessions, type=f.type)
         elif f.name == "grouped_runs":
             arrays[f.name] = pa.array(grouped_runs, type=f.type)
         elif f.name == "label":
@@ -109,6 +117,36 @@ def test_duplicate_run_within_one_group_is_not_reported_as_cross_row_double_coun
 
     assert any(issue.check == "duplicate_grouped_run" for issue in result.issues)
     assert not any(issue.check == "run_double_count" for issue in result.issues)
+
+
+def test_distinct_groups_sharing_leader_are_not_a_run_double_count():
+    """Two DIFFERENT groups that share a leading protein (same anchor) but have
+    different membership are distinct pg rows; overlapping grouped_runs must NOT
+    be flagged as a double-count — the check keys on full pg_accessions."""
+    table = _pg_table(
+        anchor=["P1", "P1"],
+        pg_accessions=[["P1", "P2"], ["P1", "P3"]],
+        grouped_runs=[["r1"], ["r1"]],
+        label=["LFQ", "LFQ"],
+    )
+    # Distinct membership -> distinct pg_id, so no duplicate PK either.
+    assert len(set(table.column("pg_id").to_pylist())) == 2
+    result = PgSchema.validate_full(table, strict=True)
+    assert not any(issue.check == "run_double_count" for issue in result.issues)
+    assert not any(issue.check == "duplicate_pk" for issue in result.issues)
+
+
+def test_same_group_overlapping_runs_is_a_run_double_count():
+    """The SAME group (same pg_accessions + label) measured over overlapping
+    run sets double-counts its intensity and must be flagged."""
+    table = _pg_table(
+        anchor=["P1", "P1"],
+        pg_accessions=[["P1", "P2"], ["P1", "P2"]],
+        grouped_runs=[["r1", "r2"], ["r2", "r3"]],
+        label=["LFQ", "LFQ"],
+    )
+    result = PgSchema.validate_full(table, strict=True)
+    assert any(issue.check == "run_double_count" for issue in result.issues)
 
 
 def test_validation_result_dataclass():


### PR DESCRIPTION
This pull request makes several important changes to the QPX data model specification, converter logic, and schema validation, primarily to fix identity handling for protein groups (PGs). The main update is that PG identity now keys on the full group membership (`pg_accessions`), not just the leading protein, ensuring distinct groups are not conflated and duplicate identities are avoided. Additional improvements include more robust handling of spectrum references, better annotation aggregation, and relaxed duplicate key validation during conversion.

**Protein Group Identity and Data Model Updates:**

- Changed the default PG identity composite from `[anchor_protein, grouped_runs, label]` to `[pg_accessions, grouped_runs, label]` throughout the documentation and schema files, ensuring that the full protein group membership uniquely identifies a PG row, not just the leader. This fixes issues where distinct groups sharing a leader were previously conflated. [[1]](diffhunk://#diff-525ce305bef308915c399759ac1463bc63859a2e6e64280e2c29ee894948c9efL30-R30) [[2]](diffhunk://#diff-525ce305bef308915c399759ac1463bc63859a2e6e64280e2c29ee894948c9efL70-R70) [[3]](diffhunk://#diff-525ce305bef308915c399759ac1463bc63859a2e6e64280e2c29ee894948c9efL216-R216) [[4]](diffhunk://#diff-5a0e656d551f3eb133f9eccd2e924a5e660132b2e58319dea4148ad92d5ce5baL129-R129) [[5]](diffhunk://#diff-5d9fabdf6527d006c6b8a29e22c6d99297b7ccca2ce0b2614e820b9d7a739a8cL17-R17) [[6]](diffhunk://#diff-5d9fabdf6527d006c6b8a29e22c6d99297b7ccca2ce0b2614e820b9d7a739a8cL71-R71) [[7]](diffhunk://#diff-191f2074b33bf1d5694cbfeea90ba0bd8e63b8934c67a3e19788ab5efdf82daeL4-R4)

- Updated the documentation and schema for `pg_accessions` and `anchor_protein` to clarify their roles: `pg_accessions` is now part of the identity, and `anchor_protein` is descriptive only. [[1]](diffhunk://#diff-191f2074b33bf1d5694cbfeea90ba0bd8e63b8934c67a3e19788ab5efdf82daeL19-R19) [[2]](diffhunk://#diff-191f2074b33bf1d5694cbfeea90ba0bd8e63b8934c67a3e19788ab5efdf82daeL36-R36)

- Added a changelog entry for version 1.1.2, describing the backward-incompatible identity fix and the new duplicate key handling policy.

**Converter and Annotation Logic Improvements:**

- In the DIA-NN PG adapter, group-by logic now aggregates on `pg_accessions` and `run_file_name` only, using the first non-null value for names/genes within a group to avoid splitting on inconsistent annotations. [[1]](diffhunk://#diff-6f40067783999ec55b93f0ba095ff7936ff1c35606f1620ff89fa238b39d9f5eR48-R60) [[2]](diffhunk://#diff-6f40067783999ec55b93f0ba095ff7936ff1c35606f1620ff89fa238b39d9f5eL236-R265)

**Spectrum Reference Handling:**

- Improved spectrum ID parsing and attachment: introduced `_parse_native_id` to distinguish between scan numbers and 0-based indices, ensuring spectra are matched correctly by their nativeID scheme (scan vs. index). Updated PSM adapters and spectrum attachment logic to propagate and respect this scheme. [[1]](diffhunk://#diff-5e7ffdaee721cc07d54a774b444be12ecce985b211e0a19333d65b7b70840b84L332-R333) [[2]](diffhunk://#diff-5e7ffdaee721cc07d54a774b444be12ecce985b211e0a19333d65b7b70840b84R353-R356) [[3]](diffhunk://#diff-5e7ffdaee721cc07d54a774b444be12ecce985b211e0a19333d65b7b70840b84L412-R423) [[4]](diffhunk://#diff-5e7ffdaee721cc07d54a774b444be12ecce985b211e0a19333d65b7b70840b84L657-R706) [[5]](diffhunk://#diff-813572b0f34c99fe25165198086b26f92df6c5298ee7eed2f5670b42570d1204L157-R171)

**Schema Validation and Error Handling:**

- Changed schema validation during conversion to use `strict=False`, making duplicate primary keys a warning instead of a hard error (except for null primary keys, which remain fatal). This allows data to be persisted as-produced during format stabilization.

**Referential Integrity Checks:**

- Updated referential integrity checks to use `pg_accessions` instead of `anchor_protein` when verifying disjointness of `grouped_runs`, aligning with the new identity composite.