### PR TITLE
fix(cdap,ptm): pg membership keying, single-row representative, C-term/duplicate mods

### DIFF
--- a/qpx/converters/cdap/feature_adapter.py
+++ b/qpx/converters/cdap/feature_adapter.py
@@ -136,25 +136,32 @@ class CdapFeatureAdapter(CdapBaseAdapter):
                 f"TRY_CAST(split_part(CAST({qcol} AS VARCHAR), '/', 1) AS DOUBLE) AS {self._safe_channel_alias(col)}"
             )
 
+        # Representative fields must all come from the SAME best PSM row --
+        # independent ``arg_min`` per column produced a "Frankenstein" record
+        # (scan/observed_mz/rt from different PSMs) on tied or NULL Evalue.
+        # Applying one deterministic ORDER BY to every ``first()`` guarantees a
+        # single source row. NULLS LAST so a real Evalue is preferred over a
+        # missing one; scan/mz/rt break ties reproducibly.
+        best_order = "evalue ASC NULLS LAST, scan_num ASC NULLS LAST, observed_mz ASC NULLS LAST, rt ASC NULLS LAST"
         agg_cols: list[str] = [
             "peptide_raw",
             "charge",
             "file_name",
-            "arg_min(scan_num, evalue) AS best_scan",
-            "arg_min(observed_mz, evalue) AS best_observed_mz",
-            "arg_min(original_mz, evalue) AS best_original_mz",
-            "arg_min(ppm, evalue) AS best_ppm",
-            "arg_min(rt, evalue) AS best_rt",
-            "arg_min(evalue, evalue) AS best_evalue",
-            "arg_min(msgf, evalue) AS best_msgf",
-            "arg_min(denovo, evalue) AS best_denovo",
-            "arg_min(qvalue, evalue) AS best_qvalue",
-            "arg_min(pep_qvalue, evalue) AS best_pep_qvalue",
+            f"first(scan_num ORDER BY {best_order}) AS best_scan",
+            f"first(observed_mz ORDER BY {best_order}) AS best_observed_mz",
+            f"first(original_mz ORDER BY {best_order}) AS best_original_mz",
+            f"first(ppm ORDER BY {best_order}) AS best_ppm",
+            f"first(rt ORDER BY {best_order}) AS best_rt",
+            f"first(evalue ORDER BY {best_order}) AS best_evalue",
+            f"first(msgf ORDER BY {best_order}) AS best_msgf",
+            f"first(denovo ORDER BY {best_order}) AS best_denovo",
+            f"first(qvalue ORDER BY {best_order}) AS best_qvalue",
+            f"first(pep_qvalue ORDER BY {best_order}) AS best_pep_qvalue",
             "list(protein_cell ORDER BY evalue) AS protein_cells",
             "count(*) AS psm_count",
         ]
         if has_precursor_area:
-            agg_cols.append("arg_min(precursor_area, evalue) AS best_precursor_area")
+            agg_cols.append(f"first(precursor_area ORDER BY {best_order}) AS best_precursor_area")
         # SUM pre-extracted intensities directly in SQL.
         for col in channel_cols:
             alias = self._safe_channel_alias(col)
@@ -230,9 +237,11 @@ class CdapFeatureAdapter(CdapBaseAdapter):
         scan: list[int] = [scan_val] if scan_val else []
 
         observed_mz = self._finite_float(row.get("best_observed_mz"))
+        # ``calculated_mz`` is a THEORETICAL mass. When the peptidoform carries
+        # an unparseable token (e.g. a CHEMMOD unknown-mass tag), keep it NULL
+        # rather than falling back to a measured precursor m/z, which would
+        # silently corrupt the theoretical-mass semantics (bigbio/qpx#250).
         calculated_mz = compute_precursor_mz(peptidoform, charge) if peptidoform and charge else None
-        if calculated_mz is None:
-            calculated_mz = self._finite_float(row.get("best_original_mz"))
 
         mass_error_ppm = self._optional_float(row.get("best_ppm"))
         rt = self._optional_float(row.get("best_rt"))

--- a/qpx/converters/cdap/pg_adapter.py
+++ b/qpx/converters/cdap/pg_adapter.py
@@ -29,8 +29,10 @@ class CdapPgAdapter(CdapBaseAdapter):
         """Aggregate the given feature parquet into per-run protein groups."""
         self._load_parquet("features", feature_path)
         actual_cols = self.get_table_columns("features")
