### PR TITLE
fix(core): wire pg referential validation into streaming/partitioned writes; fix mudata mapping, multi-shard read, spectronaut run keys

### DIFF
--- a/qpx/converters/spectronaut/feature_adapter.py
+++ b/qpx/converters/spectronaut/feature_adapter.py
@@ -304,7 +304,9 @@ class SpectronautFeatureAdapter(SpectronautBaseAdapter):
             parts.append("NULL::FLOAT AS predicted_rt")
 
         run_col = r["run_file_name"]
-        parts.append(f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d)$', '') AS run_file_name")
+        # Match the pg adapter's case-insensitive, extended extension strip so
+        # feature / pg / run keys agree on .wiff / .htrms / .RAW (bigbio/qpx#252).
+        parts.append(f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d|wiff|htrms)$', '', 'i') AS run_file_name")
         parts.append("[]::INTEGER[] AS scan")
 
         rt_col = r.get("rt")
@@ -358,7 +360,7 @@ class SpectronautFeatureAdapter(SpectronautBaseAdapter):
 
         # id_run_file_name
         run_col = r["run_file_name"]
-        parts.append(f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d)$', '') AS id_run_file_name")
+        parts.append(f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d|wiff|htrms)$', '', 'i') AS id_run_file_name")
         return parts
 
     def _build_batch_sql(

--- a/qpx/converters/spectronaut/pg_adapter.py
+++ b/qpx/converters/spectronaut/pg_adapter.py
@@ -93,7 +93,7 @@ class SpectronautPgAdapter(SpectronautBaseAdapter):
 
         parts = [
             f'FIRST(r."{pg_col}") AS pg_accessions',
-            f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d|wiff|htrms)$', '') AS run_file_name",
+            f"regexp_replace(FIRST(r.\"{run_col}\"), '\\.(mzML|raw|d|wiff|htrms)$', '', 'i') AS run_file_name",
             f'FIRST(CAST(r."{int_col}" AS DOUBLE)) AS pg_quantity',
         ]
 

--- a/qpx/core/engine.py
+++ b/qpx/core/engine.py
@@ -104,6 +104,26 @@ class DuckDBEngine:
             )
         )
 
+    def register_parquet_files(self, name: str, file_paths) -> None:
+        """Register several Parquet shards as one unioned DuckDB view.
+
+        DuckDB reads the list of files positionally-unioned, matching the S3
+        glob path's behaviour so a multi-shard structure yields the same rows
+        locally and over S3 (bigbio/qpx#252).
+        """
+        paths = list(file_paths)
+        if len(paths) == 1:
+            self.register_parquet(name, paths[0])
+            return
+        path_list = ", ".join(f"'{escape_path(str(p))}'" for p in paths)
+        self._conn.execute(
+            sql_build(
+                "CREATE OR REPLACE VIEW $view AS SELECT * FROM read_parquet([$paths])",
+                view=validate_table(name),
+                paths=path_list,
+            )
+        )
+
     def register_partitioned_parquet(self, name: str, directory: str | Path) -> None:
         """Register a Hive-partitioned Parquet directory as a DuckDB view."""
         glob_pattern = str(Path(directory) / "**" / "*.parquet")

--- a/qpx/dataset.py
+++ b/qpx/dataset.py
@@ -160,21 +160,19 @@ class Dataset:
         pattern = f"{self._file_prefix}{suffix}" if self._file_prefix else f"*{suffix}"
         matches = sorted(self.path.glob(pattern))
         if matches:
-            if len(matches) > 1:
-                _log.warning(
-                    "Multiple files match '%s': %s — using first: %s",
-                    pattern,
-                    [m.name for m in matches],
-                    matches[0].name,
-                )
-            file_path = matches[0]  # Take first match
+            # Read ALL matching shards unioned, matching the S3 path (which globs
+            # and reads every match). Previously only the first was taken, so a
+            # sharded structure returned different rows locally vs over S3
+            # (bigbio/qpx#252). The registered structure's file_path points at the
+            # first shard for provenance; the view unions them all.
             if name == "pg":
