### PR TITLE
fix(maxquant): PSM empty-modseq crash, dedup=identity, TMT drop warn, pg leader collision

### DIFF
--- a/qpx/converters/maxquant/feature_adapter.py
+++ b/qpx/converters/maxquant/feature_adapter.py
@@ -82,6 +82,10 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
             chunksize: Rows per batch.
             creator: Creator tag in Parquet metadata.
         """
+        # Track which dropped-TMT-channel warnings have already been emitted so
+        # the message is logged once, not once per batch.
+        self._warned_tmt_channels: set = set()
+
         # Step 1: Load evidence into DuckDB
         self._load_evidence(evidence_path)
 
@@ -122,24 +126,43 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
         self.logger.info(f"MaxQuant feature conversion complete -> {output_path}")
 
     def _deduplicated_evidence_query(self, actual_cols: set[str]) -> str:
-        """Prefer identified evidence when MaxQuant repeats an MBR feature."""
-        identity_columns = [
+        """Collapse rows that share the feature identity, preferring identified evidence.
+
+        The partition key mirrors ``_FEATURE_IDENTITY_COMPOSITE`` -- the columns
+        ``feature_id`` is hashed from -- so rows resolving to the same
+        ``feature_id`` collapse to one. The previous key partitioned on
+        ``Calibrated retention time`` (which is *not* part of the identity), so
+        identity-equal rows differing only in calibrated RT survived as
+        duplicate primary keys. Only identity columns actually present are used;
+        a missing column narrows the partition rather than degrading to a
+        no-dedup ``SELECT * FROM evidence`` (which would let MBR duplicates
+        through).
+        """
+        # Map each identity-composite field to its resolved MaxQuant column.
+        # "Modified sequence" stands in for ``peptidoform`` (a deterministic
+        # function of it); the remaining fields match the composite directly.
+        identity_field_columns = [
             self._resolved.get("modified_sequence", "Modified sequence"),
             self._resolved.get("charge", "Charge"),
             self._resolved.get("run_file_name", "Raw file"),
-            self._resolved.get("rt", "Calibrated retention time"),
+            self._resolved.get("rt_start", "Calibrated retention time start"),
+            self._resolved.get("rt_stop", "Calibrated retention time finish"),
+            self._resolved.get("scan", "MS/MS scan number"),
         ]
-        if "Type" not in actual_cols or not all(column in actual_cols for column in identity_columns):
+        identity_columns = [column for column in identity_field_columns if column in actual_cols]
+        if not identity_columns:
             return "SELECT * FROM evidence"
 
         partition_by = ", ".join(validate_identifier(column) for column in identity_columns)
-        type_column = validate_identifier("Type")
-        order_by = [
-            sql_build(
-                "CASE WHEN UPPER(TRIM(CAST($type_column AS VARCHAR))) = 'MULTI-MATCH' THEN 1 ELSE 0 END",
-                type_column=type_column,
+        order_by = []
+        if "Type" in actual_cols:
+            type_column = validate_identifier("Type")
+            order_by.append(
+                sql_build(
+                    "CASE WHEN UPPER(TRIM(CAST($type_column AS VARCHAR))) = 'MULTI-MATCH' THEN 1 ELSE 0 END",
+                    type_column=type_column,
+                )
             )
-        ]
         pep_column = self._resolved.get("posterior_error_probability", "PEP")
         if pep_column in actual_cols:
             order_by.append(
@@ -155,6 +178,9 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
                     id_column=validate_identifier("id"),
                 )
             )
+        if not order_by:
+            # No preference columns present; keep an arbitrary-but-stable row.
+            order_by.append("1")
 
         return sql_build(
             """
@@ -187,12 +213,22 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
     # ------------------------------------------------------------------
 
     def _build_protein_group_maps(self, protein_groups_path: Optional[str]) -> dict:
-        """Build protein accession lookup maps from proteinGroups.txt.
+        """Build protein-group lookup maps from proteinGroups.txt.
 