-        if "anchor_protein" not in actual_cols or "run_file_name" not in actual_cols:
-            raise ValueError("feature.parquet missing 'anchor_protein' / 'run_file_name' columns")
+        required = {"anchor_protein", "run_file_name", "pg_accessions"}
+        missing = required - set(actual_cols)
+        if missing:
+            raise ValueError(f"feature.parquet missing columns: {sorted(missing)}")
 
         sql = self._build_aggregation_sql()
         self.logger.info("Transforming CDAP protein groups ...")
@@ -45,10 +47,29 @@ class CdapPgAdapter(CdapBaseAdapter):
 
     @staticmethod
     def _build_aggregation_sql() -> str:
-        """Build a query that aggregates features per (anchor_protein, run)."""
+        """Build a query that aggregates features per (protein group, run).
+
+        The group key is the FULL protein-group membership (the sorted set of
+        ``pg_accessions`` accessions), not the leading ``anchor_protein``.
+        Keying on the leader alone collapsed two genuinely distinct groups that
+        share a leading protein (e.g. ``P1;P2`` and ``P1;P3``) into one, and
+        filed shared peptides under whichever accession happened to be listed
+        first. This mirrors the pg-identity fix (bigbio/qpx#240) that keys
+        ``pg_id`` on ``pg_accessions``; ``anchor_protein`` stays a descriptive
+        leader carried through with ``any_value``.
+        """
         return (
+            "WITH keyed AS (\n"
+            "    SELECT\n"
+            "        *,\n"
+            "        COALESCE(\n"
+            "            array_to_string(list_sort(list_transform(pg_accessions, x -> x.accession)), ';'),\n"
+            "            anchor_protein\n"
+            "        ) AS pg_membership_key\n"
+            "    FROM features\n"
+            ")\n"
             "SELECT\n"
-            "    anchor_protein,\n"
+            "    any_value(anchor_protein) AS anchor_protein,\n"
             "    run_file_name,\n"
             "    any_value(is_decoy) AS any_decoy,\n"
             "    bool_and(is_decoy) AS all_decoy,\n"
@@ -59,8 +80,8 @@ class CdapPgAdapter(CdapBaseAdapter):
             "    list(intensities) AS intensities_per_feature,\n"
             "    list(pg_accessions) AS pg_accessions_per_feature,\n"
             "    list(additional_scores) AS additional_scores_per_feature\n"
-            "FROM features\n"
-            "GROUP BY anchor_protein, run_file_name"
+            "FROM keyed\n"
+            "GROUP BY pg_membership_key, run_file_name"
         )
 
     # ------------------------------------------------------------------

--- a/qpx/converters/cdap/psm_adapter.py
+++ b/qpx/converters/cdap/psm_adapter.py
@@ -151,9 +151,11 @@ class CdapPsmAdapter(CdapBaseAdapter):
         scan: list[int] = [scan_val] if scan_val else []
 
         observed_mz = self._finite_float(row.get("observed_mz"))
+        # ``calculated_mz`` is a THEORETICAL mass. When the peptidoform carries
+        # an unparseable token (e.g. a CHEMMOD unknown-mass tag), keep it NULL
+        # rather than falling back to a measured precursor m/z, which would
+        # silently corrupt the theoretical-mass semantics (bigbio/qpx#250).
         calculated_mz = compute_precursor_mz(peptidoform, charge) if peptidoform and charge else None
-        if calculated_mz is None:
-            calculated_mz = self._finite_float(row.get("original_mz"))
 
         mass_error_ppm = self._optional_float(row.get("mass_error_ppm"))
         rt = self._optional_float(row.get("rt"))

--- a/qpx/converters/ptm.py
+++ b/qpx/converters/ptm.py
@@ -115,25 +115,46 @@ def build_proforma(sequence: str, mods: list[tuple[int, str]]) -> str:
     Args:
         sequence: Stripped peptide sequence (no modification annotations).
         mods: List of (position, tag) where position is 0 for N-term,
-            1..N for residue positions (1-indexed). Tag is e.g. "UNIMOD:35"
-            or "CHEMMOD:+15.99".
+            1..N for residue positions (1-indexed), and ``len(sequence)+1``
+            for the C-term (the mzIdentML/FragPipe/CDAP convention). Tag is
+            e.g. "UNIMOD:35" or "CHEMMOD:+15.99". Multiple mods may share a
+            position; all are emitted (order preserved) rather than collapsed.
 
     Returns:
