### PR TITLE
fix(converters): normalise blank DIA-NN anchor_protein and dedupe ontology PK

### DIFF
--- a/qpx/converters/base.py
+++ b/qpx/converters/base.py
@@ -217,6 +217,12 @@ class BaseConverter(ABC):
         if not entries:
             return None
 
+        # Honour the ontology primary key (field_name, view): a field can surface
+        # both as a discovered score and as a mapped field, so collapse duplicates.
+        from qpx.converters.orchestrator import _dedupe_ontology_entries
+
+        entries = _dedupe_ontology_entries(entries)
+
         from qpx.writers.ontology import OntologyWriter
 
         output_path = Path(output_path)
@@ -270,6 +276,12 @@ class BaseConverter(ABC):
             entries.extend(extra_entries)
         if not entries:
             return None
+
+        # Honour the ontology primary key (field_name, view): a field can surface
+        # both as a discovered score and as a mapped field, so collapse duplicates.
+        from qpx.converters.orchestrator import _dedupe_ontology_entries
+
+        entries = _dedupe_ontology_entries(entries)
 
         from qpx.writers.ontology import OntologyWriter
 

--- a/qpx/converters/diann/feature_adapter.py
+++ b/qpx/converters/diann/feature_adapter.py
@@ -422,7 +422,10 @@ class DiannFeatureAdapter(DiaNNBaseAdapter):
         parts.extend(
             [
                 "CAST(lk.missed_cleavages AS SMALLINT) AS missed_cleavages",
-                f"SPLIT_PART(r.\"{pg_col}\", ';', 1) AS anchor_protein",
+                # An unmapped feature (DIA-NN 2.2.0 emits an empty Protein.Group for
+                # some rows) has no leading protein: normalise the blank split-part to
+                # NULL rather than "" so anchor_protein stays a real accession or null.
+                f"NULLIF(TRIM(SPLIT_PART(r.\"{pg_col}\", ';', 1)), '') AS anchor_protein",
             ]
         )
         return parts

--- a/qpx/converters/orchestrator.py
+++ b/qpx/converters/orchestrator.py
@@ -16,6 +16,25 @@ import duckdb
 logger = logging.getLogger(__name__)
 
 