-        Returns a dict with ``qvalue`` and ``genes`` sub-maps.
+        Returns a dict with two sub-maps:
+            ``by_group``: full protein-group membership (a ``frozenset`` of
+                normalised accessions) -> ``{"qvalue", "genes"}``. This is the
+                primary key, consistent with the pg identity fix which keys on
+                the whole ``pg_accessions`` membership rather than the leader.
+            ``by_accession``: single accession -> ``{"qvalue", "genes"}``, but
+                *only* for accessions that belong to exactly one protein group.
+                Ambiguous razor accessions (shared across groups) are excluded
+                so a feature cannot inherit another group's q-value/genes via
+                its leader.
         """
+        empty = {"by_group": {}, "by_accession": {}}
         if not protein_groups_path:
-            return {"qvalue": {}, "genes": {}}
+            return empty
         try:
             df = self._conn.execute(
                 "SELECT * FROM read_csv_auto($1, delim='\t', header=true, auto_detect=true, null_padding=true)",
@@ -200,18 +236,17 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
             ).df()
             acc_col, qval_col, gene_col = self._detect_pg_columns(df)
             if not acc_col:
-                return {"qvalue": {}, "genes": {}}
-            qvalue_map = self._extract_qvalue_map(df, acc_col, qval_col)
-            gene_map = self._extract_gene_map(df, acc_col, gene_col)
+                return empty
+            maps = self._build_pg_lookup(df, acc_col, qval_col, gene_col)
             self.logger.info(
-                "Built protein group maps: %d q-values, %d gene entries",
-                len(qvalue_map),
-                len(gene_map),
+                "Built protein group maps: %d group(s), %d unambiguous accession(s)",
+                len(maps["by_group"]),
+                len(maps["by_accession"]),
             )
-            return {"qvalue": qvalue_map, "genes": gene_map}
+            return maps
         except (FileNotFoundError, pd.errors.ParserError, KeyError, ValueError, duckdb.Error) as e:
             self.logger.warning("Could not build protein group maps: %s", e)
-        return {"qvalue": {}, "genes": {}}
+        return empty
 
     @staticmethod
     def _detect_pg_columns(df: pd.DataFrame) -> tuple:
@@ -225,43 +260,68 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
         return acc_col, qval_col, gene_col
 
     @staticmethod
-    def _extract_qvalue_map(df: pd.DataFrame, acc_col: str, qval_col: Optional[str]) -> dict[str, float]:
-        """Build accession -> q-value map from proteinGroups DataFrame."""
-        if not qval_col:
-            return {}
-        sub = df[[acc_col, qval_col]].copy()
-        sub[qval_col] = pd.to_numeric(sub[qval_col], errors="coerce")
-        sub = sub.dropna(subset=[qval_col])
-        # Explode semicolon-separated protein groups into individual accessions
-        sub = sub.assign(**{acc_col: sub[acc_col].astype(str).str.split(";")}).explode(acc_col)
-        sub[acc_col] = sub[acc_col].str.strip().apply(strip_uniprot_prefix)
-        sub = sub[sub[acc_col].str.len() > 0].drop_duplicates(subset=[acc_col], keep="first")
-        return dict(zip(sub[acc_col], sub[qval_col]))
+    def _canonical_group_key(accessions) -> frozenset:
+        """Order-independent key for a protein-group membership."""
+        return frozenset(a.strip() for a in accessions if a and a.strip())
 
     @staticmethod
-    def _extract_gene_map(df: pd.DataFrame, acc_col: str, gene_col: Optional[str]) -> dict[str, list[str]]:
-        """Build accession -> gene name list map from proteinGroups DataFrame."""
-        gene_map: dict[str, list[str]] = {}
+    def _parse_genes(gene_raw, fasta_raw) -> Optional[list[str]]:
+        """Parse gene names from a proteinGroups row (Gene names, else Fasta headers)."""
+        genes: list[str] | None = None
+        if gene_raw is not None and pd.notna(gene_raw) and str(gene_raw).strip():
+            genes = [g.strip() for g in str(gene_raw).split(";") if g.strip()] or None
+        if not genes and fasta_raw is not None and pd.notna(fasta_raw) and str(fasta_raw).strip():
+            genes = []
+            for hdr in str(fasta_raw).split(";"):
+                m = re.search(r"GN=([^\s;]+)", hdr)
+                if m and m.group(1) not in genes:
+                    genes.append(m.group(1))
+            genes = genes or None
+        return genes
+
+    def _build_pg_lookup(self, df: pd.DataFrame, acc_col: str, qval_col: Optional[str], gene_col: Optional[str]) -> dict:
+        """Build the ``by_group``/``by_accession`` lookup maps (see caller)."""
+        by_group: dict[frozenset, dict] = {}
+        acc_to_groups: dict[str, set] = {}
+        acc_value: dict[str, dict] = {}
+
         acc_vals = df[acc_col].astype(str).tolist()
+        qval_vals = pd.to_numeric(df[qval_col], errors="coerce").tolist() if qval_col else [None] * len(df)
         gene_vals = df[gene_col].tolist() if (gene_col and gene_col in df.columns) else [None] * len(df)
         fasta_vals = df["Fasta headers"].tolist() if "Fasta headers" in df.columns else [None] * len(df)
-        for acc_raw, gene_raw, fasta_raw in zip(acc_vals, gene_vals, fasta_vals):
+
+        for acc_raw, qval, gene_raw, fasta_raw in zip(acc_vals, qval_vals, gene_vals, fasta_vals):
             accs = [strip_uniprot_prefix(a.strip()) for a in acc_raw.split(";") if a.strip()]
-            genes: list[str] | None = None
-            if gene_raw and pd.notna(gene_raw):
-                genes = [g.strip() for g in str(gene_raw).split(";") if g.strip()] or None
-            if not genes and fasta_raw and pd.notna(fasta_raw):
-                genes = []
-                for hdr in str(fasta_raw).split(";"):
-                    m = re.search(r"GN=([^\s;]+)", hdr)
-                    if m and m.group(1) not in genes:
-                        genes.append(m.group(1))
-                genes = genes or None
-            if genes:
-                for acc in accs:
-                    if acc not in gene_map:
-                        gene_map[acc] = genes
-        return gene_map
+            if not accs:
+                continue
+            qvalue = float(qval) if qval is not None and pd.notna(qval) else None
+            genes = self._parse_genes(gene_raw, fasta_raw)
+            value = {"qvalue": qvalue, "genes": genes}
+            key = self._canonical_group_key(accs)
+            by_group.setdefault(key, value)
+            for acc in accs:
+                acc_to_groups.setdefault(acc, set()).add(key)
+                acc_value.setdefault(acc, value)
+
+        # Keep only accessions that map to a single protein group for the
+        # leader fallback; ambiguous accessions would otherwise collide.
+        by_accession = {acc: acc_value[acc] for acc, keys in acc_to_groups.items() if len(keys) == 1}
+        return {"by_group": by_group, "by_accession": by_accession}
+
+    def _lookup_pg_metadata(self, pg_maps: Optional[dict], pg_acc_list: list[str], anchor_protein: str) -> tuple:
+        """Resolve ``(pg_global_qvalue, genes)`` for a feature's protein group.
+
+        Keyed on the full protein-group membership first; only falls back to the
+        leader accession when that leader is unambiguous (belongs to one group).
+        """
+        if not pg_maps:
+            return None, None
+        entry = pg_maps.get("by_group", {}).get(self._canonical_group_key(pg_acc_list))
+        if entry is None and anchor_protein:
+            entry = pg_maps.get("by_accession", {}).get(anchor_protein)
+        if entry is None:
+            return None, None
+        return entry.get("qvalue"), entry.get("genes")
 
     def _detect_ri_offset(self, columns) -> int:
         """Detect whether reporter intensity columns are 0-indexed or 1-indexed.
