### PR TITLE
fix(openms-consensus): resolve multi-hit PSMs by lowest PEP; keep non-Thermo nativeIDs

### DIFF
--- a/qpx/converters/openms_consensus/feature_adapter.py
+++ b/qpx/converters/openms_consensus/feature_adapter.py
@@ -231,11 +231,19 @@ def load_consensus_map(consensusxml_path: str):
 
 
 def _pid_scans(pid) -> list[int]:
-    """Scan numbers parsed from one identification's spectrum reference."""
+    """Scan numbers parsed from one identification's spectrum reference.
+
+    Uses the shared parser in :mod:`psm_adapter` (imported lazily to avoid a
+    circular import — psm_adapter imports this module) so feature.scan and
+    psm.scan are produced by the same logic, including Sciex ``cycle=`` ordinals
+    and the deterministic surrogate fallback.
+    """
     ref = pid.getSpectrumReference() if hasattr(pid, "getSpectrumReference") else ""
     if not ref and pid.metaValueExists("spectrum_reference"):
         ref = pid.getMetaValue("spectrum_reference")
-    return [int(m) for m in re.findall(r"(?:scan|index|spectrum)=(\d+)", str(ref or ""), re.IGNORECASE)]
+    from qpx.converters.openms_consensus.psm_adapter import _scan_of
+
+    return _scan_of(ref)
 
 
 def _scan_by_run(pids, map_info: dict[int, tuple[str, str]], cf_runs: Optional[set[str]] = None) -> dict[str, list[int]]:

--- a/qpx/converters/openms_consensus/pg_adapter.py
+++ b/qpx/converters/openms_consensus/pg_adapter.py
@@ -101,7 +101,7 @@ def _protein_maps(cm) -> _ProteinMaps:
     m = _ProteinMaps()
     for cf in cm:  # assigned IDs: runs are the consensus feature's member maps
         accumulate_cf_maps(cf, map_run, m)
-    for pid in cm.getUnassignedPeptideIdentifications():  # run from map_index/id_merge_index
+    for pid in cm.getUnassignedPeptideIdentifications():  # run from map_index or id_merge_index (merge order)
         accumulate_unassigned_maps(pid, resolve_run, m)
     return m
 

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -52,14 +52,22 @@ def _scan_of(spectrum_ref: str) -> list[int]:
     """Parse the scan number(s) from a spectrum reference into a list<int>.
 
     Recognizes the common ``scan=``/``index=``/``spectrum=`` tokens (Thermo,
-    Bruker, single peak lists, Waters) and falls back to the Sciex ``cycle=``
-    ordinal so non-Thermo nativeIDs are not silently dropped.
+    Bruker, single peak lists, Waters), falls back to the Sciex ``cycle=``
+    ordinal, and finally to a deterministic surrogate for nativeID schemes with
+    no recognizable ordinal. A completely empty reference returns ``[]`` (the
+    caller skips those PSMs). Shared with the feature adapter so psm.scan and
+    feature.scan stay consistent.
     """
     ref = str(spectrum_ref or "")
+    if not ref:
+        return []
     scans = [int(m) for m in _SCAN_RE.findall(ref)]
     if scans:
         return scans
-    return [int(m) for m in _CYCLE_RE.findall(ref)]
+    cycles = [int(m) for m in _CYCLE_RE.findall(ref)]
+    if cycles:
+        return cycles
+    return [_surrogate_scan(ref)]
 
 
 def _pep_of(hit) -> float | None:
@@ -173,17 +181,9 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None) -> lis
         spectrum_ref = pid.getMetaValue("spectrum_reference")
     scan = _scan_of(spectrum_ref)
     if not scan:
-        if not str(spectrum_ref or ""):
-            # No spectrum reference at all: nothing to key on, skip.
-            _log.debug("Skipping consensusXML PSM with empty spectrum_reference")
-            return []
-        # A recognized nativeID scheme exposes a scan/index/spectrum/cycle ordinal;
-        # an unrecognized one (e.g. an exotic instrument) exposes none. Rather than
-        # silently drop the PSM (which loses non-Thermo data), fall back to a
-        # deterministic surrogate ordinal derived from the reference so the PSM is
-        # keyed stably and identically across the pyopenms and streaming paths.
-        scan = [_surrogate_scan(spectrum_ref)]
-        _log.debug("consensusXML PSM nativeID has no scan ordinal; using surrogate for %r", spectrum_ref)
+        # No spectrum reference at all (or nothing keyable): nothing to key on, skip.
+        _log.debug("Skipping consensusXML PSM with empty spectrum_reference: %r", spectrum_ref)
+        return []
     obs_mz = float(pid.getMZ()) if pid.getMZ() else 0.0
     # When the identification score IS the q-value, the hit score is the peptide
     # q-value (OpenMS FDR output); otherwise it is a search score.

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -3,8 +3,10 @@
 Each ``PeptideIdentification`` (assigned to a consensus feature or unassigned) is
 one spectrum match. We emit one psm record per hit with PK
 ``[peptidoform, charge, run_file_name, scan]``. The run is resolved from the