-                check_pg_file_compatible(file_path)
-            self._engine.register_parquet(name, file_path)
+                for match in matches:
+                    check_pg_file_compatible(match)
+            self._engine.register_parquet_files(name, matches)
             self._structures[name] = cls(
                 engine=self._engine,
                 table_name=name,
-                file_path=file_path,
+                file_path=matches[0],
             )
         elif self._file_prefix is None:
             # Check for Hive-partitioned directory

--- a/qpx/mudata.py
+++ b/qpx/mudata.py
@@ -431,15 +431,30 @@ def _build_protein_adata(
 def _build_feature_mapping(engine: DuckDBEngine, mdata) -> sparse.csr_matrix:
     """Build boolean sparse adjacency linking precursor IDs to protein IDs.
 
-    Returns a symmetric CSR matrix of shape (N, N) where N is the total
-    number of var_names across all modalities in mdata.  Non-zero entries
+    Returns a symmetric CSR matrix of shape (N, N) where N is ``mdata.n_vars``
+    — the total number of var_names across **all** modalities present, in their
+    global-axis order — so the matrix is assignable to ``mdata.varp`` even when
+    expression / differential modalities are also built (bigbio/qpx#252). The
+    precursor and protein blocks are positioned by their per-modality offset on
+    the global var axis (not by a global name lookup), so a protein accession
+    that also appears as an expression var is never mislocated. Non-zero entries
     indicate a precursor-protein relationship.
     """
     if "precursors" not in mdata.mod or "proteins" not in mdata.mod:
         raise ValueError("Both 'precursors' and 'proteins' modalities are required for feature mapping.")
 
-    precursor_names = mdata.mod["precursors"].var_names
-    protein_names = mdata.mod["proteins"].var_names
+    # Per-modality offsets on the global var axis (modalities are concatenated in
+    # mdata.mod insertion order). Sizing/positioning against the full axis is what
+    # keeps the mapping valid — and present — with a 3rd/4th modality around.
+    offsets: dict[str, int] = {}
+    running = 0
+    for name, adata in mdata.mod.items():
+        offsets[name] = running
+        running += adata.n_vars
+    n = running  # == mdata.n_vars
+
+    precursor_names = pd.Index(mdata.mod["precursors"].var_names)
+    protein_names = pd.Index(mdata.mod["proteins"].var_names)
 
     # Query mapping from feature table
     sql = """
@@ -451,20 +466,15 @@ def _build_feature_mapping(engine: DuckDBEngine, mdata) -> sparse.csr_matrix:
     df = engine.execute(sql).fetchdf()
 
     if df.empty:
-        n = len(precursor_names) + len(protein_names)
         return sparse.csr_matrix((n, n), dtype=bool)
 
-    # Build combined index
-    all_names = pd.Index(list(precursor_names) + list(protein_names))
+    precursor_local = precursor_names.get_indexer(df["precursor_id"])
+    protein_local = protein_names.get_indexer(df["anchor_protein"])
 
-    precursor_pos = all_names.get_indexer(df["precursor_id"])
-    protein_pos = all_names.get_indexer(df["anchor_protein"])
+    mask = (precursor_local >= 0) & (protein_local >= 0)
+    precursor_pos = precursor_local[mask] + offsets["precursors"]
+    protein_pos = protein_local[mask] + offsets["proteins"]
 
-    mask = (precursor_pos >= 0) & (protein_pos >= 0)
-    precursor_pos = precursor_pos[mask]
-    protein_pos = protein_pos[mask]
-
-    n = len(all_names)
     data = np.ones(len(precursor_pos) * 2, dtype=bool)
     rows = np.concatenate([precursor_pos, protein_pos])
     cols = np.concatenate([protein_pos, precursor_pos])

--- a/qpx/writers/base.py
+++ b/qpx/writers/base.py
@@ -457,6 +457,27 @@ class BaseWriter:
             self._writer = None
         if validate and wrote_file:
             self._validate_identity_uniqueness()
+            self._validate_referential()
+
+    def _validate_referential(self) -> None:
+        """Warn on pg referential / run-disjointness problems over the full file.
+
+        The streaming ``write_batch`` path validates each batch's schema but
+        cannot see cross-row invariants (run-disjointness and duplicate
+        ``grouped_runs`` span the whole table), so ``write_table``'s referential
+        checks were effectively off for every streamed pg converter
+        (bigbio/qpx#242). They are re-run here at ``close()`` over the complete
+        written file, so the record/batch and table paths converge. Per the
+        maintainer policy (1.1.2) these are **warnings** on the write/convert
+        path, never a raise; ``qpxc validate --strict`` stays the strict gate.
+        """
+        if getattr(self._schema_class, "_view_name", None) != "pg":
+            return
+        table = pq.read_table(str(self._path))
+        result = self._schema_class.validate_full(table, strict=False)
+        for issue in result.warnings:
+            if issue.check in ("run_double_count", "duplicate_grouped_run"):
+                logger.warning("pg referential check '%s': %s", issue.check, issue.message)
 
     def _validate_identity_uniqueness(self) -> None:
         """Reject duplicate or null identity ids across the complete output file."""
@@ -529,8 +550,9 @@ class BaseWriter:
         """
         return parquet_write_options(self.arrow_schema, self._compression)
 
-    @staticmethod
+    @classmethod
     def write_partitioned(
+        cls,
         table: pa.Table,
         output_dir: str | Path,
         partition_cols: list[str] | None = None,
@@ -538,6 +560,15 @@ class BaseWriter:
         file_metadata: dict | None = None,
     ) -> Path:
         """Write Arrow table as Hive-partitioned Parquet.
+
+        Called on a concrete writer subclass (e.g. ``FeatureWriter``) the table
+        is routed through the **same id-derivation and schema validation** as
+        the single-file writers before it is written, so a partitioned dump no
+        longer bypasses those checks (bigbio/qpx#252): the derived id is stamped
+        when absent, and referential / null / primary-key problems are emitted
+        as ``logger.warning`` (matching the write-path policy — not a raise).
+        Called on the un-bound ``BaseWriter`` (no schema is known) it stays a
+        raw partitioned dump, unchanged.
 
         Encoding parity with the single-file writers: the same
         :func:`parquet_write_options` path is used, so partitioned output gets
@@ -571,6 +602,25 @@ class BaseWriter:
 
         output_dir = Path(output_dir)
         cols = partition_cols or ["run_file_name"]
+
+        # When called on a concrete writer subclass, route through the same
+        # id-derivation + validation the single-file writers use so partitioned
+        # output is not a validation-bypass (bigbio/qpx#252). An instance is
+        # built only to reuse _fill_identity_table / the schema; no file is
+        # opened until write_dataset below. On the un-bound BaseWriter
+        # (_schema_class is None) this is skipped and the raw dump is unchanged.
+        schema_class = cls._schema_class
+        if schema_class is not None:
+            deriver = cls(output_dir, compression=compression)
+            table = deriver._fill_identity_table(table)
+            result = schema_class.validate_full(table, strict=False)
+            for issue in result.issues:
+                logger.warning(
+                    "%s partitioned-write validation '%s': %s",
+                    schema_class._view_name,
+                    issue.check,
+                    issue.message,
+                )
 
         # Validate the partition columns up front so the default path (or an
         # unsupported key) fails with an actionable message instead of a raw

--- a/qpx/writers/pg.py
+++ b/qpx/writers/pg.py
@@ -70,6 +70,21 @@ class PgWriter(BaseWriter):
         """Explode ``intensities`` into one row per label, then buffer/flush."""
         super().write_batch(_explode_pg_records(records))
 
+    def write_dataframe(self, df):
+        """Explode ``intensities`` before writing a flat pg DataFrame.
+
+        The base ``write_dataframe`` builds the table against the flat pg schema
+        (which has no ``intensities`` column), so a DataFrame that still carries
+        the natural ``intensities`` list would have its quant silently dropped
+        (bigbio/qpx#252). Route such frames through the same explode the
+        ``write_batch`` / ``write_table`` paths use; frames already flattened
+        (scalar ``label``/``intensity``) fall through unchanged.
+        """
+        if "intensities" in df.columns:
+            self.write_batch(df.to_dict("records"))
+            return
+        super().write_dataframe(df)
+
     def write_table(self, table: pa.Table):
         """Explode a pg table that still carries the ``intensities`` list column."""
         if "intensities" in table.schema.names:

--- a/tests/converters/test_spectronaut_converter.py
+++ b/tests/converters/test_spectronaut_converter.py
@@ -213,3 +213,51 @@ class TestSpectronautProvenance:
         table = pq.read_table(str(path))
         tool_names = table.column("tool_name").to_pylist()
         assert any("qpx" in str(t).lower() for t in tool_names if t), "Expected qpx in provenance tool_names"
+
+
+class TestRunNameNormalization:
+    """Regression for bigbio/qpx#252: the Spectronaut feature adapter stripped
+    only ``\\.(mzML|raw|d)$`` case-sensitively while the pg adapter stripped
+    ``(?i)\\.(mzML|raw|d|wiff|htrms)$``, so ``.wiff`` / ``.htrms`` / ``.RAW``
+    broke feature<->pg<->run joins. Both adapters must strip the same set,
+    case-insensitively, by DuckDB SQL."""
+
+    @staticmethod
+    def _run_expr(part: str) -> str:
+        # part looks like "regexp_replace(...) AS <alias>"; return the expression.
+        return part.rsplit(" AS ", 1)[0]
+
+    def test_feature_and_pg_use_same_extension_strip(self):
+        import duckdb
+
+        from qpx.converters.spectronaut.feature_adapter import SpectronautFeatureAdapter as FeatureAdapter
+        from qpx.converters.spectronaut.pg_adapter import SpectronautPgAdapter as PgAdapter
+
+        r = {
+            "sequence": "SEQ",
+            "charge": "CHG",
+            "run_file_name": "RUN",
+            "pg_accessions": "PG",
+            "intensity": "INT",
+        }
+        core = FeatureAdapter._build_core_select_parts(r, set())
+        meta = FeatureAdapter._build_meta_select_parts(r, set())
+        pg = PgAdapter._build_pg_select_parts(r, set())
+
+        feat_run = next(self._run_expr(p) for p in core if p.endswith("AS run_file_name"))
+        feat_id_run = next(self._run_expr(p) for p in meta if p.endswith("AS id_run_file_name"))
+        pg_run = next(self._run_expr(p) for p in pg if p.endswith("AS run_file_name"))
+
+        con = duckdb.connect()
+        try:
+            for name in ("sample.mzML", "sample.RAW", "sample.wiff", "sample.HTRMS", "sample.d"):
+                # Evaluate each adapter's expression against the same input value.
+                feat_val = con.execute(f'SELECT {feat_run} FROM (SELECT ? AS "RUN") r', [name]).fetchone()[0]
+                feat_id_val = con.execute(f'SELECT {feat_id_run} FROM (SELECT ? AS "RUN") r', [name]).fetchone()[0]
+                pg_val = con.execute(f'SELECT {pg_run} FROM (SELECT ? AS "RUN") r', [name]).fetchone()[0]
+                assert feat_val == "sample", f"feature did not strip {name}: {feat_val}"
+                assert feat_id_val == "sample", f"feature id_run did not strip {name}: {feat_id_val}"
+                assert pg_val == "sample", f"pg did not strip {name}: {pg_val}"
+                assert feat_val == pg_val == feat_id_val
+        finally:
+            con.close()

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -758,3 +758,27 @@ class TestMokumeWorkflow:
             df = result.to_df()
             assert len(df) > 0
             assert "log2fc" in df.columns
+
+
+class TestMultiShardLocalRead:
+    """bigbio/qpx#252: a local structure split across several shards must read
+    ALL of them (unioned), matching the S3 path — previously only the first
+    matching file was used, so local and S3 returned different rows."""
+
+    def test_local_reads_all_shards(self, tmp_path):
+        # Two feature shards with no file_prefix, so the '*.feature.parquet'
+        # glob matches both.
+        with FeatureWriter(tmp_path / "a.feature.parquet") as w:
+            w.write_batch([make_feature_record(peptidoform="PEPTIDEK", run_file_name="run_01")])
+        with FeatureWriter(tmp_path / "b.feature.parquet") as w:
+            w.write_batch(
+                [
+                    make_feature_record(peptidoform="ELVISK", run_file_name="run_02"),
+                    make_feature_record(peptidoform="SAMPLERK", run_file_name="run_03"),
+                ]
+            )
+
+        with Dataset(tmp_path) as ds:
+            assert ds.feature is not None
+            # All three rows across both shards, not just the first shard's one.
+            assert ds.feature.count() == 3

--- a/tests/integration/test_partitioning.py
+++ b/tests/integration/test_partitioning.py
@@ -146,3 +146,39 @@ class TestPartitionedWriting:
         BaseWriter.write_partitioned(table, out)  # No partition_cols arg
         dirs = sorted(d.name for d in out.iterdir() if d.is_dir())
         assert any("run_file_name=" in d for d in dirs)
+
+    def test_write_partitioned_via_subclass_derives_id_and_validates(self, tmp_path, caplog):
+        """bigbio/qpx#252: called on a concrete writer subclass, write_partitioned
+        must derive the identity id (when absent) and run schema validation,
+        instead of bypassing both. Called on the bare BaseWriter it stays a raw
+        dump (covered by the other tests)."""
+        import logging
+
+        import pyarrow.dataset as pds
+
+        from qpx.writers import FeatureWriter
+        from tests.conftest import make_feature_record
+
+        # Build a proper feature file, then strip the derived feature_id so the
+        # partitioned write has to re-derive it.
+        src = tmp_path / "src.feature.parquet"
+        with FeatureWriter(src) as w:
+            w.write_batch(
+                [
+                    make_feature_record(peptidoform="PEPTIDEK", run_file_name="run_01"),
+                    make_feature_record(peptidoform="ELVISK", run_file_name="run_02"),
+                ]
+            )
+        table = pq.read_table(src)
+        assert "feature_id" in table.schema.names
+        stripped = table.drop_columns(["feature_id"])
+
+        out = tmp_path / "feat_part"
+        with caplog.at_level(logging.WARNING, logger="qpx.writers.base"):
+            FeatureWriter.write_partitioned(stripped, out, ["run_file_name"])
+
+        back = pds.dataset(str(out), format="parquet", partitioning="hive").to_table()
+        assert "feature_id" in back.schema.names
+        ids = back.column("feature_id").to_pylist()
+        assert all(i is not None for i in ids), "feature_id must be derived, not left null"
+        assert len(set(ids)) == 2

--- a/tests/unit/test_mudata.py
+++ b/tests/unit/test_mudata.py
@@ -525,3 +525,53 @@ def test_detect_label_field_uses_label_for_current_schema(tmp_path):
         assert mdata.mod["precursors"].X.nnz > 0
     finally:
         dataset.close()
+
+
+def test_build_mudata_feature_mapping_survives_third_modality(tmp_path):
+    """bigbio/qpx#252: ``varp['feature_mapping']`` was sized against only
+    precursors+proteins, so with a 3rd modality present the assignment raised
+    'incorrect shape' and was silently swallowed. The mapping must be built
+    against the full global var axis and be present + correct."""
+    import scipy.sparse as _sp
+
+    _write_quant_bundle(
+        tmp_path,
+        "m3",
+        [{"label": "LFQ", "intensity": 100.0}],
+        [{"label": "LFQ", "intensity": 1000.0}],
+    )
+    # 3rd modality: an absolute-expression AnnData (<prefix>.pe.h5ad) with its
+    # own var axis, disjoint names from the protein accessions.
+    expr = anndata.AnnData(
+        X=np.array([[1.0, 2.0, 3.0, 4.0]], dtype=float),
+        var=pd.DataFrame(index=["G1", "G2", "G3", "G4"]),
+    )
+    expr.write_h5ad(tmp_path / "m3.pe.h5ad")
+
+    dataset = Dataset(tmp_path, file_prefix="m3")
+    try:
+        mdata = build_mudata(dataset, modalities=["precursors", "proteins", "expression"])
+    finally:
+        dataset.close()
+
+    assert "expression" in mdata.mod, "3rd modality must be built for this regression"
+    # The axis is genuinely larger than precursors+proteins alone.
+    assert mdata.n_vars > mdata.mod["precursors"].n_vars + mdata.mod["proteins"].n_vars
+
+    assert "feature_mapping" in mdata.varp, "feature_mapping must NOT be silently dropped"
+    mapping = mdata.varp["feature_mapping"]
+    assert mapping.shape == (mdata.n_vars, mdata.n_vars)
+
+    # The PEPTIDEK|2 <-> P12345 precursor/protein link is set at the correct
+    # global positions (per-modality offsets on the global axis).
+    offsets = {}
+    running = 0
+    for name, adata in mdata.mod.items():
+        offsets[name] = running
+        running += adata.n_vars
+    prec_pos = offsets["precursors"] + list(mdata.mod["precursors"].var_names).index("PEPTIDEK|2")
+    prot_pos = offsets["proteins"] + list(mdata.mod["proteins"].var_names).index("P12345")
+    csr = _sp.csr_matrix(mapping)
+    assert csr[prec_pos, prot_pos]
+    assert csr[prot_pos, prec_pos]
+    assert csr.nnz == 2

--- a/tests/unit/test_writers.py
+++ b/tests/unit/test_writers.py
@@ -190,3 +190,61 @@ def test_writer_compression(tmp_path):
     with FeatureWriter(path2, compression="snappy") as w:
         w.write_batch([make_feature_record()])
     assert read_parquet_metadata(path2)["compression_format"] == "snappy"
+
+
+def test_pg_write_batch_warns_on_run_double_count(tmp_path, caplog):
+    """bigbio/qpx#242: the streaming write_batch path must run the pg
+    run-disjointness / referential check at close() (as a warning), not skip it.
+
+    Two pg rows sharing the same (pg_accessions, label) with an overlapping
+    grouped_runs double-count that run's intensity.
+    """
+    import logging
+
+    path = tmp_path / "dup.pg.parquet"
+    rec_a = make_pg_record(run_file_name="run_01")
+    rec_b = make_pg_record(run_file_name="run_01")  # same members + label + run
+    with caplog.at_level(logging.WARNING, logger="qpx.writers.base"):
+        with PgWriter(path) as w:
+            w.write_batch([rec_a, rec_b])
+    assert path.exists()
+    assert any("run_double_count" in rec.message for rec in caplog.records), (
+        "streaming write_batch should warn on cross-row run double-count at close"
+    )
+
+
+def test_pg_write_batch_clean_has_no_referential_warning(tmp_path, caplog):
+    """Disjoint grouped_runs across rows must NOT trigger the referential warning."""
+    import logging
+
+    path = tmp_path / "ok.pg.parquet"
+    rec_a = make_pg_record(run_file_name="run_01")
+    rec_b = make_pg_record(run_file_name="run_02")  # disjoint runs
+    with caplog.at_level(logging.WARNING, logger="qpx.writers.base"):
+        with PgWriter(path) as w:
+            w.write_batch([rec_a, rec_b])
+    assert not any("run_double_count" in rec.message for rec in caplog.records)
+
+
+def test_pg_write_dataframe_explodes_intensities(tmp_path):
+    """bigbio/qpx#252: PgWriter.write_dataframe must explode the natural
+    ``intensities`` list into flat label/intensity rows instead of silently
+    dropping quant (the base write_dataframe builds against the flat schema,
+    which has no ``intensities`` column)."""
+    import pandas as pd
+
+    rec = make_pg_record(
+        intensities=[
+            {"label": "TMT126", "intensity": 5000.0},
+            {"label": "TMT127N", "intensity": 6000.0},
+        ]
+    )
+    df = pd.DataFrame([rec])
+    path = tmp_path / "df.pg.parquet"
+    with PgWriter(path) as w:
+        w.write_dataframe(df)
+
+    table = pq.read_table(path)
+    assert table.num_rows == 2, "intensities list should explode into one row per label"
+    assert set(table.column("label").to_pylist()) == {"TMT126", "TMT127N"}
+    assert set(table.column("intensity").to_pylist()) == {5000.0, 6000.0}


### PR DESCRIPTION
Fixes the pre-release converter-audit findings in **#242** and **#252**.

Closes #242
Closes #252

## What changed

### #242 — streaming `write_batch` skipped pg run-disjointness / referential validation
`write_table` ran `_pg_referential_issues` (`run_double_count` / `duplicate_grouped_run`), but the streaming `write_batch`/`_write_arrow_batch` path never did, so every streamed pg converter (diann, fragpipe, maxquant, mzidentml, cdap — incl. the DIA pipeline) skipped it. Added `BaseWriter._validate_referential()`, run at `close()` over the complete written pg file so record/batch and table paths converge. Per the 1.1.2 write-path policy these are **`logger.warning`**, not a raise; `qpxc validate --strict` stays strict.

### #252 — MuData `varp["feature_mapping"]` dropped with a 3rd modality
`_build_feature_mapping` sized the adjacency as `len(precursors)+len(proteins)`, so with expression/differential modalities present the `mdata.varp[...] =` assignment raised "incorrect shape" and was swallowed. Now built against the full global var axis using per-modality offsets (so a protein accession that also appears as an expression var is never mislocated), sized `mdata.n_vars`.

### #252 — S3-vs-local read divergence on multi-shard datasets
`_register_local_structure` used only the **first** of multiple matching files; the S3 path reads **all** matches unioned. Local now reads all shards via a new `DuckDBEngine.register_parquet_files`, matching S3.
*Deferred:* descending Hive-partitioned **subdirs over S3** (the local Hive fallback already exists; S3 subdir listing is a larger, separate change). Local multi-shard union — the clearly more-wrong side — is fixed.

### #252 — validation-bypass in `write_partitioned` / `PgWriter.write_dataframe`
- `write_partitioned` is now a `@classmethod`: called on a concrete writer subclass it routes through id-derivation + schema validation (warning-level); called on bare `BaseWriter` (no schema known) it stays an unchanged raw dump, so all existing `BaseWriter.write_partitioned(...)` call sites are unaffected.
- `PgWriter.write_dataframe` now explodes the natural `intensities` list into flat `label`/`intensity` rows (previously silent quant loss via `Dataset.save_structure`).

### #252 — Spectronaut run-name normalization divergence
Feature adapter stripped only `\.(mzML|raw|d)$` case-sensitively; pg strips `(?i)\.(mzML|raw|d|wiff|htrms)$`. Feature adapter (both `run_file_name` and `id_run_file_name`) now uses the case-insensitive extended DuckDB regex; pg adapter SQL also made case-insensitive so the SQL layer matches (idempotent with its existing Python strip). `.wiff` / `.htrms` / `.RAW` now agree across feature/pg/run keys.

## Tests
Regression test per fix: streaming pg double-count warning + clean-case negative (`test_writers`), `PgWriter.write_dataframe` explode (`test_writers`), `write_partitioned` subclass id-derivation (`test_partitioning`), MuData mapping survives 3rd modality with correct positions (`test_mudata`), local multi-shard union (`test_dataset`), feature/pg run-key extension parity (`test_spectronaut_converter`).

Full suite: **885 passed** (`.venv/bin/python -m pytest -q`). `ruff check` / `ruff format` clean.