@@ -277,6 +337,39 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
             return 0
         return 1
 
+    def _warn_dropped_tmt_channels(self, columns, experiment_type: str, tmt_channels: list[str], ri_offset: int) -> None:
+        """Warn when the SDRF plex declares channels absent from evidence.txt.
+
+        A ``Reporter intensity N`` column missing for a declared channel means
+        that channel is silently dropped from every feature; surface it once.
+        """
+        if getattr(self, "_warned_tmt_channels", None) is None:  # pragma: no cover - defensive
+            self._warned_tmt_channels = set()
+        exp_type = re.sub(r"\d+", "", experiment_type or "").upper()
+        if exp_type not in ("TMT", "ITRAQ") or not tmt_channels:
+            return
+        col_set = set(columns)
+        dropped: list[tuple[str, str]] = []
+        for seq_idx, channel_name in enumerate(tmt_channels):
+            col_idx = TMT_LABEL_TO_MQ_COL.get(str(channel_name).strip().upper())
+            if col_idx is None:
+                col_idx = seq_idx
+            col_name = f"Reporter intensity {col_idx + ri_offset}"
+            if col_name not in col_set:
+                dropped.append((str(channel_name), col_name))
+        if not dropped:
+            return
+        key = tuple(sorted(ch for ch, _ in dropped))
+        if key in self._warned_tmt_channels:
+            return
+        self._warned_tmt_channels.add(key)
+        logger.warning(
+            "SDRF declares %d TMT/iTRAQ channel(s) with no matching reporter intensity "
+            "column in evidence.txt; these channels are dropped from all features: %s",
+            len(dropped),
+            ", ".join(f"{ch} (expected {col})" for ch, col in dropped),
+        )
+
     def _transform_batch(
         self,
         df: pd.DataFrame,
@@ -290,6 +383,8 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
         records: list[dict] = []
         # Detect reporter intensity column indexing once per batch
         ri_offset = self._detect_ri_offset(df.columns)
+        # Warn (once) about SDRF channels with no reporter column in evidence.txt
+        self._warn_dropped_tmt_channels(df.columns, experiment_type, tmt_channels, ri_offset)
         # Pre-extract column arrays for faster per-row access than to_dict("records")
         col_arrays = {col: df[col].values for col in df.columns}
         n_rows = len(df)
@@ -386,11 +481,14 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
         # Unique peptide indicator
         unique = len(pg_acc_list) <= 1
 
+        # Protein-group q-value and genes, keyed on the full membership.
+        pg_qvalue, pg_genes = self._lookup_pg_metadata(pg_maps, pg_acc_list, anchor_protein)
+
         # Gene names
         gg_raw = row.get(r.get("gg_names", "Gene names"))
         gg_names = str(gg_raw).split(";") if pd.notna(gg_raw) and gg_raw else None
-        if not gg_names and pg_maps and anchor_protein:
-            gg_names = pg_maps.get("genes", {}).get(anchor_protein)
+        if not gg_names:
+            gg_names = pg_genes
 
         # Mass error (ppm) — direct column from evidence.txt
         mass_error_ppm = safe_float(row.get(r.get("mass_error_ppm", "Mass error [ppm]")))
@@ -452,7 +550,7 @@ class MaxQuantFeatureAdapter(MaxQuantBaseAdapter):
             "pg_accessions": pg_accessions,
             "anchor_protein": anchor_protein,
             "unique": unique,
-            "pg_global_qvalue": (pg_maps.get("qvalue", {}).get(anchor_protein) if pg_maps else None),
+            "pg_global_qvalue": pg_qvalue,
             "ion_mobility_start": None,
             "ion_mobility_stop": None,
             "gg_accessions": gg_names,

--- a/qpx/converters/maxquant/pg_adapter.py
+++ b/qpx/converters/maxquant/pg_adapter.py
@@ -50,6 +50,8 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
         super().__init__(**kwargs)
         self._experiment_to_runs: dict[str, list[str]] = {}
         self._sdrf_experiment_to_runs: dict[str, list[str]] | None = None
+        # Dropped-TMT-channel warnings already emitted (once per experiment).
+        self._warned_tmt_channels: set = set()
 
     def convert(
         self,
@@ -287,6 +289,26 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
             records.extend(recs)
         return records
 
+    def _warn_dropped_tmt_channels(self, experiment: str, dropped_channels: list[str]) -> None:
+        """Warn once per experiment about declared channels absent from proteinGroups.txt.
+
+        A channel with no matching ``Reporter intensity N <experiment>`` column
+        is silently dropped from the protein-group intensities; surface it.
+        """
+        if not dropped_channels:
+            return
+        key = (experiment, tuple(sorted(dropped_channels)))
+        if key in self._warned_tmt_channels:
+            return
+        self._warned_tmt_channels.add(key)
+        logger.warning(
+            "SDRF declares %d TMT/iTRAQ channel(s) with no matching reporter intensity "
+            "column for experiment %r in proteinGroups.txt; dropped: %s",
+            len(dropped_channels),
+            experiment,
+            ", ".join(dropped_channels),
+        )
+
     @staticmethod
     def _extract_gene_names(fasta_headers: str) -> list[str] | None:
         """Extract gene names from Fasta header lines using ``GN=`` tag."""
@@ -421,6 +443,7 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
                 intensities: list[dict] = []
                 additional_intensities: list[dict] = []
                 channels = tmt_channels or []
+                dropped_channels: list[str] = []
                 for seq_idx, channel_name in enumerate(channels):
                     col_idx = TMT_LABEL_TO_MQ_COL.get(str(channel_name).strip().upper())
                     if col_idx is None:
@@ -428,6 +451,7 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
                     mq_col_num = col_idx + ri_offset
                     col_name = ch_cols.get(mq_col_num)
                     if not col_name:
+                        dropped_channels.append(str(channel_name))
                         continue
                     val = safe_float(row.get(col_name))
                     if val and val > 0:
@@ -443,6 +467,7 @@ class MaxQuantPgAdapter(MaxQuantBaseAdapter):
                                     ],
                                 }
                             )