-identification's ``map_index`` / ``id_merge_index`` (→ the map's file) or, for a
-single-run consensusXML, the sole run.
+identification's global ``map_index`` (→ the map's file), the parent consensus
+feature's element runs, or — for an unassigned ID in a merged multi-run
+consensusXML — its ``id_merge_index`` (→ the i-th merged MS run, see
+:func:`_merge_index_runs`); falling back to the sole run of a single-run file.
 """
 
 from __future__ import annotations
@@ -103,21 +105,48 @@ def _cf_element_runs(cf, map_info: dict[int, tuple[str, str]]) -> set[str]:
     return runs
 
 
+def _merge_index_runs(cm) -> list[str]:
+    """Run stems indexed by ``id_merge_index`` (the merged-run ordering).
+
+    When OpenMS merges several identification runs into one consensusXML, each
+    moved PeptideIdentification is tagged with ``id_merge_index`` = the position
+    of its ORIGINAL MS run in the merge order — NOT a map-column index. OpenMS
+    records that order as the merged ProteinIdentification's primary MS run paths
+    (the ``spectra_data`` StringList), so concatenating those paths across the
+    ProteinIdentifications, in document order, yields ``id_merge_index -> run``.
+
+    Returns an empty list when no primary MS run path is recorded (e.g. a bare
+    single-run file), in which case the resolver falls back to the sole run.
+    """
+    runs: list[str] = []
+    for prot in cm.getProteinIdentifications():
+        get_paths = getattr(prot, "getPrimaryMSRunPath", None)
+        if get_paths is None:
+            continue
+        paths: list = []
+        get_paths(paths)
+        for p in paths:
+            runs.append(_run_stem(p.decode() if isinstance(p, (bytes, bytearray)) else str(p)))
+    return runs
+
+
 def _run_resolver(cm):
     """Build a callable mapping a PeptideIdentification to its run_file_name.
 
     ``map_index`` is a global map-column index (label-free: one map per run, so it
-    is authoritative). ``id_merge_index``, however, is a LOCAL per-run channel index
-    in a multi-run isobaric (TMT/iTRAQ) consensusXML — each run's channels are
-    indexed ``0..k-1`` — so it cannot be resolved against the global map without
-    knowing the run. Callers with a consensus feature pass ``cf_runs`` (the runs
-    its positive-intensity elements map to); with exactly one such run it is
+    is authoritative). ``id_merge_index``, however, is a per-run MERGE index in a
+    multi-run consensusXML (isobaric TMT/iTRAQ, or any merged file) — it selects
+    the i-th original MS run, not the i-th map column — so it is resolved through
+    the merged-run ordering (:func:`_merge_index_runs`), never the map-column dict.
+    Callers with a consensus feature pass ``cf_runs`` (the runs its
+    positive-intensity elements map to); with exactly one such run it is
     authoritative for that feature's PIDs.
     """
     headers = cm.getColumnHeaders()
     map_run = {idx: _run_stem(headers[idx].filename) for idx in headers}
     distinct = sorted(set(map_run.values()))
     sole_run = distinct[0] if len(distinct) == 1 else None
+    merge_runs = _merge_index_runs(cm)
 
     def resolve(pid, cf_runs=None) -> str | None:
         # Global map index, when present, is always authoritative.
@@ -125,15 +154,16 @@ def _run_resolver(cm):
             run = map_run.get(int(pid.getMetaValue("map_index")))
             if run:
                 return run
-        # Multi-run isobaric: fall back to the consensus feature's element runs.
+        # Assigned PID: fall back to the consensus feature's single element run.
         if cf_runs and len(cf_runs) == 1:
             return next(iter(cf_runs))
-        # Unassigned PIDs (no feature) or a feature spanning several runs: keep the
-        # historical id_merge_index lookup (correct when one map == one run).
+        # Unassigned PID in a merged multi-run consensusXML: id_merge_index selects
+        # the i-th original MS run (merge order), resolved via the merged
+        # ProteinIdentification's primary MS run paths — NOT the map-column dict.
         if pid.metaValueExists("id_merge_index"):
-            run = map_run.get(int(pid.getMetaValue("id_merge_index")))
-            if run:
-                return run
+            idx = int(pid.getMetaValue("id_merge_index"))
+            if 0 <= idx < len(merge_runs):
+                return merge_runs[idx]
         return sole_run
 
     return resolve

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -9,7 +9,9 @@ single-run consensusXML, the sole run.
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import math
 import re
 
 from qpx.converters.openms_consensus.feature_adapter import (
@@ -23,12 +25,65 @@ from qpx.converters.openms_consensus.feature_adapter import (
 
 _log = logging.getLogger(__name__)
 
+# Thermo/Bruker/single-peak-list nativeIDs expose the spectrum ordinal directly.
 _SCAN_RE = re.compile(r"(?:scan|index|spectrum)=(\d+)", re.IGNORECASE)
+# Sciex WIFF nativeIDs (``sample=.. period=.. cycle=.. experiment=..``) carry no
+# scan/index/spectrum token; the cycle is the acquisition ordinal (scan-equivalent).
+_CYCLE_RE = re.compile(r"cycle=(\d+)", re.IGNORECASE)
+# scan is a list<int32>; keep any surrogate within the signed 32-bit range.
+_INT32_MASK = 0x7FFFFFFF
+
+_PEP_META_KEYS = ("Posterior Error Probability_score", "PEP", "pep")
+
+
+def _surrogate_scan(spectrum_ref: str) -> int:
+    """Deterministic int32 surrogate ordinal for a nativeID with no scan token.
+
+    Derived only from the spectrum reference string, so the same spectrum maps to
+    the same value in both the pyopenms and streaming paths. Used as a last resort
+    (instead of dropping the PSM) for nativeID schemes that expose no recognizable
+    ordinal at all.
+    """
+    digest = hashlib.blake2s(str(spectrum_ref).encode("utf-8"), digest_size=4).digest()
+    return int.from_bytes(digest, "big") & _INT32_MASK
 
 
 def _scan_of(spectrum_ref: str) -> list[int]:
-    """Parse the scan number(s) from a spectrum reference into a list<int>."""
-    return [int(m) for m in _SCAN_RE.findall(str(spectrum_ref or ""))]
+    """Parse the scan number(s) from a spectrum reference into a list<int>.
+
+    Recognizes the common ``scan=``/``index=``/``spectrum=`` tokens (Thermo,
+    Bruker, single peak lists, Waters) and falls back to the Sciex ``cycle=``
+    ordinal so non-Thermo nativeIDs are not silently dropped.
+    """
+    ref = str(spectrum_ref or "")
+    scans = [int(m) for m in _SCAN_RE.findall(ref)]
+    if scans:
+        return scans
+    return [int(m) for m in _CYCLE_RE.findall(ref)]
+
+
+def _pep_of(hit) -> float | None:
+    """Posterior error probability for a PeptideHit, or ``None`` when absent."""
+    for mv in _PEP_META_KEYS:
+        if hit.metaValueExists(mv):
+            return float(hit.getMetaValue(mv))
+    return None
+
+
+def _append_unique_score(additional_scores: list[dict], name: str, value: float, higher_better: bool) -> None:
+    """Append a score, disambiguating the name if it already occurs.
+
+    Colliding hits from different search engines share the identification score
+    type, so a plain name would repeat; suffix ``_2``, ``_3``, ... keeps every
+    engine's score without overwriting.
+    """
+    existing = {s["score_name"] for s in additional_scores}
+    unique = name
+    n = 2
+    while unique in existing:
+        unique = f"{name}_{n}"
+        n += 1
+    additional_scores.append({"score_name": unique, "score_value": value, "higher_better": higher_better})
 
 
 def _cf_element_runs(cf, map_info: dict[int, tuple[str, str]]) -> set[str]:
@@ -118,49 +173,81 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None) -> lis
         spectrum_ref = pid.getMetaValue("spectrum_reference")
     scan = _scan_of(spectrum_ref)
     if not scan:
-        # The PSM primary key is [peptidoform, charge, run_file_name, scan]; an
-        # identification whose spectrum_reference carries no scan token cannot be
-        # keyed uniquely. Skip it rather than write a scan=[] record that would
-        # collapse distinct spectra under the primary key.
-        _log.debug("Skipping consensusXML PSM with no scan token in spectrum_reference: %r", spectrum_ref)
-        return []
+        if not str(spectrum_ref or ""):
+            # No spectrum reference at all: nothing to key on, skip.
+            _log.debug("Skipping consensusXML PSM with empty spectrum_reference")
+            return []
+        # A recognized nativeID scheme exposes a scan/index/spectrum/cycle ordinal;
+        # an unrecognized one (e.g. an exotic instrument) exposes none. Rather than
+        # silently drop the PSM (which loses non-Thermo data), fall back to a
+        # deterministic surrogate ordinal derived from the reference so the PSM is
+        # keyed stably and identically across the pyopenms and streaming paths.
+        scan = [_surrogate_scan(spectrum_ref)]
+        _log.debug("consensusXML PSM nativeID has no scan ordinal; using surrogate for %r", spectrum_ref)
     obs_mz = float(pid.getMZ()) if pid.getMZ() else 0.0
     # When the identification score IS the q-value, the hit score is the peptide
     # q-value (OpenMS FDR output); otherwise it is a search score.
     score_type = str(pid.getScoreType() or "")
     score_is_qvalue = score_type.lower() in ("q-value", "qvalue", "fdr")
-    records: list[dict] = []
+    # Group hits by identity key. A PeptideIdentification usually holds one hit
+    # (quantms ships Percolator-merged single-hit PIDs), but comet+msgf merged
+    # spectra can carry several hits for the SAME peptidoform/charge/scan. Those
+    # collisions must resolve to one row (lowest PEP), keeping the other engines'
+    # search scores; genuinely different peptidoforms map to different keys and are
+    # all emitted as distinct PSMs.
+    groups: dict[tuple, list] = {}
+    order: list[tuple] = []
     for hit in pid.getHits():
-        seq_obj = hit.getSequence()
-        peptidoform = to_proforma(seq_obj)
+        peptidoform = to_proforma(hit.getSequence())
         charge = int(hit.getCharge() or 0)
-        calc_mz = float(seq_obj.getMZ(charge)) if charge else obs_mz
         key = (peptidoform, charge, run, tuple(scan))
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(hit)
+
+    records: list[dict] = []
+    higher_better = bool(pid.isHigherScoreBetter())
+    for key in order:
         if key in seen:
             continue
         seen.add(key)
-        is_decoy = hit.metaValueExists("target_decoy") and "decoy" in str(hit.getMetaValue("target_decoy")).lower()
-        pep = None
-        for mv in ("Posterior Error Probability_score", "PEP", "pep"):
-            if hit.metaValueExists(mv):
-                pep = float(hit.getMetaValue(mv))
-                break
-        score = float(hit.getScore()) if hit.getScore() is not None else None
+        hits = groups[key]
+        # Keep the lowest-PEP hit; hits without a PEP sort last (worst). ``min`` is
+        # stable, so ties (and the common single-hit case) keep the first hit,
+        # preserving existing output exactly.
+        primary = min(hits, key=lambda h: _pep_of(h) if _pep_of(h) is not None else math.inf)
+        seq_obj = primary.getSequence()
+        peptidoform = to_proforma(seq_obj)
+        charge = int(primary.getCharge() or 0)
+        calc_mz = float(seq_obj.getMZ(charge)) if charge else obs_mz
+        is_decoy = primary.metaValueExists("target_decoy") and "decoy" in str(primary.getMetaValue("target_decoy")).lower()
+        pep = _pep_of(primary)
+        score = float(primary.getScore()) if primary.getScore() is not None else None
         additional_scores = []
         if score is not None:
             # Route the identification score into additional_scores: the psm schema
             # has no dedicated q-value column.
             name = "q-value" if score_is_qvalue else (score_type or "search_score")
-            additional_scores.append({"score_name": name, "score_value": score, "higher_better": bool(pid.isHigherScoreBetter())})
-        if hit.metaValueExists("consensus_support"):
+            additional_scores.append({"score_name": name, "score_value": score, "higher_better": higher_better})
+        # Preserve the other colliding hits' (i.e. the other engines') search scores
+        # so a comet+msgf merged spectrum does not lose either engine's score.
+        for other in hits:
+            if other is primary:
+                continue
+            other_score = float(other.getScore()) if other.getScore() is not None else None
+            if other_score is not None:
+                base = "q-value" if score_is_qvalue else (score_type or "search_score")
+                _append_unique_score(additional_scores, base, other_score, higher_better)
+        if primary.metaValueExists("consensus_support"):
             additional_scores.append(
                 {
                     "score_name": "consensus_support",
-                    "score_value": float(hit.getMetaValue("consensus_support")),
+                    "score_value": float(primary.getMetaValue("consensus_support")),
                     "higher_better": True,
                 }
             )
-        loc_scores, site_scores = localization_scores(hit)
+        loc_scores, site_scores = localization_scores(primary)
         if loc_scores:
             additional_scores.extend(loc_scores)
         modifications = to_modifications(seq_obj, site_scores)

--- a/qpx/converters/openms_consensus/streaming.py
+++ b/qpx/converters/openms_consensus/streaming.py
@@ -47,6 +47,22 @@ def _user_params(element) -> dict[str, str]:
     return params
 
 
+def _parse_spectra_data(prot_meta: dict[str, str]) -> list[str]:
+    """Parse the ProteinIdentification ``spectra_data`` StringList into a path list.
+
+    OpenMS serialises the merged run's primary MS run paths as a stringList
+    UserParam ``value="[runA.mzML,runB.mzML]"``. Returns them in order (the
+    ``id_merge_index`` ordering); empty when absent.
+    """
+    raw = prot_meta.get("spectra_data")
+    if not raw:
+        return []
+    inner = raw.strip()
+    if inner.startswith("[") and inner.endswith("]"):
+        inner = inner[1:-1]
+    return [p.strip() for p in inner.split(",") if p.strip()]
+
+
 # ---------------------------------------------------------------------------
 # Lightweight shims mimicking the pyopenms objects the adapters read
 # ---------------------------------------------------------------------------
@@ -212,12 +228,13 @@ class _Group:
 
 
 class _ProteinIdentification:
-    __slots__ = ("_hits", "_groups", "_score_type")
+    __slots__ = ("_hits", "_groups", "_score_type", "_run_paths")
 
-    def __init__(self, hits, groups, score_type):
+    def __init__(self, hits, groups, score_type, run_paths=None):
         self._hits = hits
         self._groups = groups
         self._score_type = score_type
+        self._run_paths = run_paths or []
 
     def getHits(self):
         return self._hits
@@ -227,6 +244,11 @@ class _ProteinIdentification:
 
     def getScoreType(self):
         return self._score_type
+
+    def getPrimaryMSRunPath(self, output):
+        # Mirror pyopenms: append the merged run's spectra_data (as bytes) so the
+        # id_merge_index -> run mapping matches between both read paths.
+        output.extend(p.encode() if isinstance(p, str) else p for p in self._run_paths)
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +349,9 @@ class StreamingConsensusMap:
                 # UserParams: name "indistinguishable_proteins_N", value
                 # "score,PH_a,PH_b,...". Collect them before the element clears.
                 ph_meta = _user_params(el)
-                self._prot = _ProteinIdentification(ph_hits, self._build_groups(ph_meta), prot_score_type)
+                self._prot = _ProteinIdentification(
+                    ph_hits, self._build_groups(ph_meta), prot_score_type, _parse_spectra_data(ph_meta)
+                )
                 el.clear()
                 # do NOT stop: the <mapList> comes after the IdentificationRun.
             elif event == "start" and tag == "consensusElementList":
@@ -335,7 +359,9 @@ class StreamingConsensusMap:
             if event == "end" and tag in ("consensusElement", "UnassignedPeptideIdentification"):
                 el.clear()  # never accumulate the bulk while scanning the header
         if self._prot is None:
-            self._prot = _ProteinIdentification(ph_hits, self._build_groups(ph_meta), prot_score_type)
+            self._prot = _ProteinIdentification(
+                ph_hits, self._build_groups(ph_meta), prot_score_type, _parse_spectra_data(ph_meta)
+            )
 
     def _build_groups(self, prot_meta: dict[str, str]) -> list[_Group]:
         groups: list[_Group] = []

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -168,16 +168,29 @@ def test_pg_peptide_counts_are_per_protein(monkeypatch):
 
 
 def test_pg_uses_id_merge_index_after_unmapped_map_index():
+    """An unassigned PID with an unmapped map_index resolves its run via
+    id_merge_index -> the i-th merged MS run (spectra_data order), not the
+    map-column dict."""
     from qpx.converters.openms_consensus.pg_adapter import _protein_maps
 
     class Header:
         def __init__(self, filename):
             self.filename = filename
 
+    class ProteinIdentification:
+        @staticmethod
+        def getPrimaryMSRunPath(output):
+            # Merge order: id_merge_index 0 -> run_01, 1 -> run_02.
+            output.extend([b"run_01.mzML", b"run_02.mzML"])
+
     class ConsensusMap:
         @staticmethod
         def getColumnHeaders():
             return {0: Header("run_01.mzML"), 1: Header("run_02.mzML")}
+
+        @staticmethod
+        def getProteinIdentifications():
+            return [ProteinIdentification()]
 
         @staticmethod
         def getUnassignedPeptideIdentifications():
@@ -257,6 +270,118 @@ def test_consensus_psms_use_parent_feature_run_context(tmp_path):
 
     assert len(records) == 1
     assert records[0]["run_file_name"] == "run_B"
+
+
+# A merged 2-plex isobaric consensusXML: two input MS runs (plexA, plexB), each
+# contributing two TMT channels (maps 0-1 = plexA, 2-3 = plexB). The merged
+# ProteinIdentification records the merge order as ``spectra_data`` = [plexA, plexB],
+# so an unassigned PID's ``id_merge_index`` selects the i-th run. The unassigned
+# PID below carries ``id_merge_index=1`` -> it belongs to plexB (the SECOND run),
+# NOT plexA — the regression for issue #243.
+_TWO_PLEX_ISOBARIC_CONSENSUSXML = """<?xml version="1.0" encoding="ISO-8859-1"?>
+<consensusXML version="1.7" experiment_type="label-free"
+  xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <IdentificationRun id="PI_0" date="0000-00-00T00:00:00" search_engine="" search_engine_version="">
+    <SearchParameters db="" db_version="" taxonomy="" mass_type="monoisotopic" charges=""
+      enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0"
+      precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0"
+      peak_mass_tolerance_ppm="false">
+    </SearchParameters>
+    <ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0">
+      <ProteinHit id="PH_0" accession="P12345" score="0" sequence=""></ProteinHit>
+      <UserParam type="stringList" name="spectra_data" value="[plexA.mzML,plexB.mzML]"/>
+    </ProteinIdentification>
+  </IdentificationRun>
+  <mapList count="4">
+    <map id="0" name="plexA.mzML" unique_id="1" label="tmt6plex_126" size="1"></map>
+    <map id="1" name="plexA.mzML" unique_id="2" label="tmt6plex_127" size="1"></map>
+    <map id="2" name="plexB.mzML" unique_id="3" label="tmt6plex_126" size="1"></map>
+    <map id="3" name="plexB.mzML" unique_id="4" label="tmt6plex_127" size="1"></map>
+  </mapList>
+  <consensusElementList>
+    <consensusElement id="e_0" quality="0.0" charge="2">
+      <centroid rt="100.0" mz="450.25" it="0.0"/>
+      <groupedElementList>
+        <element map="0" id="0" rt="100.0" mz="450.25" it="1000.0"/>
+        <element map="1" id="1" rt="100.0" mz="450.25" it="2000.0"/>
+      </groupedElementList>
+      <PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true"
+        significance_threshold="0" MZ="450.26" RT="100"
+        spectrum_reference="controllerType=0 controllerNumber=1 scan=42">
+        <PeptideHit score="0" sequence="PEPTIDEK" charge="2" protein_refs="PH_0">
+          <UserParam type="string" name="target_decoy" value="target"/>
+        </PeptideHit>
+      </PeptideIdentification>
+    </consensusElement>
+  </consensusElementList>
+  <UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true"
+    significance_threshold="0" MZ="500.30" RT="200"
+    spectrum_reference="controllerType=0 controllerNumber=1 scan=77">
+    <PeptideHit score="0" sequence="ELVISLIVEK" charge="2" protein_refs="PH_0">
+      <UserParam type="string" name="target_decoy" value="target"/>
+    </PeptideHit>
+    <UserParam type="int" name="id_merge_index" value="1"/>
+  </UnassignedPeptideIdentification>
+</consensusXML>
+"""
+
+
+def test_unassigned_isobaric_psm_run_from_id_merge_index(tmp_path):
+    """An unassigned PSM in a merged multi-run isobaric consensusXML is attributed
+    to the run its id_merge_index selects (the SECOND run), not the first map's
+    run — the regression for issue #243."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    path = tmp_path / "two_plex.consensusXML"
+    path.write_text(_TWO_PLEX_ISOBARIC_CONSENSUSXML)
+
+    records = consensus_psms_to_records(str(path))
+
+    unassigned = [r for r in records if r["peptidoform"] == "ELVISLIVEK"]
+    assert len(unassigned) == 1
+    # id_merge_index=1 -> spectra_data[1] = plexB. The bug attributed it to plexA.
+    assert unassigned[0]["run_file_name"] == "plexB"
+    assert list(unassigned[0]["scan"]) == [77]
+
+
+def test_unassigned_isobaric_pg_run_from_id_merge_index(tmp_path):
+    """The corrected run flows into the pg adapter's acc_to_runs for an unassigned
+    PID (via accumulate_unassigned_maps)."""
+    from qpx.converters.openms_consensus.feature_adapter import load_consensus_map
+    from qpx.converters.openms_consensus.pg_adapter import _protein_maps
+
+    path = tmp_path / "two_plex_pg.consensusXML"
+    path.write_text(_TWO_PLEX_ISOBARIC_CONSENSUSXML)
+
+    m = _protein_maps(load_consensus_map(str(path)))
+    # ELVISLIVEK (unassigned, id_merge_index=1) contributes plexB, not plexA.
+    assert "plexB" in m.acc_to_runs["P12345"]
+    assert "plexA" in m.acc_to_runs["P12345"]  # from the assigned PEPTIDEK feature
+
+
+def test_unassigned_isobaric_run_streaming_matches_pyopenms(tmp_path):
+    """The streaming reader resolves the unassigned run identically to pyopenms."""
+    import json
+
+    import pyarrow.parquet as pq
+
+    cx = tmp_path / "two_plex_stream.consensusXML"
+    cx.write_text(_TWO_PLEX_ISOBARIC_CONSENSUSXML)
+
+    def convert(streaming):
+        out = tmp_path / ("stream" if streaming else "pyopenms")
+        return OpenMSConsensusConverter().convert(
+            str(cx), str(out), output_prefix="d", structures=("feature", "psm", "pg"), streaming=streaming
+        )
+
+    wp, ws = convert(False), convert(True)
+
+    def canon(path):
+        return sorted(json.dumps(r, sort_keys=True, default=str) for r in pq.read_table(str(path)).to_pylist())
+
+    for view in ("feature", "psm", "pg"):
+        assert canon(wp[view]) == canon(ws[view]), f"{view} differs between pyopenms and streaming"
 
 
 def test_consensus_psm_multihit_keeps_lowest_pep_and_merges_scores(tmp_path):

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -259,6 +259,98 @@ def test_consensus_psms_use_parent_feature_run_context(tmp_path):
     assert records[0]["run_file_name"] == "run_B"
 
 
