### PR TITLE
Require MuData stack and fix DIA-NN anchor normalization issues

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -e .
+          python -c "import anndata, mudata, scipy; import qpx.mudata"
           pip install -e ".[dev]"
       - name: Lint with ruff
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MuData stack is core**: `mudata`, `anndata`, and `scipy` are required dependencies (no longer an optional extra). Use bare `pip install qpx`.
+- **`quantify` extra**: now `mokume[directlfq]>=0.1.0` (DirectLFQ via mokume's optional extra).
+
+### Removed
+
+- **`[mudata]` optional extra** — MuData export is included in the default install.
+
+### Fixed
+
+- **Ontology PK uniqueness**: ontology writes collapse to one row per `(field_name, view)` (first-wins) when a field is both a discovered score and a mapped field.
+- **DIA-NN blank `anchor_protein`**: empty/whitespace first accession from `Protein.Group` is written as NULL; validators treat blank anchors as unset.
+
 ### Added
 
 - **Spectronaut converter**: `qpxc convert spectronaut` — full support for Spectronaut report TSV files, producing feature.parquet and pg.parquet with DuckDB-accelerated batch processing

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 #
 # QPX container image
 # -------------------
-# Provides the ``qpxc`` CLI built from this repository's source, with the
-# optional ``[mudata]`` extras pre-installed for MuData export.
+# Provides the ``qpxc`` CLI built from this repository's source, including
+# MuData export support.
 #
 # Build:
 #   docker build -t ghcr.io/bigbio/qpx:dev .
@@ -30,7 +30,7 @@ COPY pyproject.toml README.md LICENSE ./
 COPY qpx ./qpx
 
 RUN pip install --no-cache-dir --upgrade pip==24.0 \
- && pip install --no-cache-dir ".[mudata]" \
+ && pip install --no-cache-dir . \
  && rm -rf /src
 
 LABEL org.opencontainers.image.source="https://github.com/bigbio/qpx"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ mdata.write("PXD000000.h5mu")  # serialize to HDF5
 Use `build_mudata(ds, all_intensity_labels=True)` to represent every TMT/iTRAQ
 channel as a separate `run|label` observation.
 
-> Requires the optional `mudata` dependency: `pip install "qpx[mudata]"`
+> MuData support is included in the default QPX installation.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ channel as a separate `run|label` observation.
 pip install qpx                # includes MuData export (mudata, anndata, scipy)
 
 # Optional extras
-pip install "qpx[quantify]"    # protein quantification (mokume + DirectLFQ)
+pip install "qpx[quantify]"    # protein quantification via mokume[directlfq]
 pip install "qpx[transforms]"  # gene mapping / BioPython helpers
 pip install "qpx[plotting]"    # plotting dependencies
 pip install "qpx[mzidentml]"   # mzIdentML conversion (lxml)

--- a/README.md
+++ b/README.md
@@ -48,11 +48,15 @@ channel as a separate `run|label` observation.
 ### Install from PyPI
 
 ```bash
-pip install qpx
+pip install qpx                # includes MuData export (mudata, anndata, scipy)
 
-# With optional extras
+# Optional extras
 pip install "qpx[quantify]"    # protein quantification (mokume + DirectLFQ)
-pip install "qpx[all]"         # all optional dependencies
+pip install "qpx[transforms]"  # gene mapping / BioPython helpers
+pip install "qpx[plotting]"    # plotting dependencies
+pip install "qpx[mzidentml]"   # mzIdentML conversion (lxml)
+pip install "qpx[pdc]"         # PDC/CPTAC download (pridepy)
+pip install "qpx[all]"         # all optional extras above
 ```
 
 ### Install from GitHub (latest dev)
@@ -82,8 +86,8 @@ pip install .
 # Install from GitHub
 uv pip install "qpx @ git+https://github.com/bigbio/qpx.git"
 
-# With optional extras (transforms, plotting)
-uv pip install "qpx[transforms,plotting] @ git+https://github.com/bigbio/qpx.git"
+# With optional extras
+uv pip install "qpx[quantify,transforms,plotting] @ git+https://github.com/bigbio/qpx.git"
 ```
 
 **From a local clone:**

--- a/docs/guide/transform.md
+++ b/docs/guide/transform.md
@@ -246,12 +246,12 @@ print(generate_params_table(transform_quantify_cmd))
 
 | Method | Description | Extra Requirements |
 |--------|-------------|-------------------|
-| `directlfq` | DirectLFQ intensity traces (default) | `pip install mokume[directlfq]` |
-| `maxlfq` | MaxLFQ delayed normalization | -- |
-| `topn` | Average of N most intense peptides | `--topn-n` to set N |
-| `top3` | Average of 3 most intense peptides | -- |
-| `ibaq` | Intensity-Based Absolute Quantification | `--fasta` required |
-| `sum` | Sum of all peptide intensities | -- |
+| `directlfq` | DirectLFQ intensity traces (default) | `pip install "qpx[quantify]"` |
+| `maxlfq` | MaxLFQ delayed normalization | `pip install "qpx[quantify]"` |
+| `topn` | Average of N most intense peptides | `pip install "qpx[quantify]"` |
+| `top3` | Average of 3 most intense peptides | `pip install "qpx[quantify]"` |
+| `ibaq` | Intensity-Based Absolute Quantification | `pip install "qpx[quantify]"` + `--fasta` |
+| `sum` | Sum of all peptide intensities | `pip install "qpx[quantify]"` |
 
 ### Usage Examples {#quantify-examples}
 
@@ -299,13 +299,9 @@ qpxc transform quantify \
 
 ### Common Issues {#quantify-issues}
 
-**Issue**: `mokume is not installed`
+**Issue**: `mokume is not installed` / `DirectLFQ is not installed`
 
-- **Solution**: Install with `pip install mokume`
-
-**Issue**: `DirectLFQ is not installed`
-
-- **Solution**: Install with `pip install mokume[directlfq]`
+- **Solution**: Install with `pip install "qpx[quantify]"` (pulls `mokume[directlfq]>=0.1.0`)
 
 **Issue**: `--fasta option is required for the ibaq method`
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8,12 +8,13 @@ qpx defines a standardized Parquet-based format (QPX) for quantitative proteomic
 
 ## Installation
 
-pip install qpx                    # Core
-pip install qpx[all]               # All optional dependencies
-pip install qpx[mzidentml]         # mzIdentML support
-pip install qpx[transforms]        # Gene mapping, AnnData export
+pip install qpx                    # Core (includes mudata, anndata, scipy)
+pip install qpx[all]               # All optional extras
+pip install qpx[mzidentml]         # mzIdentML (lxml)
+pip install qpx[transforms]        # Gene mapping (biopython, mygene)
 pip install qpx[plotting]          # Visualization
-pip install qpx[quantify]          # Integration with mokume
+pip install qpx[quantify]          # mokume[directlfq]>=0.1.0
+pip install qpx[pdc]               # PDC/CPTAC download (pridepy)
 
 ## CLI Usage
 

--- a/docs/spec/feature.md
+++ b/docs/spec/feature.md
@@ -82,7 +82,7 @@ These fields are shared with the PSM view and describe the peptide identificatio
 | Field | Description | Type | Required |
 |-------|-------------|------|----------|
 | `pg_accessions` | Protein group accessions of all proteins that the peptide maps to | array[string], null | no |
-| `anchor_protein` | One protein accession that represents the protein group; null when no protein mapping was performed | string, null | yes |
+| `anchor_protein` | One protein accession that represents the protein group; null when no protein mapping was performed (converters normalize blank/whitespace to null) | string, null | yes |
 | `unique` | Whether the peptide maps uniquely to a single protein group | bool, null | no |
 | `pg_positions` | Peptide start and end positions within each protein in the protein group | array[struct], null | no |
 | `pg_global_qvalue` | Global q-value of the protein group at the experiment level | float64, null | optional |

--- a/docs/spec/ontology.md
+++ b/docs/spec/ontology.md
@@ -20,6 +20,11 @@ Each QPX dataset includes an `ontology.parquet` file that stores the field-to-on
 
 See the full YAML schema in [`ontology.yaml`](schemas/ontology.yaml).
 
+!!! note "Primary key"
+    Rows are unique on `(field_name, view)`. Converters collapse duplicates
+    (first-wins) when the same field is accumulated both as a discovered score
+    and as a mapped field, so validation does not report duplicate ontology PKs.
+
 ### Schema
 
 ```python

--- a/docs/spec/pg.md
+++ b/docs/spec/pg.md
@@ -50,7 +50,7 @@ A `pg` row is an **analyte**: the quantified unit is the protein group *as a who
   - `feature.run_file_name ∈ pg.grouped_runs`; **AND**
   - a label in `feature.intensities` `IS NOT DISTINCT FROM pg.label`, so a feature links **only** to pg rows for the channels/labels it actually carries (LFQ: one `LFQ` row; TMT/plexDIA: one row per channel the feature has, never the missing ones).
   `pg_id` is read straight from the matched pg row (never re-derived); never join on `anchor_protein` alone. **No match = identified but not quantified** in that channel/fraction — the feature simply produces no link (not an error). `feature.pg_ids` remains an **optional producer hardlink** (a slot a producer MAY populate); qpx's own converters do **not** materialize it, and when it is absent consumers use the computed softlink above.
-- **Integrity check:** a row with a non-null `anchor_protein` MUST also carry `pg_accessions` (its full group membership). Since the group is the analyte and the join key, a protein-mapped feature that lacked membership would be an orphan. QPX validates this (a warning on the write/convert path, an error under `qpxc validate --strict`).
+- **Integrity check:** a row with a non-null `anchor_protein` MUST also carry `pg_accessions` (its full group membership). Since the group is the analyte and the join key, a protein-mapped feature that lacked membership would be an orphan. QPX validates this (a warning on the write/convert path, an error under `qpxc validate --strict`). Blank/whitespace `anchor_protein` is treated as unset (not a membership violation).
 
 ### Counts
 
@@ -263,7 +263,7 @@ DIA-NN's main report is precursor-level. PG-level columns (`PG.*`, `Genes.*`) ar
 
     | DIA-NN column | QPX field | Notes |
     |---|---|---|
-    | `Protein.Group` | `pg_accessions` | Semicolon-separated → array; also `anchor_protein` (first accession) |
+    | `Protein.Group` | `pg_accessions` | Semicolon-separated → array; `anchor_protein` = first accession. Blank/whitespace groups (e.g. DIA-NN unmapped rows) → `anchor_protein` NULL, not `""`. |
     | `Protein.Names` | `pg_names` | |
     | `Genes` | `gg_names` / `gg_accessions` | |
     | `Run` | `grouped_runs` | Raw file name without path, wrapped as a single-element list |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,12 +50,12 @@ pip install qpx
 
 ### Missing dependencies
 
-**Problem**: Import errors for packages like `venn`, `pyopenms`, or `anndata`.
+**Problem**: Import errors for packages like `venn` or `pyopenms`.
 
-**Solution**: Install the missing package:
+**Solution**: Install the missing package (`anndata` / `mudata` / `scipy` ship with core `qpx`):
 
 ```bash
-pip install venn pyopenms anndata
+pip install venn pyopenms
 ```
 
 ## Conversion Issues

--- a/environment.yml
+++ b/environment.yml
@@ -12,8 +12,11 @@ dependencies:
   - pyopenms>=3.3.0,<3.5.0
   - duckdb>=1.1.3,<=1.3.0
   - pyyaml>=6.0
-  # Dev / test dependencies (needed for full test suite)
+  # Core MuData stack (also declared in pyproject.toml)
   - anndata
+  - mudata
+  - scipy
+  # Dev / test
   - scikit-learn
   # Optional (uncomment as needed)
   # - biopython     # transforms: gene mapping

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - pyyaml>=6.0
   # Core MuData stack (also declared in pyproject.toml)
   - anndata
-  - mudata
+  - mudata>=0.3.1
   - scipy
   # Dev / test
   - scikit-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ mzidentml = ["lxml>=4.9.0"]
 pdc = ["pridepy>=0.0.15"]
 transforms = ["biopython", "mygene>=1.0.0"]
 plotting = ["plotly>=5.0.0", "scikit-learn>=1.5.0"]
-all = ["lxml>=4.9.0", "biopython", "mygene>=1.0.0", "plotly>=5.0.0", "scikit-learn>=1.5.0"]
+quantify = ["mokume>=0.1.0", "directlfq"]
+all = ["lxml>=4.9.0", "biopython", "mygene>=1.0.0", "plotly>=5.0.0", "scikit-learn>=1.5.0", "mokume>=0.1.0", "directlfq"]
 dev = [
     "pytest",
     "pytest-timeout",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,13 @@ dependencies = [
     # Canonical channel-label vocabulary (TMT/iTRAQ/SILAC/mTRAQ + synonyms) —
     # single source of truth shared with the OpenMS/DIA-NN SDRF converters.
     "sdrf-pipelines>=0.1.6",
+    # MuData export is a first-class QPX output (the portal, quantms and
+    # quantmsdiann all build it), so its stack is a required dependency, not an
+    # optional extra. scipy is imported directly by qpx/mudata.py, so it must be
+    # declared explicitly rather than relied on transitively through anndata.
+    "mudata>=0.2.4",
+    "anndata>=0.9.0",
+    "scipy>=1.10",
 ]
 [project.optional-dependencies]
 mzidentml = ["lxml>=4.9.0"]
@@ -33,7 +40,7 @@ pdc = ["pridepy>=0.0.15"]
 transforms = ["biopython", "mygene>=1.0.0", "anndata>=0.9.0"]
 plotting = ["plotly>=5.0.0", "scikit-learn>=1.5.0"]
 quantify = ["mokume>=0.1.0", "directlfq"]
-mudata = ["mudata>=0.2.4", "anndata>=0.9.0"]
+mudata = []  # now core dependencies; kept as a no-op for back-compat with `pip install qpx[mudata]`
 all = ["lxml>=4.9.0", "biopython", "mygene>=1.0.0", "anndata>=0.9.0", "plotly>=5.0.0", "scikit-learn>=1.5.0", "mokume>=0.1.0", "directlfq", "mudata>=0.2.4"]
 dev = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,10 @@ dependencies = [
     # Canonical channel-label vocabulary (TMT/iTRAQ/SILAC/mTRAQ + synonyms) —
     # single source of truth shared with the OpenMS/DIA-NN SDRF converters.
     "sdrf-pipelines>=0.1.6",
-    "mudata>=0.2.4",
+    # mudata>=0.3.1: 0.3.0 imports an AnnData private API (AlignedViewMixin) that
+    # was removed in anndata 0.10.9, so 0.3.0 + modern anndata fails to import;
+    # 0.3.1 added the compatibility wrapper (validated with mudata 0.3.10 / anndata 0.12).
+    "mudata>=0.3.1",
     "anndata>=0.9.0",
     "scipy>=1.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,7 @@ dependencies = [
     # Canonical channel-label vocabulary (TMT/iTRAQ/SILAC/mTRAQ + synonyms) —
     # single source of truth shared with the OpenMS/DIA-NN SDRF converters.
     "sdrf-pipelines>=0.1.6",
-    # mudata>=0.3.1: 0.3.0 imports an AnnData private API (AlignedViewMixin) that
-    # was removed in anndata 0.10.9, so 0.3.0 + modern anndata fails to import;
-    # 0.3.1 added the compatibility wrapper (validated with mudata 0.3.10 / anndata 0.12).
+    # Floor at 0.3.1: mudata 0.3.0 breaks against anndata>=0.10.9 (private API).
     "mudata>=0.3.1",
     "anndata>=0.9.0",
     "scipy>=1.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ mzidentml = ["lxml>=4.9.0"]
 pdc = ["pridepy>=0.0.15"]
 transforms = ["biopython", "mygene>=1.0.0"]
 plotting = ["plotly>=5.0.0", "scikit-learn>=1.5.0"]
-quantify = ["mokume>=0.1.0", "directlfq"]
-all = ["lxml>=4.9.0", "biopython", "mygene>=1.0.0", "plotly>=5.0.0", "scikit-learn>=1.5.0", "mokume>=0.1.0", "directlfq"]
+quantify = ["mokume[directlfq]>=0.1.0"]
+all = ["lxml>=4.9.0", "biopython", "mygene>=1.0.0", "plotly>=5.0.0", "scikit-learn>=1.5.0", "mokume[directlfq]>=0.1.0"]
 dev = [
     "pytest",
     "pytest-timeout",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,6 @@ dependencies = [
     # Canonical channel-label vocabulary (TMT/iTRAQ/SILAC/mTRAQ + synonyms) —
     # single source of truth shared with the OpenMS/DIA-NN SDRF converters.
     "sdrf-pipelines>=0.1.6",
-    # MuData export is a first-class QPX output (the portal, quantms and
-    # quantmsdiann all build it), so its stack is a required dependency, not an
-    # optional extra. scipy is imported directly by qpx/mudata.py, so it must be
-    # declared explicitly rather than relied on transitively through anndata.
     "mudata>=0.2.4",
     "anndata>=0.9.0",
     "scipy>=1.10",
@@ -37,18 +33,14 @@ dependencies = [
 [project.optional-dependencies]
 mzidentml = ["lxml>=4.9.0"]
 pdc = ["pridepy>=0.0.15"]
-transforms = ["biopython", "mygene>=1.0.0", "anndata>=0.9.0"]
+transforms = ["biopython", "mygene>=1.0.0"]
 plotting = ["plotly>=5.0.0", "scikit-learn>=1.5.0"]
-quantify = ["mokume>=0.1.0", "directlfq"]
-mudata = []  # now core dependencies; kept as a no-op for back-compat with `pip install qpx[mudata]`
-all = ["lxml>=4.9.0", "biopython", "mygene>=1.0.0", "anndata>=0.9.0", "plotly>=5.0.0", "scikit-learn>=1.5.0", "mokume>=0.1.0", "directlfq", "mudata>=0.2.4"]
+all = ["lxml>=4.9.0", "biopython", "mygene>=1.0.0", "plotly>=5.0.0", "scikit-learn>=1.5.0"]
 dev = [
     "pytest",
     "pytest-timeout",
     "hypothesis",
     "lxml>=4.9.0",
-    "anndata",
-    "mudata>=0.2.4",
     "scikit-learn",
     "plotly>=5.0.0",
     "pre-commit",

--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -350,9 +350,9 @@ def _validate_quantify_inputs(method_lower: str, fasta: Optional[Path]) -> None:
     try:
         from mokume.quantification import is_directlfq_available
     except ImportError:
-        raise click.UsageError("mokume is not installed. Install with: pip install \"qpx[quantify]\"")
+        raise click.UsageError('mokume is not installed. Install with: pip install "qpx[quantify]"')
     if method_lower == "directlfq" and not is_directlfq_available():
-        raise click.UsageError("DirectLFQ is not installed. Install with: pip install \"qpx[quantify]\"")
+        raise click.UsageError('DirectLFQ is not installed. Install with: pip install "qpx[quantify]"')
 
 
 def _run_ibaq(peptide_df, fasta, enzyme, normalize, min_aa, max_aa, ploidy, cpc, organism, output, verbose) -> None:

--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -350,9 +350,9 @@ def _validate_quantify_inputs(method_lower: str, fasta: Optional[Path]) -> None:
     try:
         from mokume.quantification import is_directlfq_available
     except ImportError:
-        raise click.UsageError("mokume is not installed. Install with: pip install mokume")
+        raise click.UsageError("mokume is not installed. Install with: pip install \"qpx[quantify]\"")
     if method_lower == "directlfq" and not is_directlfq_available():
-        raise click.UsageError("DirectLFQ is not installed. Install with: pip install mokume[directlfq]")
+        raise click.UsageError("DirectLFQ is not installed. Install with: pip install \"qpx[quantify]\"")
 
 
 def _run_ibaq(peptide_df, fasta, enzyme, normalize, min_aa, max_aa, ploidy, cpc, organism, output, verbose) -> None:

--- a/qpx/converters/base.py
+++ b/qpx/converters/base.py
@@ -217,14 +217,10 @@ class BaseConverter(ABC):
         if not entries:
             return None
 
-        # Honour the ontology primary key (field_name, view): a field can surface
-        # both as a discovered score and as a mapped field, so collapse duplicates.
-        from qpx.converters.orchestrator import _dedupe_ontology_entries
-
-        entries = _dedupe_ontology_entries(entries)
-
+        from qpx.converters.ontology_util import dedupe_ontology_entries
         from qpx.writers.ontology import OntologyWriter
 
+        entries = dedupe_ontology_entries(entries)
         output_path = Path(output_path)
         with OntologyWriter(output_path, creator="qpx", compression=self._compression) as writer:
             writer.write_batch(entries)
@@ -277,14 +273,10 @@ class BaseConverter(ABC):
         if not entries:
             return None
 
-        # Honour the ontology primary key (field_name, view): a field can surface
-        # both as a discovered score and as a mapped field, so collapse duplicates.
-        from qpx.converters.orchestrator import _dedupe_ontology_entries
-
-        entries = _dedupe_ontology_entries(entries)
-
+        from qpx.converters.ontology_util import dedupe_ontology_entries
         from qpx.writers.ontology import OntologyWriter
 
+        entries = dedupe_ontology_entries(entries)
         output_path = Path(output_path)
         with OntologyWriter(output_path, creator="qpx", compression=self._compression) as writer:
             writer.write_batch(entries)

--- a/qpx/converters/base.py
+++ b/qpx/converters/base.py
@@ -217,6 +217,12 @@ class BaseConverter(ABC):
         if not entries:
             return None
 
+        # Honour the ontology primary key (field_name, view): a field can surface
+        # both as a discovered score and as a mapped field, so collapse duplicates.
+        from qpx.converters.orchestrator import _dedupe_ontology_entries
+
+        entries = _dedupe_ontology_entries(entries)
+
         from qpx.writers.ontology import OntologyWriter
 
         output_path = Path(output_path)
@@ -270,6 +276,12 @@ class BaseConverter(ABC):
             entries.extend(extra_entries)
         if not entries:
             return None
+
+        # Honour the ontology primary key (field_name, view): a field can surface
+        # both as a discovered score and as a mapped field, so collapse duplicates.
+        from qpx.converters.orchestrator import _dedupe_ontology_entries
+
+        entries = _dedupe_ontology_entries(entries)
 
         from qpx.writers.ontology import OntologyWriter
 

--- a/qpx/converters/column_mappings.yaml
+++ b/qpx/converters/column_mappings.yaml
@@ -99,7 +99,7 @@ diann:
       global_qvalue: ["Global.PG.Q.Value"]
       gg_qvalue: ["GG.Q.Value"]
       lfq: ["PG.MaxLFQ"]
-      qvalue: ["PG.Q.Value"]
+      pg_qvalue: ["PG.Q.Value"]
       run_file_name: ["Run"]
 
 maxquant:

--- a/qpx/converters/diann/feature_adapter.py
+++ b/qpx/converters/diann/feature_adapter.py
@@ -422,7 +422,10 @@ class DiannFeatureAdapter(DiaNNBaseAdapter):
         parts.extend(
             [
                 "CAST(lk.missed_cleavages AS SMALLINT) AS missed_cleavages",
-                f"SPLIT_PART(r.\"{pg_col}\", ';', 1) AS anchor_protein",
+                # An unmapped feature (DIA-NN 2.2.0 emits an empty Protein.Group for
+                # some rows) has no leading protein: normalise the blank split-part to
+                # NULL rather than "" so anchor_protein stays a real accession or null.
+                f"NULLIF(TRIM(SPLIT_PART(r.\"{pg_col}\", ';', 1)), '') AS anchor_protein",
             ]
         )
         return parts

--- a/qpx/converters/diann/feature_adapter.py
+++ b/qpx/converters/diann/feature_adapter.py
@@ -422,9 +422,7 @@ class DiannFeatureAdapter(DiaNNBaseAdapter):
         parts.extend(
             [
                 "CAST(lk.missed_cleavages AS SMALLINT) AS missed_cleavages",
-                # An unmapped feature (DIA-NN 2.2.0 emits an empty Protein.Group for
-                # some rows) has no leading protein: normalise the blank split-part to
-                # NULL rather than "" so anchor_protein stays a real accession or null.
+                # Blank/whitespace Protein.Group → NULL (e.g. DIA-NN unmapped rows).
                 f"NULLIF(TRIM(SPLIT_PART(r.\"{pg_col}\", ';', 1)), '') AS anchor_protein",
             ]
         )

--- a/qpx/converters/diann/pg_adapter.py
+++ b/qpx/converters/diann/pg_adapter.py
@@ -273,7 +273,7 @@ class DiannPgAdapter(DiaNNBaseAdapter):
         # the filter with a warning rather than crash.
         qvalue_filter = ""
         if qvalue_threshold is not None:
-            pg_qvalue_col = r.get("global_qvalue") or r.get("qvalue")
+            pg_qvalue_col = r.get("global_qvalue") or r.get("pg_qvalue")
             if pg_qvalue_col and pg_qvalue_col in actual_report_cols:
                 qvalue_filter = sql_build(
                     "AND CAST(report.$qv_col AS DOUBLE) <= $threshold",
@@ -463,11 +463,11 @@ class DiannPgAdapter(DiaNNBaseAdapter):
         peptides = [{"protein_name": acc, "peptide_count": peptide_count} for acc in pg_accessions]
 
         # Additional scores — track inline
-        qvalue_val = safe_float(_col_first(group, "qvalue"))
+        pg_qvalue = safe_float(_col_first(group, "pg_qvalue"))
         additional_scores = []
-        if qvalue_val is not None:
-            additional_scores.append({"score_name": "qvalue", "score_value": qvalue_val, "higher_better": False})
-            self._discovered_scores.add("qvalue")
+        if pg_qvalue is not None:
+            additional_scores.append({"score_name": "pg_qvalue", "score_value": pg_qvalue, "higher_better": False})
+            self._discovered_scores.add("pg_qvalue")
 
         return {
             "pg_accessions": pg_accessions,
@@ -478,7 +478,7 @@ class DiannPgAdapter(DiaNNBaseAdapter):
             "anchor_protein": anchor_protein,
             "grouped_runs": [run_file_name],
             "global_qvalue": global_qvalue,
-            "pg_qvalue": qvalue_val,
+            "pg_qvalue": pg_qvalue,
             "intensities": intensities or None,
             "additional_intensities": additional_intensities or None,
             "is_decoy": is_decoy,

--- a/qpx/converters/ontology_util.py
+++ b/qpx/converters/ontology_util.py
@@ -4,16 +4,45 @@ from __future__ import annotations
 
 
 def dedupe_ontology_entries(entries: list[dict]) -> list[dict]:
-    """Collapse ontology entries to one row per ``(field_name, view)`` primary key.
+    """Merge complementary entries sharing an ontology primary key.
 
-    Order-preserving, first-wins: later duplicates for the same key are dropped.
+    Score discovery supplies CV metadata while converter mappings supply source
+    provenance. Conflicting identifiers or provenance are rejected.
     """
-    seen: set[tuple] = set()
+    conflict_fields = {
+        "ontology_accession",
+        "ontology_source",
+        "ontology_version",
+        "source_column_name",
+        "source_tool",
+    }
+    by_key: dict[tuple[str, str], dict] = {}
     deduped: list[dict] = []
     for entry in entries:
-        key = (entry.get("field_name"), entry.get("view"))
-        if key in seen:
+        field_name = entry.get("field_name")
+        view = entry.get("view")
+        if field_name is None or view is None:
+            raise ValueError("Ontology entries must contain non-null field_name and view")
+        key = (field_name, view)
+        current = by_key.get(key)
+        if current is not None:
+            for field, value in entry.items():
+                if value is None:
+                    continue
+                existing = current.get(field)
+                if existing is None:
+                    current[field] = value
+                elif (
+                    existing != value
+                    and field == "ontology_name"
+                    and current.get("ontology_accession") is None
+                    and entry.get("ontology_accession") is None
+                ):
+                    raise ValueError(f"Conflicting ontology entries for {key}: {field}={existing!r} versus {value!r}")
+                elif existing != value and field in conflict_fields:
+                    raise ValueError(f"Conflicting ontology entries for {key}: {field}={existing!r} versus {value!r}")
             continue
-        seen.add(key)
-        deduped.append(entry)
+        merged = dict(entry)
+        by_key[key] = merged
+        deduped.append(merged)
     return deduped

--- a/qpx/converters/ontology_util.py
+++ b/qpx/converters/ontology_util.py
@@ -1,0 +1,19 @@
+"""Shared helpers for converter ontology writing."""
+
+from __future__ import annotations
+
+
+def dedupe_ontology_entries(entries: list[dict]) -> list[dict]:
+    """Collapse ontology entries to one row per ``(field_name, view)`` primary key.
+
+    Order-preserving, first-wins: later duplicates for the same key are dropped.
+    """
+    seen: set[tuple] = set()
+    deduped: list[dict] = []
+    for entry in entries:
+        key = (entry.get("field_name"), entry.get("view"))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(entry)
+    return deduped

--- a/qpx/converters/orchestrator.py
+++ b/qpx/converters/orchestrator.py
@@ -16,25 +16,6 @@ import duckdb
 logger = logging.getLogger(__name__)
 
 
-def _dedupe_ontology_entries(entries: list[dict]) -> list[dict]:
-    """Collapse ontology entries to one row per ``(field_name, view)`` primary key.
-
-    Order-preserving, first-wins: the first entry seen for a key is kept and later
-    duplicates are dropped. This honours the ontology view's primary key when the
-    same field is accumulated from more than one path (e.g. a q-value emitted both
-    as a discovered score and as a mapped field).
-    """
-    seen: set[tuple] = set()
-    deduped: list[dict] = []
-    for entry in entries:
-        key = (entry.get("field_name"), entry.get("view"))
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(entry)
-    return deduped
-
-
 def build_dataset_record(
     *,
     project_accession: str | None = None,
@@ -89,13 +70,10 @@ class BaseOrchestrator:
         """Write combined ontology.parquet. Returns path if written, else None."""
         if not ontology_entries:
             return None
+        from qpx.converters.ontology_util import dedupe_ontology_entries
         from qpx.writers.ontology import OntologyWriter
 
-        # The ontology view is keyed on (field_name, view). A field can surface from
-        # more than one accumulation path -- e.g. a q-value that is both a discovered
-        # score and a mapped field -- so collapse to the first entry per key to honour
-        # the primary key rather than emitting a duplicate row.
-        entries = _dedupe_ontology_entries(ontology_entries)
+        entries = dedupe_ontology_entries(ontology_entries)
         dropped = len(ontology_entries) - len(entries)
         onto_path = output_folder / f"{prefix}.ontology.parquet"
         with OntologyWriter(onto_path, creator="qpx", compression=self._compression) as writer:

--- a/qpx/converters/orchestrator.py
+++ b/qpx/converters/orchestrator.py
@@ -16,6 +16,25 @@ import duckdb
 logger = logging.getLogger(__name__)
 
 
+def _dedupe_ontology_entries(entries: list[dict]) -> list[dict]:
+    """Collapse ontology entries to one row per ``(field_name, view)`` primary key.
+
+    Order-preserving, first-wins: the first entry seen for a key is kept and later
+    duplicates are dropped. This honours the ontology view's primary key when the
+    same field is accumulated from more than one path (e.g. a q-value emitted both
+    as a discovered score and as a mapped field).
+    """
+    seen: set[tuple] = set()
+    deduped: list[dict] = []
+    for entry in entries:
+        key = (entry.get("field_name"), entry.get("view"))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(entry)
+    return deduped
+
+
 def build_dataset_record(
     *,
     project_accession: str | None = None,
@@ -72,10 +91,18 @@ class BaseOrchestrator:
             return None
         from qpx.writers.ontology import OntologyWriter
 
+        # The ontology view is keyed on (field_name, view). A field can surface from
+        # more than one accumulation path -- e.g. a q-value that is both a discovered
+        # score and a mapped field -- so collapse to the first entry per key to honour
+        # the primary key rather than emitting a duplicate row.
+        entries = _dedupe_ontology_entries(ontology_entries)
+        dropped = len(ontology_entries) - len(entries)
         onto_path = output_folder / f"{prefix}.ontology.parquet"
         with OntologyWriter(onto_path, creator="qpx", compression=self._compression) as writer:
-            writer.write_batch(ontology_entries)
-        logger.info("Wrote %d ontology entries to %s", len(ontology_entries), onto_path)
+            writer.write_batch(entries)
+        if dropped:
+            logger.info("Collapsed %d duplicate (field_name, view) ontology entries", dropped)
+        logger.info("Wrote %d ontology entries to %s", len(entries), onto_path)
         return onto_path
 
     def _write_provenance(

--- a/qpx/core/data/schema.py
+++ b/qpx/core/data/schema.py
@@ -268,17 +268,14 @@ def _anchor_membership_issues(table: pa.Table, structure: str, severity: str) ->
     # above; skip here rather than let list_value_length raise on malformed input.
     if not (pa.types.is_list(pg.type) or pa.types.is_large_list(pg.type)):
         return []
-    # Likewise, a non-string anchor_protein is a type mismatch reported elsewhere;
-    # skip rather than let the UTF-8 kernels below raise on malformed input.
+    # Non-string anchor_protein is a type mismatch reported elsewhere.
     if not (pa.types.is_string(anchor.type) or pa.types.is_large_string(anchor.type)):
         return []
     # list_value_length is null where pg_accessions is null; fill_null(0) folds a
     # null membership into "empty" so the boolean logic never propagates nulls.
     pg_len = pc.fill_null(pc.list_value_length(pg), 0)
     pg_missing = pc.equal(pg_len, 0)
-    # An anchor is "set" only when it names a real protein. A blank/whitespace
-    # string (e.g. DIA-NN 2.2.0 emits "" for unmapped features instead of null)
-    # is not a leading protein, so it must not count as a membership violation.
+    # Blank/whitespace anchors are unset (not a membership violation).
     anchor_set = pc.greater(pc.utf8_length(pc.utf8_trim_whitespace(pc.fill_null(anchor, ""))), 0)
     violation = pc.and_(anchor_set, pg_missing)
     bad = pc.sum(pc.cast(violation, pa.int64())).as_py() or 0

--- a/qpx/core/data/schema.py
+++ b/qpx/core/data/schema.py
@@ -268,6 +268,10 @@ def _anchor_membership_issues(table: pa.Table, structure: str, severity: str) ->
     # above; skip here rather than let list_value_length raise on malformed input.
     if not (pa.types.is_list(pg.type) or pa.types.is_large_list(pg.type)):
         return []
+    # Likewise, a non-string anchor_protein is a type mismatch reported elsewhere;
+    # skip rather than let the UTF-8 kernels below raise on malformed input.
+    if not (pa.types.is_string(anchor.type) or pa.types.is_large_string(anchor.type)):
+        return []
     # list_value_length is null where pg_accessions is null; fill_null(0) folds a
     # null membership into "empty" so the boolean logic never propagates nulls.
     pg_len = pc.fill_null(pc.list_value_length(pg), 0)

--- a/qpx/core/data/schema.py
+++ b/qpx/core/data/schema.py
@@ -272,7 +272,11 @@ def _anchor_membership_issues(table: pa.Table, structure: str, severity: str) ->
     # null membership into "empty" so the boolean logic never propagates nulls.
     pg_len = pc.fill_null(pc.list_value_length(pg), 0)
     pg_missing = pc.equal(pg_len, 0)
-    violation = pc.and_(pc.is_valid(anchor), pg_missing)
+    # An anchor is "set" only when it names a real protein. A blank/whitespace
+    # string (e.g. DIA-NN 2.2.0 emits "" for unmapped features instead of null)
+    # is not a leading protein, so it must not count as a membership violation.
+    anchor_set = pc.greater(pc.utf8_length(pc.utf8_trim_whitespace(pc.fill_null(anchor, ""))), 0)
+    violation = pc.and_(anchor_set, pg_missing)
     bad = pc.sum(pc.cast(violation, pa.int64())).as_py() or 0
     if not bad:
         return []

--- a/qpx/core/scores.py
+++ b/qpx/core/scores.py
@@ -486,6 +486,13 @@ _FIELD_CV_MAP: dict[str, dict] = {
     },
 }
 
+# A shared QPX field name can represent a different level in each view. Resolve
+# those cases through the corresponding score definition rather than attaching
+# precursor-level semantics to a protein-group field.
+_VIEW_FIELD_SCORE_ALIASES: dict[tuple[str, str], str] = {
+    ("pg", "global_qvalue"): "pg_global_qvalue",
+}
+
 
 # ---------------------------------------------------------------------------
 # Ontology entry generation
@@ -528,8 +535,8 @@ def field_ontology_entries(
         for field_name, source_column in sorted(resolved_mappings.items()):
             cv_info = _FIELD_CV_MAP.get(field_name)
             if cv_info is None:
-                # Try OBO lookup
-                cv_info = _lookup_from_obo(field_name)
+                score_name = _VIEW_FIELD_SCORE_ALIASES.get((view, field_name))
+                cv_info = lookup_score(score_name) if score_name else _lookup_from_obo(field_name)
             entries.append(
                 {
                     "field_name": field_name,

--- a/qpx/views/api.py
+++ b/qpx/views/api.py
@@ -313,7 +313,7 @@ class AbsoluteExpressionView:
         try:
             import anndata as ad
         except ImportError:
-            raise ImportError("anndata is required for AbsoluteExpressionView. Install with: pip install anndata")
+            raise ImportError("anndata is required for AbsoluteExpressionView; reinstall qpx (anndata is a core dependency)")
 
         ds_path = Path(self._dataset.path)
         # Look for <prefix>.ae.h5ad or any .ae.h5ad

--- a/qpx/views/api.py
+++ b/qpx/views/api.py
@@ -312,8 +312,10 @@ class AbsoluteExpressionView:
 
         try:
             import anndata as ad
-        except ImportError:
-            raise ImportError("anndata is required for AbsoluteExpressionView; reinstall qpx (anndata is a core dependency)")
+        except ImportError as exc:
+            raise ImportError(
+                "anndata is required for AbsoluteExpressionView; reinstall qpx (anndata is a core dependency)"
+            ) from exc
 
         ds_path = Path(self._dataset.path)
         # Look for <prefix>.ae.h5ad or any .ae.h5ad

--- a/tests/unit/test_field_ontology.py
+++ b/tests/unit/test_field_ontology.py
@@ -39,3 +39,26 @@ def test_field_ontology_entries():
     for e in entries:
         assert "source_column_name" in e
         assert "source_tool" in e
+
+
+def test_dedupe_ontology_entries_keeps_first_per_key():
+    """_dedupe_ontology_entries: collapse duplicate (field_name, view) to first-wins.
+
+    A q-value can surface both as a discovered score and as a mapped field, which
+    would otherwise emit two rows for the same ontology primary key.
+    """
+    from qpx.converters.orchestrator import _dedupe_ontology_entries
+
+    entries = [
+        {"field_name": "qvalue", "view": "feature", "source_column_name": "Q.Value"},
+        {"field_name": "qvalue", "view": "feature", "source_column_name": "Lib.Q.Value"},
+        {"field_name": "qvalue", "view": "pg", "source_column_name": "PG.Q.Value"},
+        {"field_name": "rt", "view": "feature", "source_column_name": "RT"},
+    ]
+    deduped = _dedupe_ontology_entries(entries)
+
+    keys = [(e["field_name"], e["view"]) for e in deduped]
+    assert keys == [("qvalue", "feature"), ("qvalue", "pg"), ("rt", "feature")]
+    # first-wins: the (qvalue, feature) row keeps the first source column
+    qv_feature = next(e for e in deduped if e["field_name"] == "qvalue" and e["view"] == "feature")
+    assert qv_feature["source_column_name"] == "Q.Value"

--- a/tests/unit/test_field_ontology.py
+++ b/tests/unit/test_field_ontology.py
@@ -19,6 +19,16 @@ def test_field_ontology_entries():
     assert rt_entries[0]["ontology_accession"] == "MS:1000016"
     assert rt_entries[0]["view"] == "feature"
 
+    # A shared field name is resolved according to its view: PG global q-value
+    # must not inherit precursor-level Global.Q.Value semantics.
+    entries = field_ontology_entries(
+        view="pg",
+        resolved_mappings={"global_qvalue": "Global.PG.Q.Value"},
+        tool_name="DIA-NN",
+    )
+    assert entries[0]["ontology_accession"] == "MS:1001214"
+    assert entries[0]["source_column_name"] == "Global.PG.Q.Value"
+
     # Missing CV still written
     resolved = {"lfq": "Precursor.Normalised"}
     entries = field_ontology_entries(
@@ -41,13 +51,27 @@ def test_field_ontology_entries():
         assert "source_tool" in e
 
 
-def test_dedupe_ontology_entries_keeps_first_per_key():
-    """dedupe_ontology_entries keeps the first row per (field_name, view)."""
+def test_dedupe_ontology_entries_merges_complementary_values():
+    """Duplicate score and field entries retain CV metadata and provenance."""
     from qpx.converters.ontology_util import dedupe_ontology_entries
 
     entries = [
-        {"field_name": "qvalue", "view": "feature", "source_column_name": "Q.Value"},
-        {"field_name": "qvalue", "view": "feature", "source_column_name": "Lib.Q.Value"},
+        {
+            "field_name": "qvalue",
+            "view": "feature",
+            "ontology_name": "q-value",
+            "ontology_accession": "MS:1002354",
+            "source_column_name": None,
+            "source_tool": None,
+        },
+        {
+            "field_name": "qvalue",
+            "view": "feature",
+            "ontology_name": "DIA-NN:Q.Value",
+            "ontology_accession": "MS:1002354",
+            "source_column_name": "Q.Value",
+            "source_tool": "DIA-NN",
+        },
         {"field_name": "qvalue", "view": "pg", "source_column_name": "PG.Q.Value"},
         {"field_name": "rt", "view": "feature", "source_column_name": "RT"},
     ]
@@ -56,4 +80,38 @@ def test_dedupe_ontology_entries_keeps_first_per_key():
     keys = [(e["field_name"], e["view"]) for e in deduped]
     assert keys == [("qvalue", "feature"), ("qvalue", "pg"), ("rt", "feature")]
     qv_feature = next(e for e in deduped if e["field_name"] == "qvalue" and e["view"] == "feature")
+    assert qv_feature["ontology_accession"] == "MS:1002354"
+    assert qv_feature["ontology_name"] == "q-value"
     assert qv_feature["source_column_name"] == "Q.Value"
+    assert qv_feature["source_tool"] == "DIA-NN"
+
+
+def test_dedupe_ontology_entries_rejects_conflicts():
+    """A primary key cannot silently select between conflicting source columns."""
+    import pytest
+
+    from qpx.converters.ontology_util import dedupe_ontology_entries
+
+    entries = [
+        {"field_name": "qvalue", "view": "feature", "source_column_name": "Q.Value"},
+        {"field_name": "qvalue", "view": "feature", "source_column_name": "Lib.Q.Value"},
+    ]
+    with pytest.raises(ValueError, match="Conflicting ontology entries"):
+        dedupe_ontology_entries(entries)
+
+    entries = [
+        {"field_name": "tool_score", "view": "feature", "ontology_name": "Tool score A"},
+        {"field_name": "tool_score", "view": "feature", "ontology_name": "Tool score B"},
+    ]
+    with pytest.raises(ValueError, match="Conflicting ontology entries"):
+        dedupe_ontology_entries(entries)
+
+
+def test_dedupe_ontology_entries_requires_primary_key_fields():
+    """Malformed entries cannot be silently collapsed under a null key."""
+    import pytest
+
+    from qpx.converters.ontology_util import dedupe_ontology_entries
+
+    with pytest.raises(ValueError, match="non-null field_name and view"):
+        dedupe_ontology_entries([{"field_name": "qvalue"}])

--- a/tests/unit/test_field_ontology.py
+++ b/tests/unit/test_field_ontology.py
@@ -42,12 +42,8 @@ def test_field_ontology_entries():
 
 
 def test_dedupe_ontology_entries_keeps_first_per_key():
-    """_dedupe_ontology_entries: collapse duplicate (field_name, view) to first-wins.
-
-    A q-value can surface both as a discovered score and as a mapped field, which
-    would otherwise emit two rows for the same ontology primary key.
-    """
-    from qpx.converters.orchestrator import _dedupe_ontology_entries
+    """dedupe_ontology_entries keeps the first row per (field_name, view)."""
+    from qpx.converters.ontology_util import dedupe_ontology_entries
 
     entries = [
         {"field_name": "qvalue", "view": "feature", "source_column_name": "Q.Value"},
@@ -55,10 +51,9 @@ def test_dedupe_ontology_entries_keeps_first_per_key():
         {"field_name": "qvalue", "view": "pg", "source_column_name": "PG.Q.Value"},
         {"field_name": "rt", "view": "feature", "source_column_name": "RT"},
     ]
-    deduped = _dedupe_ontology_entries(entries)
+    deduped = dedupe_ontology_entries(entries)
 
     keys = [(e["field_name"], e["view"]) for e in deduped]
     assert keys == [("qvalue", "feature"), ("qvalue", "pg"), ("rt", "feature")]
-    # first-wins: the (qvalue, feature) row keeps the first source column
     qv_feature = next(e for e in deduped if e["field_name"] == "qvalue" and e["view"] == "feature")
     assert qv_feature["source_column_name"] == "Q.Value"

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -353,28 +353,31 @@ def test_anchor_with_pg_accessions_ok():
 
 
 def test_blank_anchor_without_membership_not_flagged():
-    # DIA-NN 2.2.0 emits an empty-string anchor_protein (not null) for features it
-    # leaves protein-group-blank. A blank/whitespace anchor is not a leading protein,
-    # so an unmapped feature carrying "" + no membership must NOT be a violation.
-    table = _feature_anchor_table([("", None), ("   ", None), ("P1", ["P1"])])
+    """Blank/whitespace anchors are ignored; nonblank anchors without membership are not.
+
+    DIA-NN 2.2.0 emits an empty-string ``anchor_protein`` (not null) for features it
+    leaves protein-group-blank. A blank/whitespace anchor is not a leading protein,
+    so those rows must not be violations — while a real accession without membership
+    still is.
+    """
+    table = _feature_anchor_table([("", None), ("   ", None), ("P1", ["P1"]), ("P2", None)])
     strict = FeatureSchema.validate_full(table, strict=True)
     errs = [i for i in strict.issues if i.check == "anchor_without_membership"]
-    assert errs == []
+    assert len(errs) == 1
+    assert errs[0].severity == "error"
 
 
 def test_anchor_membership_skips_non_list_pg_accessions():
-    # A malformed pg_accessions (string, not list) is a type mismatch reported elsewhere;
-    # the membership check must skip it gracefully rather than raise on list_value_length.
+    """Malformed non-list ``pg_accessions`` must not raise in the membership check."""
     from qpx.core.data.schema import _anchor_membership_issues
 
     table = pa.table({"anchor_protein": pa.array(["P1"]), "pg_accessions": pa.array(["P1;P2"])})
-    assert _anchor_membership_issues(table, "feature", "warning") == []
+    assert not _anchor_membership_issues(table, "feature", "warning")
 
 
 def test_anchor_membership_skips_non_string_anchor():
-    # A malformed anchor_protein (non-string) is a type mismatch reported elsewhere;
-    # the membership check must skip it rather than raise on the UTF-8 kernels.
+    """Malformed non-string ``anchor_protein`` must not raise in the membership check."""
     from qpx.core.data.schema import _anchor_membership_issues
 
     table = pa.table({"anchor_protein": pa.array([1, 2]), "pg_accessions": pa.array([[], []], type=pa.list_(pa.string()))})
-    assert _anchor_membership_issues(table, "feature", "warning") == []
+    assert not _anchor_membership_issues(table, "feature", "warning")

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -369,3 +369,12 @@ def test_anchor_membership_skips_non_list_pg_accessions():
 
     table = pa.table({"anchor_protein": pa.array(["P1"]), "pg_accessions": pa.array(["P1;P2"])})
     assert _anchor_membership_issues(table, "feature", "warning") == []
+
+
+def test_anchor_membership_skips_non_string_anchor():
+    # A malformed anchor_protein (non-string) is a type mismatch reported elsewhere;
+    # the membership check must skip it rather than raise on the UTF-8 kernels.
+    from qpx.core.data.schema import _anchor_membership_issues
+
+    table = pa.table({"anchor_protein": pa.array([1, 2]), "pg_accessions": pa.array([[], []], type=pa.list_(pa.string()))})
+    assert _anchor_membership_issues(table, "feature", "warning") == []

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -352,6 +352,16 @@ def test_anchor_with_pg_accessions_ok():
     assert issues == []
 
 
+def test_blank_anchor_without_membership_not_flagged():
+    # DIA-NN 2.2.0 emits an empty-string anchor_protein (not null) for features it
+    # leaves protein-group-blank. A blank/whitespace anchor is not a leading protein,
+    # so an unmapped feature carrying "" + no membership must NOT be a violation.
+    table = _feature_anchor_table([("", None), ("   ", None), ("P1", ["P1"])])
+    strict = FeatureSchema.validate_full(table, strict=True)
+    errs = [i for i in strict.issues if i.check == "anchor_without_membership"]
+    assert errs == []
+
+
 def test_anchor_membership_skips_non_list_pg_accessions():
     # A malformed pg_accessions (string, not list) is a type mismatch reported elsewhere;
     # the membership check must skip it gracefully rather than raise on list_value_length.


### PR DESCRIPTION
This pull request introduces several important improvements to ontology handling, data validation, and dependency management in the QPX codebase. The main theme is ensuring data consistency and correctness, particularly around ontology entry deduplication and the handling of blank protein anchors. The changes also promote required dependencies for MuData export to core status.

**Ontology handling and deduplication:**
* Added `_dedupe_ontology_entries` utility in `qpx/converters/orchestrator.py` to collapse duplicate ontology entries by `(field_name, view)` primary key, ensuring only the first occurrence is kept.
* Updated ontology writing functions in `qpx/converters/base.py` and `qpx/converters/orchestrator.py` to use the deduplication utility, preventing duplicate ontology rows and logging the number of dropped duplicates [[1]](diffhunk://#diff-a61b828ac8e0ce7cc3cd3e87af502eecc02fa757acffb5241edc8eacf132cc2aR220-R225) [[2]](diffhunk://#diff-a61b828ac8e0ce7cc3cd3e87af502eecc02fa757acffb5241edc8eacf132cc2aR280-R285) [[3]](diffhunk://#diff-4e83306615966ac583b821deedf9706289cef99477771659f9359b515afd98a6R94-R105).

**Data validation and normalization:**
* Improved anchor protein handling in `qpx/converters/diann/feature_adapter.py` and `qpx/core/data/schema.py` to treat blank or whitespace-only anchors as `NULL`, aligning with expected semantics and avoiding false membership violations [[1]](diffhunk://#diff-86afc69e22c1673c5e42a179071e16fe5f831ec9dcc5b2838a8570e5d7bd3434L425-R428) [[2]](diffhunk://#diff-7be46a702aefbd664f6813b0650e21612ae2f4dc5d8ed08bb03107ed1f1672f9L275-R279).

**Dependency management:**
* Promoted `mudata`, `anndata`, and `scipy` to core dependencies in `pyproject.toml`, reflecting their essential role in MuData export and ensuring they are always installed.

**Testing improvements:**
* Added tests for ontology entry deduplication and for correct handling of blank anchor proteins without membership, ensuring new logic is covered and regressions are prevented [[1]](diffhunk://#diff-5a4811cb9aadd237905b3129f7ff20fabe95c62b7f31368ccea001cf24413d4dR42-R64) [[2]](diffhunk://#diff-d8fafc29ada09ab4b48595c19647760bab7cfb4df4fb2e2bd20346adefdaed04R355-R364).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate ontology entries and merged compatible metadata.
  - Improved protein accession handling by trimming values and treating blanks as missing.
  - Corrected DIA-NN protein-group q-value mapping.
  - Validation no longer flags blank or whitespace-only accessions as membership errors.

- **Documentation**
  - Clarified MuData export, quantification installation, ontology uniqueness, and blank accession behavior.

- **Dependencies**
  - AnnData, MuData, and SciPy are now included in the standard installation.
  - Updated optional installation guidance for quantification and related tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->