### PR TITLE
fix(fragpipe): pg_qvalue source, feature↔PSM join, decoy prefixes, MaxLFQ-only

### DIFF
--- a/qpx/converters/column_mappings.yaml
+++ b/qpx/converters/column_mappings.yaml
@@ -28,7 +28,10 @@ fragpipe:
       pg_accessions: ["Protein", "Protein ID"]
       gg_accessions: ["Gene", "Gene Names"]
       pg_names: ["Description", "Protein Description"]
-      pg_qvalue: ["Protein Probability", "Protein FDR", "Protein Q-Value", "Combined Protein FDR"]
+      # Real FDR/Q-Value columns first (low = best); "Protein Probability" is a
+      # confidence score (~1.0 = best) and must only be a last-resort fallback,
+      # converted as 1 - probability by the adapter — never used raw as a q-value.
+      pg_qvalue: ["Protein FDR", "Protein Q-Value", "Combined Protein FDR", "Protein Probability"]
       peptide_count_total: ["Combined Total Peptides", "Total Peptides"]
       peptide_count_unique: ["Combined Unique Peptides", "Unique Peptides"]
       spectral_count: ["Combined Spectral Count", "Spectral Count"]

--- a/qpx/converters/fragpipe/constants.py
+++ b/qpx/converters/fragpipe/constants.py
@@ -9,6 +9,27 @@ from typing import Optional
 from qpx.converters.ptm import build_proforma, from_proforma, mass_to_unimod
 
 # ---------------------------------------------------------------------------
+# Decoy detection
+# ---------------------------------------------------------------------------
+# FragPipe/Philosopher tag decoy accessions with one of these prefixes. Keep the
+# set identical across the psm/feature/pg adapters so a decoy is labelled the
+# same everywhere. Detection must run on the RAW accession, before any
+# ``sp|ACC|NAME`` parsing strips the prefix.
+DECOY_PREFIXES = ("rev_", "REV_", "DECOY_", "decoy_")
+
+
+def is_decoy_accession(protein_field: str) -> bool:
+    """True if any accession in a (possibly comma-joined) protein field is a decoy.
+
+    Operates on the raw string so ``rev_sp|P123|NAME`` is still recognised as a
+    decoy (``parse_uniprot_id`` would otherwise drop the ``rev_`` prefix).
+    """
+    if not protein_field:
+        return False
+    return any(part.strip().startswith(DECOY_PREFIXES) for part in str(protein_field).split(","))
+
+
+# ---------------------------------------------------------------------------
 # PTM parsing: FragPipe "Assigned Modifications" -> ProForma
 # ---------------------------------------------------------------------------
 

--- a/qpx/converters/fragpipe/feature_adapter.py
+++ b/qpx/converters/fragpipe/feature_adapter.py
@@ -12,7 +12,7 @@ from typing import Optional
 import pandas as pd
 
 from qpx.converters.base import BaseConverter, resolve_columns
-from qpx.converters.fragpipe.constants import to_modifications, to_proforma
+from qpx.converters.fragpipe.constants import is_decoy_accession, to_modifications, to_proforma
 from qpx.converters.mappings import get_field_mappings
 from qpx.converters.utils import parse_uniprot_id, safe_float
 from qpx.core.sql import escape_path, sql_build
@@ -186,11 +186,20 @@ class FragPipeFeatureAdapter(BaseConverter):
     # ------------------------------------------------------------------
 
     def _build_psm_lookup(self, psm_path: str) -> dict[tuple, dict]:
-        """Build a lookup from (run_file_name, peptidoform, charge) -> PSM info.
+        """Build a lookup for feature-level PSM enrichment.
 