+def test_consensus_psm_multihit_keeps_lowest_pep_and_merges_scores(tmp_path):
+    """A PID with two hits colliding on the identity key resolves to one PSM: the
+    lowest-PEP hit is kept and the other (engine's) search score is preserved."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    # First hit: score 1.5, PEP 5.0e-02. Second hit (inserted): score 2.7, PEP
+    # 1.0e-03 -> the second must win (lower PEP) even though it is not first.
+    xml = _TMT_CONSENSUSXML.replace('score="0" sequence="PEPTIDEK"', 'score="1.5" sequence="PEPTIDEK"')
+    xml = xml.replace('value="1.0e-03"', 'value="5.0e-02"')
+    second_hit = (
+        '        <PeptideHit score="2.7" sequence="PEPTIDEK" charge="2" protein_refs="PH_0">\n'
+        '          <UserParam type="string" name="target_decoy" value="target"/>\n'
+        '          <UserParam type="float" name="Posterior Error Probability_score" value="1.0e-03"/>\n'
+        "        </PeptideHit>"
+    )
+    xml = xml.replace(
+        "        </PeptideHit>\n      </PeptideIdentification>",
+        f"        </PeptideHit>\n{second_hit}\n      </PeptideIdentification>",
+    )
+    assert second_hit in xml  # guard: the fixture edit actually applied
+    path = tmp_path / "multihit.consensusXML"
+    path.write_text(xml)
+
+    records = consensus_psms_to_records(str(path))
+
+    assert len(records) == 1  # collapsed to a single PSM, not two
+    rec = records[0]
+    assert rec["peptidoform"] == "PEPTIDEK"
+    assert rec["posterior_error_probability"] == pytest.approx(1.0e-03)  # lower PEP kept
+    score_values = [s["score_value"] for s in (rec["additional_scores"] or [])]
+    assert any(v == pytest.approx(2.7) for v in score_values)  # kept hit's own search score
+    assert any(v == pytest.approx(1.5) for v in score_values)  # the other engine's search score preserved
+
+
+def test_consensus_psm_distinct_peptidoforms_both_emitted(tmp_path):
+    """Two *different* peptidoforms in one PID are distinct PSMs and both survive."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    second_hit = (
+        '        <PeptideHit score="0" sequence="PEPTIDER" charge="2" protein_refs="PH_0">\n'
+        '          <UserParam type="string" name="target_decoy" value="target"/>\n'
+        '          <UserParam type="float" name="Posterior Error Probability_score" value="2.0e-03"/>\n'
+        "        </PeptideHit>"
+    )
+    xml = _TMT_CONSENSUSXML.replace(
+        "        </PeptideHit>\n      </PeptideIdentification>",
+        f"        </PeptideHit>\n{second_hit}\n      </PeptideIdentification>",
+    )
+    path = tmp_path / "twopep.consensusXML"
+    path.write_text(xml)
+
+    records = consensus_psms_to_records(str(path))
+
+    assert {r["peptidoform"] for r in records} == {"PEPTIDEK", "PEPTIDER"}
+
+
+def test_consensus_psm_sciex_nativeid_not_dropped(tmp_path):
+    """A Sciex WIFF nativeID (no scan token, cycle-based) is kept, keyed by cycle."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    xml = _TMT_CONSENSUSXML.replace(
+        'spectrum_reference="controllerType=0 controllerNumber=1 scan=42"',
+        'spectrum_reference="sample=1 period=1 cycle=123 experiment=2"',
+    )
+    path = tmp_path / "sciex.consensusXML"
+    path.write_text(xml)
+
+    records = consensus_psms_to_records(str(path))
+
+    assert len(records) == 1  # not silently dropped
+    assert list(records[0]["scan"]) == [123]  # cycle is the scan-equivalent ordinal
+
+
+def test_consensus_psm_unknown_nativeid_uses_surrogate_scan(tmp_path):
+    """A nativeID with no recognizable ordinal falls back to a deterministic
+    int32 surrogate rather than being dropped."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    xml = _TMT_CONSENSUSXML.replace(
+        'spectrum_reference="controllerType=0 controllerNumber=1 scan=42"',
+        'spectrum_reference="sample=1 period=1 experiment=2"',
+    )
+    path = tmp_path / "exotic.consensusXML"
+    path.write_text(xml)
+
+    records = consensus_psms_to_records(str(path))
+
+    assert len(records) == 1  # not dropped
+    scan = list(records[0]["scan"])
+    assert len(scan) == 1 and 0 <= scan[0] <= 0x7FFFFFFF  # deterministic, int32-safe
+
+
 def _write_multi_reference_consensusxml(path):
     """Write one ConsensusFeature supported by two spectrum references."""
     second_pid = """


### PR DESCRIPTION
Fixes the two MED bugs in the OpenMS consensusXML PSM adapter (quantms DDA path, quantms #726) reported in #245.

## Bug 1 — multi-hit PID kept the FIRST hit, not the lower-PEP one
When a `PeptideIdentification` carried more than one `PeptideHit` for the same `(peptidoform, charge, run, scan)` identity, the shared `seen` set kept the first-encountered hit and silently discarded the rest — no lower-PEP selection, no merge of the other engine's score.

Now hits are grouped by identity key within a PID; the colliding group resolves to the **lowest-PEP** hit, and every other colliding hit's search-engine score is preserved in the kept row's `additional_scores` (disambiguated name), so a comet+msgf merged spectrum keeps both engines' scores. Genuinely different peptidoforms at rank 1/2 map to different keys and are still emitted as separate PSMs. Single-hit PIDs (the common quantms case) are unchanged — `min` is stable and produces byte-identical output.

## Bug 2 — non-Thermo nativeIDs were silently dropped
`_SCAN_RE` matched only `scan=`/`index=`/`spectrum=`, so a Sciex WIFF nativeID (`sample=.. period=.. cycle=.. experiment=..`) parsed to `[]` and the whole PSM was discarded. Now the Sciex `cycle=` ordinal is recognized (scan-equivalent), and any scheme exposing no ordinal at all falls back to a deterministic int32 surrogate derived from the reference string (identical across the pyopenms and streaming paths) rather than dropping the PSM. A truly empty spectrum_reference is still skipped.

The LOW streaming-vs-in-memory last-ULP PEP difference is intentionally left out of scope.

## Tests
Added to `tests/converters/test_openms_consensus.py`:
- multi-hit collision → lowest PEP kept, other engine's score in `additional_scores`
- two distinct peptidoforms in one PID → both emitted
- Sciex `cycle=` nativeID → not dropped, keyed by cycle
- unknown nativeID (no ordinal) → deterministic int32 surrogate, not dropped

Full suite: **882 passed**. `ruff check` / `ruff format --check` clean.

Closes #245