### PR TITLE
fix(openms-consensus): unassigned isobaric PSM run from id_merge_index merge order

### DIFF
--- a/qpx/converters/openms_consensus/pg_adapter.py
+++ b/qpx/converters/openms_consensus/pg_adapter.py
@@ -101,7 +101,7 @@ def _protein_maps(cm) -> _ProteinMaps:
     m = _ProteinMaps()
     for cf in cm:  # assigned IDs: runs are the consensus feature's member maps
         accumulate_cf_maps(cf, map_run, m)
-    for pid in cm.getUnassignedPeptideIdentifications():  # run from map_index/id_merge_index
+    for pid in cm.getUnassignedPeptideIdentifications():  # run from map_index or id_merge_index (merge order)
         accumulate_unassigned_maps(pid, resolve_run, m)
     return m
 

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -3,8 +3,10 @@
 Each ``PeptideIdentification`` (assigned to a consensus feature or unassigned) is
 one spectrum match. We emit one psm record per hit with PK
 ``[peptidoform, charge, run_file_name, scan]``. The run is resolved from the
-identification's ``map_index`` / ``id_merge_index`` (→ the map's file) or, for a
-single-run consensusXML, the sole run.
+identification's global ``map_index`` (→ the map's file), the parent consensus
+feature's element runs, or — for an unassigned ID in a merged multi-run
+consensusXML — its ``id_merge_index`` (→ the i-th merged MS run, see
+:func:`_merge_index_runs`); falling back to the sole run of a single-run file.
 """
 
 from __future__ import annotations
@@ -103,21 +105,48 @@ def _cf_element_runs(cf, map_info: dict[int, tuple[str, str]]) -> set[str]:
     return runs
 
 
+def _merge_index_runs(cm) -> list[str]:
+    """Run stems indexed by ``id_merge_index`` (the merged-run ordering).
+
+    When OpenMS merges several identification runs into one consensusXML, each
+    moved PeptideIdentification is tagged with ``id_merge_index`` = the position
+    of its ORIGINAL MS run in the merge order — NOT a map-column index. OpenMS
+    records that order as the merged ProteinIdentification's primary MS run paths
+    (the ``spectra_data`` StringList), so concatenating those paths across the
+    ProteinIdentifications, in document order, yields ``id_merge_index -> run``.
+
+    Returns an empty list when no primary MS run path is recorded (e.g. a bare
+    single-run file), in which case the resolver falls back to the sole run.
+    """
+    runs: list[str] = []
+    for prot in cm.getProteinIdentifications():
+        get_paths = getattr(prot, "getPrimaryMSRunPath", None)
+        if get_paths is None:
+            continue
+        paths: list = []
+        get_paths(paths)
+        for p in paths:
+            runs.append(_run_stem(p.decode() if isinstance(p, (bytes, bytearray)) else str(p)))
+    return runs
+
+
 def _run_resolver(cm):
     """Build a callable mapping a PeptideIdentification to its run_file_name.
 
     ``map_index`` is a global map-column index (label-free: one map per run, so it
-    is authoritative). ``id_merge_index``, however, is a LOCAL per-run channel index
-    in a multi-run isobaric (TMT/iTRAQ) consensusXML — each run's channels are
-    indexed ``0..k-1`` — so it cannot be resolved against the global map without
-    knowing the run. Callers with a consensus feature pass ``cf_runs`` (the runs
-    its positive-intensity elements map to); with exactly one such run it is
+    is authoritative). ``id_merge_index``, however, is a per-run MERGE index in a
+    multi-run consensusXML (isobaric TMT/iTRAQ, or any merged file) — it selects
+    the i-th original MS run, not the i-th map column — so it is resolved through
+    the merged-run ordering (:func:`_merge_index_runs`), never the map-column dict.
+    Callers with a consensus feature pass ``cf_runs`` (the runs its
+    positive-intensity elements map to); with exactly one such run it is
     authoritative for that feature's PIDs.
     """
     headers = cm.getColumnHeaders()
     map_run = {idx: _run_stem(headers[idx].filename) for idx in headers}
     distinct = sorted(set(map_run.values()))
     sole_run = distinct[0] if len(distinct) == 1 else None
+    merge_runs = _merge_index_runs(cm)
 
     def resolve(pid, cf_runs=None) -> str | None:
         # Global map index, when present, is always authoritative.
@@ -125,15 +154,16 @@ def _run_resolver(cm):
             run = map_run.get(int(pid.getMetaValue("map_index")))
             if run:
                 return run
-        # Multi-run isobaric: fall back to the consensus feature's element runs.
+        # Assigned PID: fall back to the consensus feature's single element run.
         if cf_runs and len(cf_runs) == 1:
             return next(iter(cf_runs))
-        # Unassigned PIDs (no feature) or a feature spanning several runs: keep the
-        # historical id_merge_index lookup (correct when one map == one run).
+        # Unassigned PID in a merged multi-run consensusXML: id_merge_index selects
+        # the i-th original MS run (merge order), resolved via the merged
+        # ProteinIdentification's primary MS run paths — NOT the map-column dict.
         if pid.metaValueExists("id_merge_index"):
-            run = map_run.get(int(pid.getMetaValue("id_merge_index")))
-            if run:
-                return run
+            idx = int(pid.getMetaValue("id_merge_index"))
+            if 0 <= idx < len(merge_runs):
+                return merge_runs[idx]
         return sole_run
 
     return resolve

--- a/qpx/converters/openms_consensus/streaming.py
+++ b/qpx/converters/openms_consensus/streaming.py
@@ -47,6 +47,22 @@ def _user_params(element) -> dict[str, str]:
     return params
 
 
+def _parse_spectra_data(prot_meta: dict[str, str]) -> list[str]:
+    """Parse the ProteinIdentification ``spectra_data`` StringList into a path list.
+
+    OpenMS serialises the merged run's primary MS run paths as a stringList
+    UserParam ``value="[runA.mzML,runB.mzML]"``. Returns them in order (the
+    ``id_merge_index`` ordering); empty when absent.
+    """
+    raw = prot_meta.get("spectra_data")
+    if not raw:
+        return []
+    inner = raw.strip()
+    if inner.startswith("[") and inner.endswith("]"):
+        inner = inner[1:-1]
+    return [p.strip() for p in inner.split(",") if p.strip()]
+
+
 # ---------------------------------------------------------------------------
 # Lightweight shims mimicking the pyopenms objects the adapters read
 # ---------------------------------------------------------------------------
@@ -212,12 +228,13 @@ class _Group:
 
 
 class _ProteinIdentification:
-    __slots__ = ("_hits", "_groups", "_score_type")
+    __slots__ = ("_hits", "_groups", "_score_type", "_run_paths")
 
-    def __init__(self, hits, groups, score_type):
+    def __init__(self, hits, groups, score_type, run_paths=None):
         self._hits = hits
         self._groups = groups
         self._score_type = score_type
+        self._run_paths = run_paths or []
 
     def getHits(self):
         return self._hits
@@ -227,6 +244,11 @@ class _ProteinIdentification:
 
     def getScoreType(self):
         return self._score_type
+
+    def getPrimaryMSRunPath(self, output):
+        # Mirror pyopenms: append the merged run's spectra_data (as bytes) so the
+        # id_merge_index -> run mapping matches between both read paths.
+        output.extend(p.encode() if isinstance(p, str) else p for p in self._run_paths)
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +349,9 @@ class StreamingConsensusMap:
                 # UserParams: name "indistinguishable_proteins_N", value
                 # "score,PH_a,PH_b,...". Collect them before the element clears.
                 ph_meta = _user_params(el)
-                self._prot = _ProteinIdentification(ph_hits, self._build_groups(ph_meta), prot_score_type)
+                self._prot = _ProteinIdentification(
+                    ph_hits, self._build_groups(ph_meta), prot_score_type, _parse_spectra_data(ph_meta)
+                )
                 el.clear()
                 # do NOT stop: the <mapList> comes after the IdentificationRun.
             elif event == "start" and tag == "consensusElementList":
@@ -335,7 +359,9 @@ class StreamingConsensusMap:
             if event == "end" and tag in ("consensusElement", "UnassignedPeptideIdentification"):
                 el.clear()  # never accumulate the bulk while scanning the header
         if self._prot is None:
-            self._prot = _ProteinIdentification(ph_hits, self._build_groups(ph_meta), prot_score_type)
+            self._prot = _ProteinIdentification(
+                ph_hits, self._build_groups(ph_meta), prot_score_type, _parse_spectra_data(ph_meta)
+            )
 
     def _build_groups(self, prot_meta: dict[str, str]) -> list[_Group]:
         groups: list[_Group] = []

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -168,16 +168,29 @@ def test_pg_peptide_counts_are_per_protein(monkeypatch):
 
 
 def test_pg_uses_id_merge_index_after_unmapped_map_index():
+    """An unassigned PID with an unmapped map_index resolves its run via
+    id_merge_index -> the i-th merged MS run (spectra_data order), not the
+    map-column dict."""
     from qpx.converters.openms_consensus.pg_adapter import _protein_maps
 
     class Header:
         def __init__(self, filename):
             self.filename = filename
 
+    class ProteinIdentification:
+        @staticmethod
+        def getPrimaryMSRunPath(output):
+            # Merge order: id_merge_index 0 -> run_01, 1 -> run_02.
+            output.extend([b"run_01.mzML", b"run_02.mzML"])
+
     class ConsensusMap:
         @staticmethod
         def getColumnHeaders():
             return {0: Header("run_01.mzML"), 1: Header("run_02.mzML")}
+
+        @staticmethod
+        def getProteinIdentifications():
+            return [ProteinIdentification()]
 
         @staticmethod
         def getUnassignedPeptideIdentifications():
@@ -257,6 +270,118 @@ def test_consensus_psms_use_parent_feature_run_context(tmp_path):
 
     assert len(records) == 1
     assert records[0]["run_file_name"] == "run_B"
+
+
+# A merged 2-plex isobaric consensusXML: two input MS runs (plexA, plexB), each
+# contributing two TMT channels (maps 0-1 = plexA, 2-3 = plexB). The merged
+# ProteinIdentification records the merge order as ``spectra_data`` = [plexA, plexB],
+# so an unassigned PID's ``id_merge_index`` selects the i-th run. The unassigned
+# PID below carries ``id_merge_index=1`` -> it belongs to plexB (the SECOND run),
+# NOT plexA — the regression for issue #243.
+_TWO_PLEX_ISOBARIC_CONSENSUSXML = """<?xml version="1.0" encoding="ISO-8859-1"?>
+<consensusXML version="1.7" experiment_type="label-free"
+  xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <IdentificationRun id="PI_0" date="0000-00-00T00:00:00" search_engine="" search_engine_version="">
+    <SearchParameters db="" db_version="" taxonomy="" mass_type="monoisotopic" charges=""
+      enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0"
+      precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0"
+      peak_mass_tolerance_ppm="false">
+    </SearchParameters>
+    <ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0">
+      <ProteinHit id="PH_0" accession="P12345" score="0" sequence=""></ProteinHit>
+      <UserParam type="stringList" name="spectra_data" value="[plexA.mzML,plexB.mzML]"/>
+    </ProteinIdentification>
+  </IdentificationRun>
+  <mapList count="4">
+    <map id="0" name="plexA.mzML" unique_id="1" label="tmt6plex_126" size="1"></map>
+    <map id="1" name="plexA.mzML" unique_id="2" label="tmt6plex_127" size="1"></map>
+    <map id="2" name="plexB.mzML" unique_id="3" label="tmt6plex_126" size="1"></map>
+    <map id="3" name="plexB.mzML" unique_id="4" label="tmt6plex_127" size="1"></map>
+  </mapList>
+  <consensusElementList>
+    <consensusElement id="e_0" quality="0.0" charge="2">
+      <centroid rt="100.0" mz="450.25" it="0.0"/>
+      <groupedElementList>
+        <element map="0" id="0" rt="100.0" mz="450.25" it="1000.0"/>
+        <element map="1" id="1" rt="100.0" mz="450.25" it="2000.0"/>
+      </groupedElementList>
+      <PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true"
+        significance_threshold="0" MZ="450.26" RT="100"
+        spectrum_reference="controllerType=0 controllerNumber=1 scan=42">
+        <PeptideHit score="0" sequence="PEPTIDEK" charge="2" protein_refs="PH_0">
+          <UserParam type="string" name="target_decoy" value="target"/>
+        </PeptideHit>
+      </PeptideIdentification>
+    </consensusElement>
+  </consensusElementList>
+  <UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true"
+    significance_threshold="0" MZ="500.30" RT="200"
+    spectrum_reference="controllerType=0 controllerNumber=1 scan=77">
+    <PeptideHit score="0" sequence="ELVISLIVEK" charge="2" protein_refs="PH_0">
+      <UserParam type="string" name="target_decoy" value="target"/>
+    </PeptideHit>
+    <UserParam type="int" name="id_merge_index" value="1"/>
+  </UnassignedPeptideIdentification>
+</consensusXML>
+"""
+
+
+def test_unassigned_isobaric_psm_run_from_id_merge_index(tmp_path):
+    """An unassigned PSM in a merged multi-run isobaric consensusXML is attributed
+    to the run its id_merge_index selects (the SECOND run), not the first map's
+    run — the regression for issue #243."""
+    from qpx.converters.openms_consensus.psm_adapter import consensus_psms_to_records
+
+    path = tmp_path / "two_plex.consensusXML"
+    path.write_text(_TWO_PLEX_ISOBARIC_CONSENSUSXML)
+
+    records = consensus_psms_to_records(str(path))
+
+    unassigned = [r for r in records if r["peptidoform"] == "ELVISLIVEK"]
+    assert len(unassigned) == 1
+    # id_merge_index=1 -> spectra_data[1] = plexB. The bug attributed it to plexA.
+    assert unassigned[0]["run_file_name"] == "plexB"
+    assert list(unassigned[0]["scan"]) == [77]
+
+
+def test_unassigned_isobaric_pg_run_from_id_merge_index(tmp_path):
+    """The corrected run flows into the pg adapter's acc_to_runs for an unassigned
+    PID (via accumulate_unassigned_maps)."""
+    from qpx.converters.openms_consensus.feature_adapter import load_consensus_map
+    from qpx.converters.openms_consensus.pg_adapter import _protein_maps
+
+    path = tmp_path / "two_plex_pg.consensusXML"
+    path.write_text(_TWO_PLEX_ISOBARIC_CONSENSUSXML)
+
+    m = _protein_maps(load_consensus_map(str(path)))
+    # ELVISLIVEK (unassigned, id_merge_index=1) contributes plexB, not plexA.
+    assert "plexB" in m.acc_to_runs["P12345"]
+    assert "plexA" in m.acc_to_runs["P12345"]  # from the assigned PEPTIDEK feature
+
+
+def test_unassigned_isobaric_run_streaming_matches_pyopenms(tmp_path):
+    """The streaming reader resolves the unassigned run identically to pyopenms."""
+    import json
+
+    import pyarrow.parquet as pq
+
+    cx = tmp_path / "two_plex_stream.consensusXML"
+    cx.write_text(_TWO_PLEX_ISOBARIC_CONSENSUSXML)
+
+    def convert(streaming):
+        out = tmp_path / ("stream" if streaming else "pyopenms")
+        return OpenMSConsensusConverter().convert(
+            str(cx), str(out), output_prefix="d", structures=("feature", "psm", "pg"), streaming=streaming
+        )
+
+    wp, ws = convert(False), convert(True)
+
+    def canon(path):
+        return sorted(json.dumps(r, sort_keys=True, default=str) for r in pq.read_table(str(path)).to_pylist())
+
+    for view in ("feature", "psm", "pg"):
+        assert canon(wp[view]) == canon(ws[view]), f"{view} differs between pyopenms and streaming"
 
 
 def test_consensus_psm_multihit_keeps_lowest_pep_and_merges_scores(tmp_path):