+def _dedupe_ontology_entries(entries: list[dict]) -> list[dict]:
+    """Collapse ontology entries to one row per ``(field_name, view)`` primary key.
+
+    Order-preserving, first-wins: the first entry seen for a key is kept and later
+    duplicates are dropped. This honours the ontology view's primary key when the
+    same field is accumulated from more than one path (e.g. a q-value emitted both
+    as a discovered score and as a mapped field).
+    """
+    seen: set[tuple] = set()
+    deduped: list[dict] = []
+    for entry in entries:
+        key = (entry.get("field_name"), entry.get("view"))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(entry)
+    return deduped
+
+
 def build_dataset_record(
     *,
     project_accession: str | None = None,
@@ -72,10 +91,18 @@ class BaseOrchestrator:
             return None
         from qpx.writers.ontology import OntologyWriter
 
+        # The ontology view is keyed on (field_name, view). A field can surface from
+        # more than one accumulation path -- e.g. a q-value that is both a discovered
+        # score and a mapped field -- so collapse to the first entry per key to honour
+        # the primary key rather than emitting a duplicate row.
+        entries = _dedupe_ontology_entries(ontology_entries)
+        dropped = len(ontology_entries) - len(entries)
         onto_path = output_folder / f"{prefix}.ontology.parquet"
         with OntologyWriter(onto_path, creator="qpx", compression=self._compression) as writer:
-            writer.write_batch(ontology_entries)
-        logger.info("Wrote %d ontology entries to %s", len(ontology_entries), onto_path)
+            writer.write_batch(entries)
+        if dropped:
+            logger.info("Collapsed %d duplicate (field_name, view) ontology entries", dropped)
+        logger.info("Wrote %d ontology entries to %s", len(entries), onto_path)
         return onto_path
 
     def _write_provenance(

--- a/qpx/core/data/schema.py
+++ b/qpx/core/data/schema.py
@@ -272,7 +272,11 @@ def _anchor_membership_issues(table: pa.Table, structure: str, severity: str) ->
     # null membership into "empty" so the boolean logic never propagates nulls.
     pg_len = pc.fill_null(pc.list_value_length(pg), 0)
     pg_missing = pc.equal(pg_len, 0)
-    violation = pc.and_(pc.is_valid(anchor), pg_missing)
+    # An anchor is "set" only when it names a real protein. A blank/whitespace
+    # string (e.g. DIA-NN 2.2.0 emits "" for unmapped features instead of null)
+    # is not a leading protein, so it must not count as a membership violation.
+    anchor_set = pc.greater(pc.utf8_length(pc.utf8_trim_whitespace(pc.fill_null(anchor, ""))), 0)
+    violation = pc.and_(anchor_set, pg_missing)
     bad = pc.sum(pc.cast(violation, pa.int64())).as_py() or 0
     if not bad:
         return []

--- a/tests/unit/test_field_ontology.py
+++ b/tests/unit/test_field_ontology.py
@@ -39,3 +39,26 @@ def test_field_ontology_entries():
     for e in entries:
         assert "source_column_name" in e
         assert "source_tool" in e
+
+
+def test_dedupe_ontology_entries_keeps_first_per_key():
+    """_dedupe_ontology_entries: collapse duplicate (field_name, view) to first-wins.
+
+    A q-value can surface both as a discovered score and as a mapped field, which
+    would otherwise emit two rows for the same ontology primary key.
+    """
+    from qpx.converters.orchestrator import _dedupe_ontology_entries
+
+    entries = [
+        {"field_name": "qvalue", "view": "feature", "source_column_name": "Q.Value"},
+        {"field_name": "qvalue", "view": "feature", "source_column_name": "Lib.Q.Value"},
+        {"field_name": "qvalue", "view": "pg", "source_column_name": "PG.Q.Value"},
+        {"field_name": "rt", "view": "feature", "source_column_name": "RT"},
+    ]
+    deduped = _dedupe_ontology_entries(entries)
+
+    keys = [(e["field_name"], e["view"]) for e in deduped]
+    assert keys == [("qvalue", "feature"), ("qvalue", "pg"), ("rt", "feature")]
+    # first-wins: the (qvalue, feature) row keeps the first source column
+    qv_feature = next(e for e in deduped if e["field_name"] == "qvalue" and e["view"] == "feature")
+    assert qv_feature["source_column_name"] == "Q.Value"

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -352,6 +352,16 @@ def test_anchor_with_pg_accessions_ok():
     assert issues == []
 
 
+def test_blank_anchor_without_membership_not_flagged():
+    # DIA-NN 2.2.0 emits an empty-string anchor_protein (not null) for features it
+    # leaves protein-group-blank. A blank/whitespace anchor is not a leading protein,
+    # so an unmapped feature carrying "" + no membership must NOT be a violation.
+    table = _feature_anchor_table([("", None), ("   ", None), ("P1", ["P1"])])
+    strict = FeatureSchema.validate_full(table, strict=True)
+    errs = [i for i in strict.issues if i.check == "anchor_without_membership"]
+    assert errs == []
+
+
 def test_anchor_membership_skips_non_list_pg_accessions():
     # A malformed pg_accessions (string, not list) is a type mismatch reported elsewhere;
     # the membership check must skip it gracefully rather than raise on list_value_length.


### PR DESCRIPTION
## Context

Release-hardening for qpx 1.1.2. Ran the full `quantmsdiann` pipeline on the EBI Codon cluster (AVX2 nodes) with a `qpx:dev` container against **DIA-NN 2.2.0 and 2.5.1** on PXD026600 (E. coli UPS1) — the DIA-NN versions that segfault on non-AVX2 hardware and so had never been exercised.

**Headline result:** the pg identity fix holds — `pg_id` has **0 duplicates** on both versions (6019 / 6351 pg rows), and the full pipeline completes (16/16 processes, `QPX_DIANN ✔`). The original `20 duplicate pg_id` crash is gone across DIA-NN 1.8.1 / 2.2.0 / 2.5.1.

The new integrity validators then surfaced two remaining `validate` findings, fixed here.

## Fixes

**1. Blank `anchor_protein` → NULL (DIA-NN 2.2.0).**
DIA-NN 2.2.0 leaves `Protein.Group` empty for some unmapped features. The feature adapter did `SPLIT_PART(pg_col, ';', 1)`, which yields `""` (empty string, not null) for those rows — 10 on PXD026600. The `anchor_without_membership` check uses `pc.is_valid(anchor)` (non-null), so `""` counted as "a leading protein with missing membership" and made `feature` INVALID. (DIA-NN 2.5.1 uses proper nulls there — 0 rows.)
- Adapter: wrap in `NULLIF(TRIM(...), '')` so a blank split-part becomes NULL.
- Validator: treat blank/whitespace anchor as not-set (defense-in-depth).

**2. Ontology PK dedupe `(field_name, view)`.**
A field that surfaces both as a discovered score and as a mapped field (the q-values: `qvalue`/`global_qvalue`/`pg_qvalue`) emitted two ontology rows for one PK, making the `ontology` structure INVALID on both versions. Collapse to one row per `(field_name, view)`, first-wins, at every ontology write path (`BaseOrchestrator._write_ontology` covers DIA-NN/OpenMS; `BaseConverter.write_ontology`/`write_score_ontology` covers MaxQuant/FragPipe).

## Tests
- `test_blank_anchor_without_membership_not_flagged` — `""`/whitespace anchor + no membership is not a violation.
- `test_dedupe_ontology_entries_keeps_first_per_key` — duplicate `(field_name, view)` collapses first-wins.
- Full converter suite (131 tests) + validate/ontology units pass; ruff clean.