-        ProForma string, e.g. ``PEPTM[UNIMOD:35]IDEK`` or ``[UNIMOD:1]-PEPTIDEK``.
+        ProForma string, e.g. ``PEPTM[UNIMOD:35]IDEK``, ``[UNIMOD:1]-PEPTIDEK``
+        (N-term) or ``PEPTIDEK-[UNIMOD:2]`` (C-term).
     """
     if not sequence:
         return ""
 
-    pos_to_tag: dict[int, str] = dict(mods)
+    cterm_pos = len(sequence) + 1
+
+    # Preserve every mod, including two at the same position; do NOT collapse
+    # via ``dict(mods)`` (which would silently drop all but the last tag).
+    pos_to_tags: dict[int, list[str]] = {}
+    for position, tag in mods:
+        pos_to_tags.setdefault(position, []).append(tag)
+
     parts: list[str] = []
 
-    if 0 in pos_to_tag:
-        parts.append(f"[{pos_to_tag[0]}]-")
+    # N-terminus: ``[tag][tag]-`` before the first residue.
+    if 0 in pos_to_tags:
+        for tag in pos_to_tags[0]:
+            parts.append(f"[{tag}]")
+        parts.append("-")
 
     for i, aa in enumerate(sequence, start=1):
         parts.append(aa)
-        if i in pos_to_tag:
-            parts.append(f"[{pos_to_tag[i]}]")
+        for tag in pos_to_tags.get(i, []):
+            parts.append(f"[{tag}]")
+
+    # C-terminus: ``-[tag][tag]`` after the last residue. Any position beyond
+    # the last residue is treated as C-terminal.
+    cterm_tags = [tag for pos, tags in pos_to_tags.items() if pos >= cterm_pos for tag in tags]
+    if cterm_tags:
+        parts.append("-")
+        for tag in cterm_tags:
+            parts.append(f"[{tag}]")
 
     return "".join(parts)
 

--- a/tests/converters/test_cdap_converter.py
+++ b/tests/converters/test_cdap_converter.py
@@ -321,6 +321,152 @@ def test_cdap_lfq_precursor_area_uses_lfq_label(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+_MIN_PSM_HEADER = [
+    "FileName",
+    "ScanNum",
+    "QueryPrecursorMz",
+    "OriginalPrecursorMz",
+    "PrecursorError(ppm)",
+    "QueryCharge",
+    "OriginalCharge",
+    "PrecursorScanNum",
+    "PrecursorArea",
+    "PrecursorRelAb",
+    "RTAtPrecursorHalfElution",
+    "PeptideSequence",
+    "AmbiguousMatch",
+    "Protein",
+    "DeNovoScore",
+    "MSGFScore",
+    "Evalue",
+    "Qvalue",
+    "PepQvalue",
+    "PrecursorPurity",
+    "FractionDecomposition",
+]
+
+
+def _write_psm(psm_dir, name, rows):
+    """Write a minimal CDAP ``.psm`` file from a list of dict rows."""
+    psm_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["\t".join(_MIN_PSM_HEADER)]
+    for row in rows:
+        lines.append("\t".join(str(row.get(col, "")) for col in _MIN_PSM_HEADER))
+    (psm_dir / name).write_text("\n".join(lines) + "\n")
+
+
+def _base_row(**overrides):
+    row = {
+        "FileName": "run_a.raw",
+        "ScanNum": "1000",
+        "QueryPrecursorMz": "500.25",
+        "OriginalPrecursorMz": "500.25",
+        "PrecursorError(ppm)": "1.0",
+        "QueryCharge": "2",
+        "OriginalCharge": "2",
+        "PrecursorScanNum": "999",
+        "PrecursorArea": "10000",
+        "PrecursorRelAb": "0.1",
+        "RTAtPrecursorHalfElution": "300.0",
+        "PeptideSequence": "PEPTIDEK",
+        "AmbiguousMatch": "0",
+        "Protein": "NP_000001.1(pre=K,post=A)",
+        "DeNovoScore": "50",
+        "MSGFScore": "40",
+        "Evalue": "0.001",
+        "Qvalue": "0.0",
+        "PepQvalue": "0.0",
+        "PrecursorPurity": "99.0,99.0",
+        "FractionDecomposition": "99.0,99.0",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_cdap_feature_representative_from_single_psm(tmp_path):
+    """Representative scan/mz/rt must all come from ONE best PSM (#250).
+
+    Independent ``arg_min`` per column produced a Frankenstein record on
+    tied/NULL Evalue. Here three PSMs share (peptidoform, charge, run); the
+    winning (scan, observed_mz, rt) triple must equal exactly one input row.
+    """
+    from qpx.converters.cdap.feature_adapter import CdapFeatureAdapter
+
+    rows = [
+        _base_row(Evalue="", ScanNum="100", QueryPrecursorMz="400.0", RTAtPrecursorHalfElution="5.0"),
+        _base_row(Evalue="0.2", ScanNum="200", QueryPrecursorMz="500.0", RTAtPrecursorHalfElution="6.0"),
+        _base_row(Evalue="0.2", ScanNum="300", QueryPrecursorMz="600.0", RTAtPrecursorHalfElution="7.0"),
+    ]
+    _write_psm(tmp_path / "psm", "frank.psm", rows)
+
+    out = tmp_path / "frank.feature.parquet"
+    with CdapFeatureAdapter() as adapter:
+        adapter.convert(psm_dir=str(tmp_path / "psm"), output_path=str(out))
+
+    table = pq.read_table(str(out))
+    assert table.num_rows == 1
+    scan = table.column("scan").to_pylist()[0]
+    observed_mz = table.column("observed_mz").to_pylist()[0]
+    rt = table.column("rt").to_pylist()[0]
+    input_triples = {(100, 400.0, 5.0), (200, 500.0, 6.0), (300, 600.0, 7.0)}
+    got = (scan[0], observed_mz, rt)
+    assert got in input_triples, f"Frankenstein: {got} matches no input PSM"
+    # Deterministic best: Evalue 0.2 tie broken by lowest scan -> row 200.
+    assert got == (200, 500.0, 6.0)
+
+
+def test_cdap_feature_chemmod_calc_mz_is_null_not_observed(tmp_path):
+    """An unparseable CHEMMOD must leave calculated_mz NULL/0, not fall back
+    to the observed precursor m/z (#250)."""
+    from qpx.converters.cdap.feature_adapter import CdapFeatureAdapter
+
+    # +123.456 is not in the CDAP mass table -> CHEMMOD -> unparseable calc mass.
+    rows = [_base_row(PeptideSequence="PEP+123.456TIDEK", OriginalPrecursorMz="777.7", QueryPrecursorMz="777.7")]
+    _write_psm(tmp_path / "psm", "chemmod.psm", rows)
+
+    out = tmp_path / "chemmod.feature.parquet"
+    with CdapFeatureAdapter() as adapter:
+        adapter.convert(psm_dir=str(tmp_path / "psm"), output_path=str(out))
+
+    table = pq.read_table(str(out))
+    assert table.num_rows == 1
+    calc = table.column("calculated_mz").to_pylist()[0]
+    # NULL calc mass is stored as 0.0; it must NOT be the measured 777.7.
+    assert not calc, f"CHEMMOD calc_mz leaked observed m/z: {calc}"
+
+
+def test_cdap_pg_distinct_groups_sharing_leader(tmp_path):
+    """Two distinct protein groups sharing a leading protein must NOT collapse
+    into one pg (#250). ``P1;P2`` and ``P1;P3`` share leader ``P1``."""
+    from qpx.converters.cdap.feature_adapter import CdapFeatureAdapter
+    from qpx.converters.cdap.pg_adapter import CdapPgAdapter
+
+    rows = [
+        _base_row(PeptideSequence="PEPTIDEA", Protein="P1(pre=K,post=A);P2(pre=K,post=A)"),
+        _base_row(PeptideSequence="PEPTIDEB", Protein="P1(pre=K,post=A);P3(pre=K,post=A)"),
+    ]
+    _write_psm(tmp_path / "psm", "leader.psm", rows)
+
+    feat = tmp_path / "leader.feature.parquet"
+    with CdapFeatureAdapter() as adapter:
+        adapter.convert(psm_dir=str(tmp_path / "psm"), output_path=str(feat))
+
+    pg = tmp_path / "leader.pg.parquet"
+    with CdapPgAdapter() as adapter:
+        adapter.convert(feature_path=str(feat), output_path=str(pg))
+
+    table = pq.read_table(str(pg))
+    memberships = set()
+    for accs in table.column("pg_accessions").to_pylist():
+        names = frozenset(a["accession"] if isinstance(a, dict) else a for a in (accs or []))
+        memberships.add(names)
+    assert frozenset({"P1", "P2"}) in memberships
+    assert frozenset({"P1", "P3"}) in memberships
+    # Not collapsed to a single leader-keyed group.
+    assert frozenset({"P1", "P2"}) != frozenset({"P1", "P3"})
+    assert len(memberships) == 2
+
+
 class TestCdapPeptidoform:
     """Unit tests for the ProForma conversion logic."""
 

--- a/tests/converters/test_ptm.py
+++ b/tests/converters/test_ptm.py
@@ -38,6 +38,27 @@ class TestBuildProforma:
     def test_empty_sequence(self):
         assert build_proforma("", []) == ""
 
+    def test_cterm_mod(self):
+        """A mod at ``len(seq)+1`` is the C-term ProForma slot (bigbio/qpx#251).
+
+        Previously this position was silently dropped from ``peptidoform``
+        while surviving in ``modifications`` -- an identity inconsistency.
+        """
+        assert build_proforma("PEPTIDEK", [(9, "UNIMOD:2")]) == "PEPTIDEK-[UNIMOD:2]"
+
+    def test_nterm_and_cterm(self):
+        assert build_proforma("PEPTIDEK", [(0, "UNIMOD:1"), (9, "UNIMOD:2")]) == "[UNIMOD:1]-PEPTIDEK-[UNIMOD:2]"
+
+    def test_two_mods_same_position(self):
+        """Two mods at the same position must not collapse (bigbio/qpx#251).
+
+        ``dict(mods)`` used to keep only the last tag; both must be emitted.
+        """
+        assert build_proforma("PEPTIDEK", [(0, "UNIMOD:1"), (0, "UNIMOD:737")]) == "[UNIMOD:1][UNIMOD:737]-PEPTIDEK"
+
+    def test_two_mods_same_residue(self):
+        assert build_proforma("PEPTMIDEK", [(5, "UNIMOD:35"), (5, "CHEMMOD:+1.0")]) == "PEPTM[UNIMOD:35][CHEMMOD:+1.0]IDEK"
+
 
 class TestFromProforma:
     def test_unimod_tag(self):


### PR DESCRIPTION
Fixes two audit issues found against `fix/diann-pg-duplicate-pgid`.

## CDAP (#250)
- **HIGH — pg leader collision.** `pg_adapter` rolled features up per `(anchor_protein, run)`, so two distinct groups sharing a leading protein (`P1;P2` vs `P1;P3`) collapsed and shared peptides landed under whichever accession was listed first. Now keyed on the **full protein-group membership** (sorted `pg_accessions` set), mirroring the `pg_id` fix in #240. `anchor_protein` stays a descriptive leader (`any_value`).
- **MED — "Frankenstein" representative PSM.** Independent `arg_min(scan,evalue)` / `arg_min(observed_mz,evalue)` / `arg_min(rt,evalue)` could source those fields from *different* PSMs on tied/NULL `Evalue`. Now a single deterministic `ORDER BY` (Evalue NULLS LAST, then scan/mz/rt) drives every `first()`, so all representative fields come from one row.
- **MED — CHEMMOD `calculated_mz` collapse.** When `compute_precursor_mz` cannot parse the peptidoform (e.g. an unknown-mass `CHEMMOD` token), `calculated_mz` fell back to a measured precursor m/z, corrupting the theoretical-mass semantics. It is now left NULL in both `feature_adapter` and `psm_adapter`.

## Shared `ptm.build_proforma` (#251)
- Emits a **C-terminal ProForma slot** (`PEPTIDE-[mod]`) for a mod at `len(seq)+1` (the mzIdentML/FragPipe/CDAP convention); previously dropped from `peptidoform` while surviving in `modifications` (identity inconsistency).
- **Supports multiple mods at the same position** instead of collapsing via `dict(mods)`. Existing internal/N-term behaviour is unchanged, so mzidentml/fragpipe/maxquant callers are not regressed.

## Tests
Regression tests added for each fix (`build_proforma` C-term + duplicate-position; CDAP single-row representative, CHEMMOD NULL calc_mz, distinct groups sharing a leader). Full suite: **885 passed**.

Closes #250
Closes #251