+                self._warn_dropped_tmt_channels(exp, dropped_channels)
                 if intensities:
                     records.append(_make_rec(self._runs_for(exp), intensities, additional_intensities))
         else:

--- a/qpx/converters/maxquant/psm_adapter.py
+++ b/qpx/converters/maxquant/psm_adapter.py
@@ -149,6 +149,10 @@ class MaxQuantPsmAdapter(MaxQuantBaseAdapter):
         if pd.notna(phospho_raw) and phospho_raw:
             site_scores = parse_phospho_probabilities(str(phospho_raw))
 
+        # Mirror the feature adapter: an empty/missing "Modified sequence"
+        # yields no peptidoform, and the tuple-unpack must degrade to
+        # (None, None) rather than a bare None (which raises TypeError and
+        # aborts the whole PSM view).
         peptidoform, modifications = (
             from_proforma(
                 peptidoform,
@@ -156,8 +160,13 @@ class MaxQuantPsmAdapter(MaxQuantBaseAdapter):
                 site_scores=site_scores,
             )
             if peptidoform
-            else None
+            else (None, None)
         )
+        if peptidoform is None:
+            # PsmSchema requires a peptidoform; a row with an empty/missing
+            # "Modified sequence" is skipped rather than aborting the whole view.
+            self.logger.debug("Skipping PSM row with empty modified sequence (sequence=%r)", sequence)
+            return None
         charge_raw = row.get(r.get("charge", "Charge"), 0)
         charge = int(charge_raw) if pd.notna(charge_raw) else 0
 

--- a/qpx/core/sql.py
+++ b/qpx/core/sql.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 import re
 from string import Template
 
-_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_\[\].: ]*$")
+# The result is always double-quoted, so the only character that could break out
+# of the quoted identifier is ``"`` itself (excluded). ``/`` is allowed because
+# MaxQuant column names legitimately contain it (e.g. "MS/MS scan number", "m/z").
+_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_\[\].:/ ]*$")
 _SAFE_TABLE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 

--- a/tests/converters/test_converter_utils.py
+++ b/tests/converters/test_converter_utils.py
@@ -3,7 +3,7 @@
 Tests cover:
 - BaseConverter._escape_path (SQL path injection prevention)
 - MaxQuantPgAdapter._extract_protein_names / _extract_gene_names