-        Loads FragPipe ``psm.tsv`` into a temporary DuckDB table and extracts
-        the first-occurrence PSM per key, providing mass error, PEP, scan,
-        and decoy flag for feature-level enrichment.
+        Loads FragPipe ``psm.tsv`` into a temporary DuckDB table and extracts the
+        first-occurrence PSM providing mass error, PEP, scan, and decoy flag.
+
+        Each PSM is registered under two keys so that the feature side (which is
+        keyed by *experiment*, not raw file) can always resolve a match:
+
+        * ``(source_file, peptidoform, charge)`` — exact, used when the FragPipe
+          experiment name equals the raw-file stem (non-fractionated case);
+        * ``(peptidoform, charge)`` — fallback, used when experiment != raw file
+          (fractionated runs), where the 3-tuple would otherwise always miss.
+
+        The 2- and 3-element tuples never collide, so a single dict holds both.
         """
         lookup: dict[tuple, dict] = {}
 
@@ -285,19 +294,16 @@ class FragPipeFeatureAdapter(BaseConverter):
                 charge_str = str(charge) if charge is not None else "0"
 
                 key = (source_file, peptidoform, charge_str)
+                fallback_key = (peptidoform, charge_str)
                 if key not in lookup:
                     # PEP = 1 - PeptideProphet Probability
                     pep = None
                     if pp_prob is not None:
                         pep = 1.0 - pp_prob if pp_prob <= 1.0 else pp_prob
 
-                    is_decoy = (
-                        any(acc.strip().startswith(("rev_", "DECOY_", "decoy_", "REV_")) for acc in str(protein).split(","))
-                        if protein
-                        else False
-                    )
+                    is_decoy = is_decoy_accession(protein)
 
-                    lookup[key] = {
+                    info = {
                         "observed_mz": float(obs_mz) if obs_mz is not None else None,
                         "calculated_mz": (float(calc_mz) if calc_mz is not None else None),
                         "pep": pep,
@@ -306,6 +312,11 @@ class FragPipeFeatureAdapter(BaseConverter):
                         "ion_mobility": (float(ion_mobility) if ion_mobility is not None else None),
                         "missed_cleavages": (int(missed_cleavages_val) if missed_cleavages_val is not None else None),
                     }
+                    lookup[key] = info
+                    # Register the run-agnostic fallback (first occurrence wins) so
+                    # the experiment-keyed feature query still resolves when the
+                    # experiment name differs from the raw-file stem.
+                    lookup.setdefault(fallback_key, info)
 
             # Clean up temporary table
             self._conn.execute("DROP TABLE IF EXISTS _fp_psm_lookup")
@@ -404,22 +415,22 @@ class FragPipeFeatureAdapter(BaseConverter):
 
             intensities = [{"label": "LFQ", "intensity": float(intensity_val)}]
 
-            # PSM lookup: enrich with mass error, PEP, scan, decoy flag
+            # PSM lookup: enrich with mass error, PEP, scan, decoy flag. Try the
+            # exact (experiment==raw-file) key first, then the run-agnostic
+            # (peptidoform, charge) fallback so fractionated experiments still hit.
             psm_info = {}
             if psm_lookup:
-                psm_key = (experiment, peptidoform, str(charge))
-                psm_info = psm_lookup.get(psm_key, {})
+                psm_info = psm_lookup.get((experiment, peptidoform, str(charge)))
+                if not psm_info:
+                    psm_info = psm_lookup.get((peptidoform, str(charge)), {})
 
             _calc = psm_info.get("calculated_mz")
             _obs = psm_info.get("observed_mz")
             mass_error_ppm = 1e6 * (_obs - _calc) / _calc if _calc and _obs else None
 
-            # Is decoy: prefer PSM lookup; fall back to protein prefix
-            _is_decoy_fallback = (
-                any(p["accession"].startswith(("rev_", "DECOY_", "decoy_", "REV_")) for p in pg_accessions)
-                if pg_accessions
-                else False
-            )
+            # Is decoy: prefer PSM lookup; fall back to the decoy prefix on the RAW
+            # protein field (before parse_uniprot_id strips e.g. the "rev_" prefix).
+            _is_decoy_fallback = is_decoy_accession(protein_raw)
 
             rec = {
                 "sequence": sequence,

--- a/qpx/converters/fragpipe/pg_adapter.py
+++ b/qpx/converters/fragpipe/pg_adapter.py
@@ -17,6 +17,7 @@ import pandas as pd
 
 from qpx.converters.base import BaseConverter, resolve_columns
 from qpx.converters.channel_labels import experiment_runs_from_sdrf
+from qpx.converters.fragpipe.constants import is_decoy_accession
 from qpx.converters.mappings import get_field_mappings
 from qpx.converters.utils import safe_float
 from qpx.core.sql import escape_path, sql_build
@@ -300,8 +301,8 @@ class FragPipePgAdapter(BaseConverter):
 
         anchor_protein = pg_accessions[0] if pg_accessions else ""
 
-        # Is decoy: detected from rev_/DECOY_/decoy_ prefix on any accession
-        is_decoy = any(acc.strip().startswith(("rev_", "DECOY_", "decoy_")) for acc in pg_accessions) if pg_accessions else False
+        # Is decoy: detected from a decoy prefix on any RAW accession
+        is_decoy = is_decoy_accession(protein_raw)
 
         # Combined counts
         total_peptides = int(row.get(r.get("peptide_count_total", "Combined Total Peptides"), 0) or 0)
@@ -315,8 +316,18 @@ class FragPipePgAdapter(BaseConverter):
         if mol_weight is not None:
             mol_weight = mol_weight / 1000.0  # Convert Da to kDa
 
-        # Protein group q-value (Protein Probability, Protein FDR, etc.)
-        pg_qvalue = safe_float(row.get(r.get("pg_qvalue", "Protein Probability")))
+        # Protein group q-value. Real FDR/Q-Value columns are preferred (see the
+        # ordered mapping in column_mappings.yaml). "Protein Probability" is a
+        # confidence score (~1.0 = best), so when it is the only column present it
+        # is converted to an FDR-like value as 1 - probability, never used raw.
+        pg_qvalue_col = r.get("pg_qvalue")
+        pg_qvalue_raw = safe_float(row.get(pg_qvalue_col)) if pg_qvalue_col else None
+        if pg_qvalue_raw is None:
+            pg_qvalue = None
+        elif pg_qvalue_col == "Protein Probability":
+            pg_qvalue = 1.0 - pg_qvalue_raw
+        else:
+            pg_qvalue = pg_qvalue_raw
 
         # Peptides per protein
         peptides = [{"protein_name": acc, "peptide_count": total_peptides} for acc in pg_accessions]
@@ -329,17 +340,24 @@ class FragPipePgAdapter(BaseConverter):
             unique_spec_col = f"{experiment} Unique Spectral Count"
 
             total_intensity = safe_float(row.get(total_int_col)) or 0.0
-            if total_intensity <= 0:
+            maxlfq_val = safe_float(row.get(maxlfq_col))
+            # MaxLFQ-only experiments (detected from a "<exp> MaxLFQ Intensity"
+            # column) have no Total Intensity; fall back to MaxLFQ as the primary
+            # intensity rather than dropping the protein group entirely.
+            if total_intensity > 0:
+                primary_intensity = total_intensity
+            elif maxlfq_val is not None and maxlfq_val > 0:
+                primary_intensity = maxlfq_val
+            else:
                 continue
 
             # Intensities (new schema: {label, intensity})
             label = "LFQ"
-            intensities = [{"label": label, "intensity": float(total_intensity)}]
+            intensities = [{"label": label, "intensity": float(primary_intensity)}]
 
             # Additional intensities pre-computed by FragPipe (MaxLFQ)
             additional_intensities = []
             extra_vals = []
-            maxlfq_val = safe_float(row.get(maxlfq_col))
             if maxlfq_val is not None:
                 extra_vals.append({"intensity_name": "maxlfq", "intensity_value": float(maxlfq_val)})
             if extra_vals:

--- a/qpx/converters/fragpipe/psm_adapter.py
+++ b/qpx/converters/fragpipe/psm_adapter.py
@@ -18,7 +18,7 @@ from typing import Optional, Tuple
 import pandas as pd
 
 from qpx.converters.base import BaseConverter, resolve_columns
-from qpx.converters.fragpipe.constants import to_modifications, to_proforma
+from qpx.converters.fragpipe.constants import is_decoy_accession, to_modifications, to_proforma
 from qpx.converters.mappings import get_field_mappings
 from qpx.converters.utils import safe_float
 from qpx.core.scores import normalize_score_name
@@ -187,8 +187,9 @@ class FragPipePsmAdapter(BaseConverter):
         protein_id = str(row.get(r.get("pg_accessions", "Protein"), ""))
         protein_accessions = [protein_id] if protein_id else []
 
-        # Is decoy (bool) -- FragPipe marks decoys with "rev_" prefix
-        is_decoy = protein_id.startswith("rev_")
+        # Is decoy (bool) -- decoy prefix on any accession in the RAW protein field
+        # (rev_/REV_/DECOY_/decoy_), kept consistent with the feature/pg adapters.
+        is_decoy = is_decoy_accession(protein_id)
 
         # Peptidoform -- build ProForma from sequence + Assigned Modifications
         assigned_mods_raw = row.get("Assigned Modifications")

--- a/tests/converters/test_fragpipe_converter.py
+++ b/tests/converters/test_fragpipe_converter.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import pyarrow.parquet as pq
 import pytest
 
+from qpx.converters.fragpipe.feature_adapter import FragPipeFeatureAdapter
 from qpx.converters.fragpipe.pg_adapter import FragPipePgAdapter
+from qpx.converters.fragpipe.psm_adapter import FragPipePsmAdapter
 
 _COMBINED_PROTEIN_TSV = (
     "Protein\tGene\tDescription\t"
@@ -131,3 +133,165 @@ def test_experiment_annotation_and_explicit_mapping_are_mutually_exclusive(
                 experiment_to_runs={"exp1": ["run_A"]},
                 experiment_annotation_path=str(annotation_path),
             )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for bigbio/qpx#246 and #247
+# ---------------------------------------------------------------------------
+
+
+def _read_pg(tmp_path, protein_tsv, **convert_kwargs):
+    """Write a combined_protein.tsv, convert, and return the pg DataFrame."""
+    protein_path = tmp_path / "combined_protein.tsv"
+    protein_path.write_text(protein_tsv)
+    out_path = tmp_path / "fragpipe.pg.parquet"
+    convert_kwargs.setdefault("experiment_to_runs", {"expA": ["run_A"]})
+    with FragPipePgAdapter() as adapter:
+        adapter.convert(protein_path=str(protein_path), output_path=str(out_path), **convert_kwargs)
+    return pq.read_table(str(out_path)).to_pandas()
+
+
+def test_pg_qvalue_prefers_real_fdr_over_probability(tmp_path):
+    """#246: with a real FDR column present, pg_qvalue must come from it, not from
+    the always-present 'Protein Probability' confidence score."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein Probability\tProtein FDR\t"
+        "expA Total Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\tprot1\t0.9999\t0.001\t1000\t5\t3\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    # The bug stored 0.9999 (the raw probability) as a q-value.
+    assert df["pg_qvalue"].iloc[0] == pytest.approx(0.001)
+
+
+def test_pg_qvalue_probability_only_is_inverted(tmp_path):
+    """#246: when only 'Protein Probability' is available it is converted to an
+    FDR-like value (1 - probability), never stored raw."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein Probability\t"
+        "expA Total Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\tprot1\t0.9999\t1000\t5\t3\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    assert df["pg_qvalue"].iloc[0] == pytest.approx(1.0 - 0.9999)
+
+
+def test_maxlfq_only_experiment_emits_pg(tmp_path):
+    """#247 (M): an experiment detected only from a '<exp> MaxLFQ Intensity' column
+    (no Total Intensity) must still produce a pg record, using MaxLFQ as intensity."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein FDR\t"
+        "expA MaxLFQ Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\tprot1\t0.001\t1234\t5\t3\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    assert len(df) == 1
+    assert df["intensity"].iloc[0] == pytest.approx(1234.0)
+
+
+def test_maxlfq_falls_back_when_total_intensity_is_zero(tmp_path):
+    """A zero Total Intensity with a positive MaxLFQ still yields a record."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein FDR\t"
+        "expA Total Intensity\texpA MaxLFQ Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\tprot1\t0.001\t0\t1234\t5\t3\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    assert len(df) == 1
+    assert df["intensity"].iloc[0] == pytest.approx(1234.0)
+
+
+def test_pg_decoy_detected_from_raw_prefix(tmp_path):
+    """#247 (H): decoy prefixes (incl. REV_) are detected on the raw accession, not
+    after parse_uniprot_id strips them."""
+    tsv = (
+        "Protein\tGene\tDescription\tProtein FDR\t"
+        "expA Total Intensity\tCombined Total Peptides\tCombined Unique Peptides\n"
+        "sp|P1|A_HUMAN\tG1\ttarget\t0.001\t1000\t5\t3\n"
+        "REV_sp|P2|B_HUMAN\tG2\tdecoy\t0.02\t50\t2\t1\n"
+    )
+    df = _read_pg(tmp_path, tsv)
+    decoy_flag = {row["pg_accessions"][0]: bool(row["is_decoy"]) for _, row in df.iterrows()}
+    assert decoy_flag["sp|P1|A_HUMAN"] is False
+    assert decoy_flag["REV_sp|P2|B_HUMAN"] is True
+
+
+# ---- Feature adapter (combined_ion.tsv + psm.tsv) --------------------------
+
+
+def _write_feature_inputs(tmp_path, *, experiment, spectrum_source, protein="sp|P12345|PROT_HUMAN"):
+    ion = tmp_path / "combined_ion.tsv"
+    ion.write_text(
+        "Peptide Sequence\tModified Sequence\tProtein\tGene\tM/Z\tCharge\tAssigned Modifications\t"
+        f"{experiment} Intensity\t{experiment} MaxLFQ Intensity\n"
+        f"PEPTIDEK\tPEPTIDEK\t{protein}\tGENE1\t500.0\t2\t\t1000\t900\n"
+    )
+    psm = tmp_path / "psm.tsv"
+    psm.write_text(
+        "Spectrum\tPeptide\tCharge\tAssigned Modifications\t"
+        "Calibrated Observed M/Z\tCalculated M/Z\tPeptideProphet Probability\tProtein\n"
+        f"{spectrum_source}.00500.00500.2\tPEPTIDEK\t2\t\t500.001\t500.000\t0.99\trev_{protein}\n"
+    )
+    return ion, psm
+
+
+def test_feature_psm_enrichment_survives_experiment_raw_mismatch(tmp_path):
+    """#247 (H): the feature is keyed by *experiment* while the PSM is keyed by the
+    raw-file stem. When they differ (fractionated case) enrichment must still hit,
+    populating PEP, scan, mass error, and the decoy flag."""
+    ion, psm = _write_feature_inputs(tmp_path, experiment="sampleA", spectrum_source="run_01")
+    out = tmp_path / "feature.parquet"
+    with FragPipeFeatureAdapter() as adapter:
+        adapter.convert(feature_path=str(ion), output_path=str(out), psm_path=str(psm))
+    df = pq.read_table(str(out)).to_pandas()
+    assert len(df) == 1
+    rec = df.iloc[0]
+    assert rec["posterior_error_probability"] == pytest.approx(1.0 - 0.99)
+    assert list(rec["scan"]) == [500]
+    assert rec["mass_error_ppm"] == pytest.approx(1e6 * (500.001 - 500.000) / 500.000)
+    assert bool(rec["is_decoy"]) is True
+
+
+def test_feature_decoy_from_raw_accession_without_psm(tmp_path):
+    """#247 (H): without a psm.tsv, is_decoy falls back to the raw protein prefix,
+    which must survive parse_uniprot_id (rev_sp|..| -> still a decoy)."""
+    ion = tmp_path / "combined_ion.tsv"
+    ion.write_text(
+        "Peptide Sequence\tModified Sequence\tProtein\tGene\tM/Z\tCharge\tAssigned Modifications\t"
+        "sampleA Intensity\n"
+        "PEPTIDEK\tPEPTIDEK\trev_sp|P12345|PROT_HUMAN\tGENE1\t500.0\t2\t\t1000\n"
+    )
+    out = tmp_path / "feature.parquet"
+    with FragPipeFeatureAdapter() as adapter:
+        adapter.convert(feature_path=str(ion), output_path=str(out))
+    df = pq.read_table(str(out)).to_pandas()
+    assert bool(df.iloc[0]["is_decoy"]) is True
+
+
+# ---- PSM adapter (psm.tsv) -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("protein", "expected"),
+    [
+        ("sp|P1|A_HUMAN", False),
+        ("rev_sp|P1|A_HUMAN", True),
+        ("REV_sp|P1|A_HUMAN", True),
+        ("DECOY_sp|P1|A_HUMAN", True),
+        ("sp|P1|A_HUMAN, rev_sp|P2|B_HUMAN", True),
+    ],
+)
+def test_psm_decoy_prefixes_consistent(tmp_path, protein, expected):
+    """#247 (H): psm.tsv decoy detection recognises the same prefix set as the
+    feature/pg adapters and inspects every comma-separated accession."""
+    psm = tmp_path / "psm.tsv"
+    psm.write_text(
+        "Spectrum\tPeptide\tCharge\tAssigned Modifications\t"
+        "Observed M/Z\tCalculated M/Z\tRetention\tProtein\n"
+        f"run_01.00500.00500.2\tPEPTIDEK\t2\t\t500.001\t500.000\t123.4\t{protein}\n"
+    )
+    out = tmp_path / "psm.parquet"
+    with FragPipePsmAdapter() as adapter:
+        adapter.convert(psm_path=str(psm), output_path=str(out))
+    df = pq.read_table(str(out)).to_pandas()
+    assert bool(df.iloc[0]["is_decoy"]) is expected


### PR DESCRIPTION
Stacked on #240. FragPipe converter correctness fixes.

- **#246** — stop filling `pg_qvalue` from the inverted "Protein Probability" metric; order real FDR/Q-Value columns first, fall back to `1 - probability` only.
- **#247** — align the feature↔PSM enrichment lookup key (build vs query), derive `is_decoy` from the raw accession before prefix stripping (with a consistent `rev_/REV_/DECOY_/decoy_` set), and fall back to MaxLFQ intensity so MaxLFQ-only experiments aren't dropped.

Regression tests added (164 lines). Full suite: 890 passed; ruff clean. Closes #246, closes #247.