### PR DESCRIPTION
## Problem (closes #243)

In `qpx/converters/openms_consensus/psm_adapter.py`, the run resolver fell back for an unassigned `PeptideIdentification` lacking a global `map_index` to `map_run.get(int(pid.getMetaValue("id_merge_index")))`. `map_run` is keyed by the **global map-column index** (channel/map column in the consensusXML headers), but `id_merge_index` is a **per-run merge index** — it selects the i-th original MS run in merge order, NOT a map column.

For **unassigned** PIDs in a **merged multi-run isobaric** consensusXML (multi-plex TMT/iTRAQ), this indexed the map dict with the wrong integer and stamped the wrong `run_file_name`. The wrong run also propagated into pg `acc_to_runs` via `accumulate_unassigned_maps`. Assigned PSMs (via `cf_runs`) and LFQ (real global `map_index`) were already correct.

## Fix

Resolve the `id_merge_index` fallback through the **merged-run ordering**: OpenMS records the merge order as the merged `ProteinIdentification`'s primary MS run paths (the `spectra_data` StringList). New `_merge_index_runs(cm)` concatenates those paths (in document order) into an `id_merge_index -> run stem` list, and the resolver indexes that instead of `map_run`.

- Single-run files are unchanged: `spectra_data` has one entry, `id_merge_index == 0` -> the sole run (identical to before); empty `spectra_data` falls back to the sole run.
- Assigned-PSM (`cf_runs`) and LFQ (`map_index`) paths are byte-identical.
- The streaming reader's `_ProteinIdentification` now exposes `getPrimaryMSRunPath` (parsing `spectra_data`), so the pyopenms and streaming read paths resolve the run identically.

## Tests

- `test_unassigned_isobaric_psm_run_from_id_merge_index` — synthetic 2-plex isobaric consensusXML (maps 0-1 = plexA, 2-3 = plexB; `spectra_data=[plexA,plexB]`) with an unassigned PID `id_merge_index=1`; asserts `run_file_name == "plexB"` (was `plexA`).
- `test_unassigned_isobaric_pg_run_from_id_merge_index` — the corrected run flows into pg `acc_to_runs`.
- `test_unassigned_isobaric_run_streaming_matches_pyopenms` — streaming vs pyopenms parity on the multi-run fixture.
- Updated `test_pg_uses_id_merge_index_after_unmapped_map_index` to supply the merge-order source (`getPrimaryMSRunPath`) instead of relying on the old map-column lookup.

Full suite: **885 passed**.