-- MaxQuantFeatureAdapter._detect_pg_columns / _extract_qvalue_map / _extract_gene_map
+- MaxQuantFeatureAdapter._detect_pg_columns / _build_pg_lookup / _lookup_pg_metadata
 """
 
 import pandas as pd
@@ -139,69 +139,108 @@ class TestDetectPgColumns:
 
 
 # ---------------------------------------------------------------------------
-# MaxQuantFeatureAdapter._extract_qvalue_map
+# MaxQuantFeatureAdapter._build_pg_lookup / _lookup_pg_metadata
 # ---------------------------------------------------------------------------
 
 
-class TestExtractQvalueMap:
-    """Validate q-value map extraction."""
+class TestBuildPgLookup:
+    """Validate membership-keyed protein-group q-value/gene maps."""
 
-    def test_basic_qvalue_map(self):
-        df = pd.DataFrame({"Protein IDs": ["P1;P2", "P3"], "Q-value": [0.01, 0.05]})
-        result = MaxQuantFeatureAdapter._extract_qvalue_map(df, "Protein IDs", "Q-value")
-        if result["P1"] != 0.01:
-            raise AssertionError(f"Expected 0.01 for P1, got {result['P1']!r}")
-        if result["P2"] != 0.01:
-            raise AssertionError(f"Expected 0.01 for P2, got {result['P2']!r}")
-        if result["P3"] != 0.05:
-            raise AssertionError(f"Expected 0.05 for P3, got {result['P3']!r}")
+    def _build(self, df, qval_col="Q-value", gene_col="Gene names"):
+        with MaxQuantFeatureAdapter() as adapter:
+            return adapter._build_pg_lookup(df, "Protein IDs", qval_col, gene_col)
 
-    def test_first_occurrence_wins(self):
-        df = pd.DataFrame({"Protein IDs": ["P1", "P1"], "Q-value": [0.01, 0.99]})
-        result = MaxQuantFeatureAdapter._extract_qvalue_map(df, "Protein IDs", "Q-value")
-        if result["P1"] != 0.01:
-            raise AssertionError(f"Expected 0.01 for P1, got {result['P1']!r}")
+    def test_group_keyed_qvalue(self):
+        df = pd.DataFrame({"Protein IDs": ["P1;P2", "P3"], "Q-value": [0.01, 0.05], "Gene names": [None, None]})
+        maps = self._build(df)
+        by_group = maps["by_group"]
+        if by_group[frozenset({"P1", "P2"})]["qvalue"] != 0.01:
+            raise AssertionError(f"Unexpected group qvalue: {by_group[frozenset({'P1', 'P2'})]!r}")
+        if by_group[frozenset({"P3"})]["qvalue"] != 0.05:
+            raise AssertionError(f"Unexpected group qvalue: {by_group[frozenset({'P3'})]!r}")
+
+    def test_ambiguous_accession_excluded_from_leader_fallback(self):
+        # P1 appears in two distinct groups → must NOT be in by_accession.
+        df = pd.DataFrame(
+            {
+                "Protein IDs": ["P1;P2", "P1;P3"],
+                "Q-value": [0.01, 0.20],
+                "Gene names": ["GENEA", "GENEB"],
+            }
+        )
+        maps = self._build(df)
+        if "P1" in maps["by_accession"]:
+            raise AssertionError("Ambiguous accession P1 must be excluded from the leader fallback")
+        # P2 and P3 are unique to one group each.
+        if maps["by_accession"]["P2"]["qvalue"] != 0.01:
+            raise AssertionError(f"Unexpected P2 qvalue: {maps['by_accession']['P2']!r}")
+        if maps["by_accession"]["P3"]["qvalue"] != 0.20:
+            raise AssertionError(f"Unexpected P3 qvalue: {maps['by_accession']['P3']!r}")
 
     def test_no_qval_col(self):
-        df = pd.DataFrame({"Protein IDs": ["P1"]})
-        result = MaxQuantFeatureAdapter._extract_qvalue_map(df, "Protein IDs", None)
-        if result != {}:
-            raise AssertionError(f"Expected empty dict, got {result!r}")
+        df = pd.DataFrame({"Protein IDs": ["P1"], "Gene names": [None]})
+        maps = self._build(df, qval_col=None)
+        if maps["by_group"][frozenset({"P1"})]["qvalue"] is not None:
+            raise AssertionError("Expected None qvalue when no q-value column present")
 
+    def test_genes_from_gene_column(self):
+        df = pd.DataFrame({"Protein IDs": ["P1;P2"], "Q-value": [0.01], "Gene names": ["TP53;BRCA1"]})
+        maps = self._build(df)
+        genes = maps["by_group"][frozenset({"P1", "P2"})]["genes"]
+        if genes != ["TP53", "BRCA1"]:
+            raise AssertionError(f"Unexpected genes: {genes!r}")
 
-# ---------------------------------------------------------------------------
-# MaxQuantFeatureAdapter._extract_gene_map
-# ---------------------------------------------------------------------------
-
-
-class TestExtractGeneMap:
-    """Validate gene map extraction with Fasta header fallback."""
-
-    def test_from_gene_column(self):
-        df = pd.DataFrame({"Protein IDs": ["P1;P2"], "Gene names": ["TP53;BRCA1"]})
-        result = MaxQuantFeatureAdapter._extract_gene_map(df, "Protein IDs", "Gene names")
-        if result["P1"] != ["TP53", "BRCA1"]:
-            raise AssertionError(f"Unexpected P1: {result['P1']!r}")
-        if result["P2"] != ["TP53", "BRCA1"]:
-            raise AssertionError(f"Unexpected P2: {result['P2']!r}")
-
-    def test_fasta_fallback(self):
+    def test_genes_fasta_fallback(self):
         df = pd.DataFrame(
             {
                 "Protein IDs": ["P1"],
+                "Q-value": [0.01],
                 "Gene names": [None],
                 "Fasta headers": ["sp|P1|X GN=TP53 PE=1"],
             }
         )
-        result = MaxQuantFeatureAdapter._extract_gene_map(df, "Protein IDs", "Gene names")
-        if result["P1"] != ["TP53"]:
-            raise AssertionError(f"Unexpected P1: {result['P1']!r}")
+        maps = self._build(df)
+        genes = maps["by_group"][frozenset({"P1"})]["genes"]
+        if genes != ["TP53"]:
+            raise AssertionError(f"Unexpected genes: {genes!r}")
 
-    def test_no_gene_info(self):
-        df = pd.DataFrame({"Protein IDs": ["P1"], "Gene names": [None]})
-        result = MaxQuantFeatureAdapter._extract_gene_map(df, "Protein IDs", "Gene names")
-        if result != {}:
-            raise AssertionError(f"Expected empty dict, got {result!r}")
+
+class TestLookupPgMetadata:
+    """Validate feature-side lookup keyed on full membership, leader as fallback."""
+
+    def test_full_membership_wins_over_leader(self):
+        # Razor accession P1 is shared by two groups with different q-values.
+        # A feature whose membership is {P1,P3} must get the {P1,P3} group's
+        # q-value/genes, not the first group's, even though P1 is the leader.
+        df = pd.DataFrame(
+            {
+                "Protein IDs": ["P1;P2", "P1;P3"],
+                "Q-value": [0.01, 0.20],
+                "Gene names": ["GENEA", "GENEB"],
+            }
+        )
+        with MaxQuantFeatureAdapter() as adapter:
+            maps = adapter._build_pg_lookup(df, "Protein IDs", "Q-value", "Gene names")
+            qvalue, genes = adapter._lookup_pg_metadata(maps, ["P1", "P3"], "P1")
+        if qvalue != 0.20:
+            raise AssertionError(f"Expected 0.20 for the {{P1,P3}} membership, got {qvalue!r}")
+        if genes != ["GENEB"]:
+            raise AssertionError(f"Expected ['GENEB'] for the {{P1,P3}} membership, got {genes!r}")
+
+    def test_leader_fallback_only_when_unambiguous(self):
+        df = pd.DataFrame(
+            {
+                "Protein IDs": ["P1;P2", "P3;P4"],
+                "Q-value": [0.01, 0.05],
+                "Gene names": ["GENEA", "GENEB"],
+            }
+        )
+        with MaxQuantFeatureAdapter() as adapter:
+            maps = adapter._build_pg_lookup(df, "Protein IDs", "Q-value", "Gene names")
+            # Membership doesn't match any group, but leader P3 is unambiguous.
+            qvalue, genes = adapter._lookup_pg_metadata(maps, ["P3"], "P3")
+        if qvalue != 0.05 or genes != ["GENEB"]:
+            raise AssertionError(f"Expected unambiguous leader fallback, got {(qvalue, genes)!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/converters/test_maxquant_converter.py
+++ b/tests/converters/test_maxquant_converter.py
@@ -49,17 +49,32 @@ def test_pg_rejects_unassignable_total_intensity(tmp_path):
     assert not output.exists()
 
 
-def test_feature_deduplication_prefers_identified_evidence(tmp_path):
-    """An identified row must win over its duplicate MBR evidence row."""
+_EVIDENCE_HEADER = (
+    "Sequence\tModified sequence\tCharge\tRaw file\tType\tMS/MS scan number\tm/z\t"
+    "Calibrated retention time\tCalibrated retention time start\tCalibrated retention time finish\t"
+    "PEP\tLeading razor protein\tLeading proteins\tIntensity\tMass\tid\n"
+)
+
+
+def test_feature_dedup_collapses_identity_equal_rows(tmp_path):
+    """Bug #248 (H): rows sharing the feature identity composite must collapse.
+
+    The two ``run1`` rows share (peptidoform, charge, run, rt_start, rt_stop, scan)
+    — i.e. the same ``feature_id`` — and differ only in ``Calibrated retention
+    time``. The old dedup partitioned on calibrated RT (not part of the identity),
+    so both survived as duplicate primary keys. They must now collapse to one,
+    keeping the identified (MULTI-MSMS, lower PEP) row over the MBR one.
+    """
     from qpx.converters.maxquant.feature_adapter import MaxQuantFeatureAdapter
 
     evidence = tmp_path / "evidence.txt"
     evidence.write_text(
-        "Sequence\tModified sequence\tCharge\tRaw file\tType\tMS/MS scan number\tm/z\t"
-        "Calibrated retention time\tPEP\tLeading razor protein\tLeading proteins\tIntensity\tMass\tid\n"
-        "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MSMS\t100\t450.25\t30.0\t0.01\tP1\tP1\t1000\t898.5\t1\n"
-        "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MATCH\t\t450.25\t30.0\t\tP1\tP1\t1000\t898.5\t2\n"
-        "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MSMS\t101\t450.25\t31.0\t0.02\tP1\tP1\t2000\t898.5\t3\n"
+        _EVIDENCE_HEADER
+        # Identified row and its MBR twin: same scan/rt-window, differ in calibrated RT.
+        + "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MSMS\t100\t450.25\t30.0\t29.5\t30.5\t0.01\tP1\tP1\t1000\t898.5\t1\n"
+        + "PEPTIDEK\t_PEPTIDEK_\t2\trun1\tMULTI-MATCH\t100\t450.25\t30.4\t29.5\t30.5\t0.90\tP1\tP1\t1000\t898.5\t2\n"
+        # A genuinely distinct feature (different charge/scan) must survive.
+        + "PEPTIDEK\t_PEPTIDEK_\t3\trun1\tMULTI-MSMS\t200\t300.50\t40.0\t39.5\t40.5\t0.02\tP1\tP1\t2000\t898.5\t3\n"
     )
     output = tmp_path / "feature.parquet"
 
@@ -67,11 +82,152 @@ def test_feature_deduplication_prefers_identified_evidence(tmp_path):
         adapter.convert(str(evidence), str(output), chunksize=1)
 
     rows = pq.read_table(output).to_pylist()
-    by_rt = {row["rt"]: row for row in rows}
-    assert set(by_rt) == {1800.0, 1860.0}
-    assert by_rt[1800.0]["scan"] == [100]
-    assert by_rt[1800.0]["posterior_error_probability"] == pytest.approx(0.01)
-    assert by_rt[1800.0]["id_run_file_name"] == "run1"
+    assert len(rows) == 2, f"identity-equal rows must collapse, got {len(rows)}"
+    # feature_id must be unique (no duplicate PK).
+    assert len({row["feature_id"] for row in rows}) == 2
+    kept = next(r for r in rows if r["charge"] == 2)
+    assert kept["scan"] == [100]
+    assert kept["posterior_error_probability"] == pytest.approx(0.01)
+    assert kept["rt"] == pytest.approx(1800.0)
+    assert kept["id_run_file_name"] == "run1"
+
+
+def test_feature_dedup_does_not_degrade_without_type_column(tmp_path):
+    """Bug #248 (H-b): a missing column must not degrade dedup to ``SELECT *``.
+
+    With no ``Type`` column, the old guard fell back to ``SELECT * FROM evidence``,
+    letting identity duplicates through. Dedup must still collapse identity-equal
+    rows using the identity columns that are present.
+    """
+    from qpx.converters.maxquant.feature_adapter import MaxQuantFeatureAdapter
+
+    header = (
+        "Sequence\tModified sequence\tCharge\tRaw file\tMS/MS scan number\tm/z\t"
+        "Calibrated retention time\tCalibrated retention time start\t"
+        "Calibrated retention time finish\tPEP\tLeading razor protein\tLeading proteins\tIntensity\tMass\tid\n"
+    )
+    evidence = tmp_path / "evidence.txt"
+    evidence.write_text(
+        header
+        + "PEPTIDEK\t_PEPTIDEK_\t2\trun1\t100\t450.25\t30.0\t29.5\t30.5\t0.01\tP1\tP1\t1000\t898.5\t1\n"
+        + "PEPTIDEK\t_PEPTIDEK_\t2\trun1\t100\t450.25\t30.4\t29.5\t30.5\t0.05\tP1\tP1\t1000\t898.5\t2\n"
+    )
+    output = tmp_path / "feature.parquet"
+
+    with MaxQuantFeatureAdapter() as adapter:
+        adapter.convert(str(evidence), str(output), chunksize=100)
+
+    rows = pq.read_table(output).to_pylist()
+    assert len(rows) == 1, f"identity duplicates must collapse even without Type, got {len(rows)}"
+
+
+def test_psm_handles_empty_modified_sequence(tmp_path):
+    """Bug #248 (H): an empty ``Modified sequence`` must not abort the PSM view.
+
+    The ``else None`` tuple-unpack raised ``TypeError`` for any row whose
+    modified sequence was empty. The adapter must now skip that single row
+    (peptidoform is a required schema field) instead of crashing the whole
+    conversion, so the remaining PSMs still convert.
+    """
+    from qpx.converters.maxquant.psm_adapter import MaxQuantPsmAdapter
+
+    msms = tmp_path / "msms.txt"
+    msms.write_text(
+        "Sequence\tModified sequence\tCharge\tRaw file\tScan number\tm/z\tMass\tPEP\tReverse\tScore\tProteins\n"
+        "PEPTIDEK\t_PEPTIDEK_\t2\trun1\t100\t450.25\t898.5\t0.01\t\t100\tP1\n"
+        # Empty modified sequence (renders to an empty peptidoform via to_proforma).
+        "PEPTIDER\t_\t2\trun1\t101\t500.25\t998.5\t0.02\t\t90\tP2\n"
+    )
+    output = tmp_path / "psm.parquet"
+
+    with MaxQuantPsmAdapter() as adapter:
+        adapter.convert(str(msms), str(output))
+
+    rows = pq.read_table(output).to_pylist()
+    # The empty-modseq row is skipped; the valid PSM must still convert.
+    assert len(rows) == 1, "valid PSM must survive; empty modseq row skipped, not crashing"
+    assert rows[0]["sequence"] == "PEPTIDEK"
+    assert rows[0]["peptidoform"]
+
+
+def test_feature_pg_qvalue_and_genes_keyed_on_full_membership(tmp_path):
+    """Bug #248 (M): a shared razor accession must not bind to another group's metadata.
+
+    Both features share leading razor protein P1, but belong to different protein
+    groups (P1;P2 vs P1;P3). The old leader-keyed map bound P1 to the first group
+    by file order, so both features inherited that group's q-value/genes. The map
+    must be keyed on the full protein-group membership.
+    """
+    from qpx.converters.maxquant.feature_adapter import MaxQuantFeatureAdapter
+
+    evidence = tmp_path / "evidence.txt"
+    evidence.write_text(
+        "Sequence\tModified sequence\tCharge\tRaw file\tType\tMS/MS scan number\tm/z\t"
+        "Calibrated retention time\tCalibrated retention time start\tCalibrated retention time finish\t"
+        "PEP\tLeading razor protein\tLeading proteins\tGene names\tIntensity\tMass\tid\n"
+        "PEPTIDEA\t_PEPTIDEA_\t2\trun1\tMULTI-MSMS\t100\t450.25\t30.0\t29.5\t30.5\t0.01\tP1\tP1;P2\t\t1000\t500\t1\n"
+        "PEPTIDEB\t_PEPTIDEB_\t2\trun1\tMULTI-MSMS\t200\t460.25\t31.0\t30.5\t31.5\t0.02\tP1\tP1;P3\t\t2000\t520\t2\n"
+    )
+    protein_groups = tmp_path / "proteinGroups.txt"
+    protein_groups.write_text(
+        "Protein IDs\tMajority protein IDs\tQ-value\tGene names\nP1;P2\tP1;P2\t0.001\tGENEA\nP1;P3\tP1;P3\t0.5\tGENEB\n"
+    )
+    output = tmp_path / "feature.parquet"
+
+    with MaxQuantFeatureAdapter() as adapter:
+        adapter.convert(str(evidence), str(output), protein_groups_path=str(protein_groups))
+
+    rows = pq.read_table(output).to_pylist()
+    by_seq = {r["sequence"]: r for r in rows}
+    assert by_seq["PEPTIDEA"]["pg_global_qvalue"] == pytest.approx(0.001)
+    assert by_seq["PEPTIDEA"]["gg_names"] == ["GENEA"]
+    assert by_seq["PEPTIDEB"]["pg_global_qvalue"] == pytest.approx(0.5)
+    assert by_seq["PEPTIDEB"]["gg_names"] == ["GENEB"]
+
+
+def test_feature_warns_on_dropped_tmt_channels(caplog):
+    """Bug #248 (M): channels with no reporter column must warn, not vanish silently."""
+    from qpx.converters.maxquant.feature_adapter import MaxQuantFeatureAdapter
+
+    # evidence has only Reporter intensity 0-7; a 10-plex SDRF adds TMT130C (col 8)
+    # and TMT131 (col 9), which have no column and would otherwise be dropped.
+    columns = [f"Reporter intensity {i}" for i in range(8)]
+    channels = [
+        "TMT126",
+        "TMT127N",
+        "TMT127C",
+        "TMT128N",
+        "TMT128C",
+        "TMT129N",
+        "TMT129C",
+        "TMT130N",
+        "TMT130C",
+        "TMT131",
+    ]
+    with MaxQuantFeatureAdapter() as adapter:
+        with caplog.at_level("WARNING"):
+            adapter._warn_dropped_tmt_channels(columns, "TMT10", channels, ri_offset=0)
+            # Second call with the same dropped set must not re-warn.
+            adapter._warn_dropped_tmt_channels(columns, "TMT10", channels, ri_offset=0)
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING" and "dropped" in r.message.lower()]
+    assert len(warnings) == 1, "dropped-channel warning must be emitted exactly once"
+    assert "TMT130C" in caplog.text
+    assert "TMT131" in caplog.text
+
+
+def test_pg_warns_on_dropped_tmt_channels(caplog):
+    """Bug #248 (M): the pg adapter must also warn about dropped channels."""
+    from qpx.converters.maxquant.pg_adapter import MaxQuantPgAdapter
+
+    with MaxQuantPgAdapter() as adapter:
+        with caplog.at_level("WARNING"):
+            adapter._warn_dropped_tmt_channels("exp1", ["TMT130C", "TMT131"])
+            adapter._warn_dropped_tmt_channels("exp1", ["TMT130C", "TMT131"])
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING" and "dropped" in r.message.lower()]
+    assert len(warnings) == 1
+    assert "TMT130C" in caplog.text and "TMT131" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #248.

