### PR TITLE
deps: make MuData stack (mudata, anndata, scipy) required

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,13 @@ dependencies = [
     # Canonical channel-label vocabulary (TMT/iTRAQ/SILAC/mTRAQ + synonyms) —
     # single source of truth shared with the OpenMS/DIA-NN SDRF converters.
     "sdrf-pipelines>=0.1.6",
+    # MuData export is a first-class QPX output (the portal, quantms and
+    # quantmsdiann all build it), so its stack is a required dependency, not an
+    # optional extra. scipy is imported directly by qpx/mudata.py, so it must be
+    # declared explicitly rather than relied on transitively through anndata.
+    "mudata>=0.2.4",
+    "anndata>=0.9.0",
+    "scipy>=1.10",
 ]
 [project.optional-dependencies]
 mzidentml = ["lxml>=4.9.0"]
@@ -33,7 +40,7 @@ pdc = ["pridepy>=0.0.15"]
 transforms = ["biopython", "mygene>=1.0.0", "anndata>=0.9.0"]
 plotting = ["plotly>=5.0.0", "scikit-learn>=1.5.0"]
 quantify = ["mokume>=0.1.0", "directlfq"]
-mudata = ["mudata>=0.2.4", "anndata>=0.9.0"]
+mudata = []  # now core dependencies; kept as a no-op for back-compat with `pip install qpx[mudata]`
 all = ["lxml>=4.9.0", "biopython", "mygene>=1.0.0", "anndata>=0.9.0", "plotly>=5.0.0", "scikit-learn>=1.5.0", "mokume>=0.1.0", "directlfq", "mudata>=0.2.4"]
 dev = [
     "pytest",


### PR DESCRIPTION
MuData export is a first-class QPX output (portal + quantms + quantmsdiann all build it), so its stack should ship with every install, not hide behind the `[mudata]` extra.

**Motivation (found via a VM integration test of qpx 1.1.2 in quantmsdiann):** a container built from bare `pip install qpx` failed `build_mudata` with `ModuleNotFoundError: No module named 'scipy'`. `qpx/mudata.py` imports `from scipy import sparse` directly, but scipy was declared **nowhere** — not core, not the `mudata` extra (`[mudata, anndata]`); it only arrived transitively through anndata.

**Change:** move `mudata>=0.2.4`, `anndata>=0.9.0`, `scipy>=1.10` into core `dependencies`; keep an empty `[mudata]` extra for back-compat with `pip install qpx[mudata]`. This guarantees `build_mudata` works in every install/container without relying on a transitive scipy.