Fixes four MaxQuant library-converter bugs found in the pre-release audit.

## Fixes

1. **HIGH — PSM crash on empty `Modified sequence`** (`psm_adapter.py`)
   `peptidoform, modifications = (... if peptidoform else None)` — the `else None`
   made the tuple-unpack raise `TypeError`, aborting the entire PSM view. Now
   mirrors the feature adapter (`else (None, None)`) and skips the single row
   (peptidoform is a required schema field) rather than crashing the conversion.

2. **HIGH — dedup key ≠ identity key** (`feature_adapter._deduplicated_evidence_query`)
   The partition used `Calibrated retention time`, which is not part of the
   feature identity, so identity-equal rows differing only in calibrated RT
   survived as duplicate primary keys; and a missing column degraded to a
   no-dedup `SELECT * FROM evidence`. The partition now mirrors
   `_FEATURE_IDENTITY_COMPOSITE` (peptidoform/charge/run/rt_start/rt_stop/scan),
   using whichever identity columns are present, and no longer degrades.

3. **MED — TMT channels silently dropped** (`feature_adapter.py`, `pg_adapter.py`)
   When the SDRF plex exceeds the reporter columns present, a missing
   `Reporter intensity N` column was skipped with no signal. Both adapters now
   emit a one-time warning listing the dropped channels.

4. **MED — pg q-value/gene leader collision** (`feature_adapter.py`)
   The proteinGroups lookup was keyed on the leader accession
   (`drop_duplicates(keep="first")`), so a razor accession in >1 group bound to
   the first group by file order and features inherited the wrong
   `pg_global_qvalue`/genes. The map is now keyed on the full protein-group
   membership, with an unambiguous-leader-only fallback.

Also extends the validated-SQL-identifier pattern to allow `/` (identifiers are
always double-quoted) so MaxQuant columns like `MS/MS scan number` can be used
in the dedup partition.

## Tests

Regression tests added for each fix in `tests/converters/test_maxquant_converter.py`
and `tests/converters/test_converter_utils.py`. Full suite: **884 passed**.
`ruff check` / `ruff format` clean.