### PR TITLE
Map feature intensities and handle missing SDRF data

### DIFF
--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -345,14 +345,21 @@ _SUPPORTED_SUFFIXES = {".parquet", ".tsv", ".csv"}
 
 def _validate_quantify_inputs(method_lower: str, fasta: Optional[Path]) -> None:
     """Validate CLI inputs before running quantification."""
+    import importlib
+
     if method_lower == "ibaq" and not fasta:
         raise click.UsageError("The --fasta option is required for the ibaq method")
     try:
-        from mokume.quantification import is_directlfq_available
-    except ImportError:
-        raise click.UsageError('mokume is not installed. Install with: pip install "qpx[quantify]"')
-    if method_lower == "directlfq" and not is_directlfq_available():
-        raise click.UsageError('DirectLFQ is not installed. Install with: pip install "qpx[quantify]"')
+        importlib.import_module("mokume.quantification")
+    except ImportError as exc:
+        raise click.UsageError('mokume is not installed. Install with: pip install "qpx[quantify]"') from exc
+    if method_lower == "directlfq":
+        try:
+            from mokume.quantification import is_directlfq_available
+        except ImportError as exc:
+            raise click.UsageError('DirectLFQ is not installed. Install with: pip install "qpx[quantify]"') from exc
+        if not is_directlfq_available():
+            raise click.UsageError('DirectLFQ is not installed. Install with: pip install "qpx[quantify]"')
 
 
 def _run_ibaq(peptide_df, fasta, enzyme, normalize, min_aa, max_aa, ploidy, cpc, organism, output, verbose) -> None:
@@ -427,19 +434,62 @@ def _save_result(result_df, output: Path) -> None:
         result_df.to_csv(str(output), index=False)
 
 
-def _qpx_feature_to_peptide_df(feature_path: Path):
+def _quantify_sdrf_mapping(sdrf_path: Path):
+    """Build an unambiguous QPX run/channel to sample/condition mapping."""
+    import pandas as pd
+
+    from qpx.converters.channel_labels import normalize_label
+    from qpx.core.files import run_file_stem
+    from qpx.core.sdrf import validate_sdrf_data_files
+
+    sdrf = pd.read_csv(sdrf_path, sep="\t", header=0)
+    sdrf.columns = sdrf.columns.str.lower()
+    validate_sdrf_data_files(sdrf)
+
+    source_col = "source name"
+    label_col = "comment[label]"
+    missing = [column for column in (source_col, label_col) if column not in sdrf.columns]
+    if missing:
+        raise click.UsageError(f"SDRF is missing required column(s): {', '.join(missing)}")
+
+    sample_ids = sdrf[source_col].astype("string").str.strip()
+    if sample_ids.isna().any() or sample_ids.eq("").any():
+        raise click.UsageError("SDRF column 'source name' contains missing or blank values")
+
+    factor_columns = [column for column in sdrf.columns if column.startswith("factor value[")]
+    conditions = sdrf[factor_columns[0]].astype("string").str.strip() if factor_columns else sample_ids
+    conditions = conditions.mask(conditions.isna() | conditions.eq(""), sample_ids)
+
+    mapping = pd.DataFrame(
+        {
+            "_run_key": sdrf["comment[data file]"].map(run_file_stem),
+            "_label_key": sdrf[label_col].map(normalize_label),
+            "SampleID": sample_ids,
+            "Condition": conditions,
+        }
+    )
+    duplicate = mapping.duplicated(["_run_key", "_label_key"], keep=False)
+    if duplicate.any():
+        pairs = mapping.loc[duplicate, ["_run_key", "_label_key"]].drop_duplicates()
+        rendered = ", ".join(f"{run_key}::{label_key}" for run_key, label_key in pairs.itertuples(index=False, name=None))
+        raise click.UsageError(f"SDRF contains duplicate run/label mappings: {rendered}")
+    return mapping
+
+
+def _qpx_feature_to_peptide_df(feature_path: Path, sdrf_path: Optional[Path] = None):
     """Read QPX feature.parquet and flatten to mokume peptide DataFrame.
 
     Mokume expects columns: ``ProteinName``, ``PeptideCanonical``,
-    ``NormIntensity``, ``SampleID``.
+    ``NormIntensity``, ``SampleID`` and, for normalized iBAQ, ``Condition``.
 
     QPX stores intensities as a list of ``{label, intensity}`` structs.
     For label-free data each feature typically has a single intensity entry;
     for TMT/iTRAQ data the list contains one entry per channel.  This
     function explodes **all** intensity entries into separate rows so that
-    multiplexed channels are preserved.  ``SampleID`` is set to
-    ``<run_file_name>::<label>`` when multiple labels exist, or just
-    ``<run_file_name>`` for single-label (LFQ) data.
+    multiplexed channels are preserved.  When an SDRF is provided,
+    ``(run_file_name, label)`` is mapped to its real sample and condition.
+    Without one, the existing ``run::label`` sample key is retained and
+    condition is explicitly marked ``not available``.
     """
     import pandas as pd
 
@@ -460,20 +510,38 @@ def _qpx_feature_to_peptide_df(feature_path: Path):
     # Drop rows without intensities, then explode vectorised
     df = df[df["intensities"].apply(lambda x: x is not None and len(x) > 0)]
     if df.empty:
-        return pd.DataFrame(columns=["ProteinName", "PeptideCanonical", "NormIntensity", "SampleID"])
+        return pd.DataFrame(columns=["ProteinName", "PeptideCanonical", "NormIntensity", "SampleID", "Condition"])
 
     exploded = df[["ProteinName", "PeptideCanonical", "run_file_name", "intensities"]].explode("intensities")
     # Extract struct fields
     exploded["NormIntensity"] = exploded["intensities"].apply(lambda e: e.get("intensity", 0.0) if isinstance(e, dict) else 0.0)
     exploded["_label"] = exploded["intensities"].apply(lambda e: e.get("label", "") if isinstance(e, dict) else "")
-    # Build SampleID: run::label when label present, else run
-    has_label = exploded["_label"].astype(bool)
-    exploded["SampleID"] = exploded["run_file_name"]
-    exploded.loc[has_label, "SampleID"] = exploded.loc[has_label, "run_file_name"] + "::" + exploded.loc[has_label, "_label"]
+    if sdrf_path is not None:
+        from qpx.converters.channel_labels import normalize_label
+        from qpx.core.files import run_file_stem
+
+        exploded["_run_key"] = exploded["run_file_name"].map(run_file_stem)
+        exploded["_label_key"] = exploded["_label"].map(normalize_label)
+        exploded = exploded.merge(
+            _quantify_sdrf_mapping(sdrf_path),
+            on=["_run_key", "_label_key"],
+            how="left",
+            validate="many_to_one",
+        )
+        unmapped = exploded["SampleID"].isna()
+        if unmapped.any():
+            pairs = exploded.loc[unmapped, ["_run_key", "_label_key"]].drop_duplicates()
+            rendered = ", ".join(f"{run_key}::{label_key}" for run_key, label_key in pairs.itertuples(index=False, name=None))
+            raise click.UsageError(f"QPX intensities have no matching SDRF run/label row: {rendered}")
+    else:
+        has_label = exploded["_label"].astype(bool)
+        exploded["SampleID"] = exploded["run_file_name"]
+        exploded.loc[has_label, "SampleID"] = exploded.loc[has_label, "run_file_name"] + "::" + exploded.loc[has_label, "_label"]
+        exploded["Condition"] = "not available"
     # Filter invalid intensities
     result = exploded.loc[
         exploded["NormIntensity"].notna() & (exploded["NormIntensity"] > 0),
-        ["ProteinName", "PeptideCanonical", "NormIntensity", "SampleID"],
+        ["ProteinName", "PeptideCanonical", "NormIntensity", "SampleID", "Condition"],
     ].copy()
     result = result[result["ProteinName"] != ""]
 
@@ -502,6 +570,12 @@ def _qpx_feature_to_peptide_df(feature_path: Path):
 @click.option(
     "--fasta",
     help="FASTA database (required for ibaq method)",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+)
+@click.option(
+    "--sdrf",
+    help="SDRF used to map QPX run/channel intensities to samples and conditions",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     default=None,
 )
@@ -540,6 +614,7 @@ def transform_quantify_cmd(
     feature_path: Path,
     method: str,
     fasta: Optional[Path],
+    sdrf: Optional[Path],
     enzyme: str,
     topn_n: int,
     threads: int,
@@ -577,7 +652,7 @@ def transform_quantify_cmd(
         # iBAQ (requires FASTA)
         qpxc transform quantify \\
             --feature-path ./qpx_output/feature.parquet \\
-            --method ibaq --fasta proteome.fasta \\
+            --method ibaq --fasta proteome.fasta --sdrf experiment.sdrf.tsv \\
             -o proteins_ibaq.tsv
 
         # MaxLFQ with 8 threads
@@ -594,7 +669,7 @@ def transform_quantify_cmd(
 
     # Step 1: Read QPX feature and flatten to mokume format
     click.echo(f"Reading QPX feature data from {feature_path}")
-    peptide_df = _qpx_feature_to_peptide_df(feature_path)
+    peptide_df = _qpx_feature_to_peptide_df(feature_path, sdrf)
     if peptide_df.empty:
         raise click.UsageError("No valid peptide intensities found in the feature file")
 

--- a/qpx/converters/sdrf.py
+++ b/qpx/converters/sdrf.py
@@ -15,6 +15,7 @@ import pandas as pd
 from qpx.converters.base import BaseConverter
 from qpx.converters.channel_labels import normalize_label
 from qpx.core.files import run_file_stem
+from qpx.core.sdrf import validate_sdrf_data_files
 from qpx.writers.run import RunWriter
 from qpx.writers.sample import SampleWriter
 
@@ -159,6 +160,8 @@ class SdrfConverter(BaseConverter):
         if sample_output is None and run_output is None:
             raise ValueError("At least one of sample_output or run_output is required")
         sdrf_df = self._read_sdrf(sdrf_path)
+        if run_output is not None:
+            validate_sdrf_data_files(sdrf_df)
         if sample_output is not None:
             self._write_samples(sdrf_df, sample_output, creator)
         if run_output is not None:
@@ -291,9 +294,6 @@ class SdrfConverter(BaseConverter):
         """Build one row per run and write ``run.parquet``."""
 
         # Strip file extension from data file column
-        if _COL_DATA_FILE not in sdrf_df.columns:
-            raise ValueError(f"SDRF is missing required column '{_COL_DATA_FILE}'")
-
         sdrf_df = sdrf_df.copy()
         sdrf_df["_run_file"] = sdrf_df[_COL_DATA_FILE].map(run_file_stem)
         sdrf_df["_file_name"] = sdrf_df[_COL_DATA_FILE].astype(str).str.strip()

--- a/qpx/core/sdrf.py
+++ b/qpx/core/sdrf.py
@@ -19,6 +19,19 @@ from qpx.core.files import run_file_stem
 logger = logging.getLogger(__name__)
 
 
+def validate_sdrf_data_files(sdrf_table: DataFrame) -> None:
+    """Require a non-empty ``comment[data file]`` value in every SDRF row."""
+    column = "comment[data file]"
+    if column not in sdrf_table.columns:
+        raise ValueError(f"SDRF is missing required column '{column}'")
+
+    values = sdrf_table[column]
+    invalid = values.isna() | values.astype("string").str.strip().eq("").fillna(True)
+    if invalid.any():
+        rows = [str(position + 2) for position, is_invalid in enumerate(invalid) if is_invalid]
+        raise ValueError(f"SDRF column '{column}' contains missing or blank value(s) at input row(s): {', '.join(rows)}")
+
+
 def get_unique_from_column_substr(sdrf_table: DataFrame, substr: str) -> list:
     """
     Get in a pandas dataframe the columns that contain a given substring
@@ -143,6 +156,7 @@ class SDRFHandler:
             raise ValueError("The SDRF file provided does not contain any supported comment[label] value")
 
     def get_sample_map_run(self):
+        validate_sdrf_data_files(self.sdrf_table)
         sdrf = self.sdrf_table[["source name", "comment[data file]", "comment[label]"]].copy()
         sdrf["comment[data file]"] = sdrf["comment[data file]"].map(run_file_stem)
         if self.get_experiment_type_from_sdrf() != "LFQ":

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -95,7 +95,84 @@ class TestTransformQuantifyCLI:
     def test_quantify_help_shows_ibaq_options(self):
         runner = CliRunner()
         result = runner.invoke(qpx_main, ["transform", "quantify", "--help"])
-        _assert_help(result, "--organism", "--ploidy", "--min-aa")
+        _assert_help(result, "--organism", "--ploidy", "--min-aa", "--sdrf")
+
+    def test_ibaq_validation_does_not_require_directlfq_helper(self, monkeypatch, tmp_path):
+        """iBAQ availability must not depend on a DirectLFQ-only helper."""
+        import sys
+        from types import ModuleType
+
+        from qpx.cli.transform import _validate_quantify_inputs
+
+        mokume = ModuleType("mokume")
+        mokume.__path__ = []
+        quantification = ModuleType("mokume.quantification")
+        monkeypatch.setitem(sys.modules, "mokume", mokume)
+        monkeypatch.setitem(sys.modules, "mokume.quantification", quantification)
+
+        _validate_quantify_inputs("ibaq", tmp_path / "database.fasta")
+
+    def test_quantify_maps_tmt_channels_to_sdrf_samples(self, tmp_path):
+        """SDRF run/channel pairs restore biological samples and conditions."""
+        import pandas as pd
+
+        from qpx.cli.transform import _qpx_feature_to_peptide_df
+
+        feature_path = tmp_path / "feature.parquet"
+        pd.DataFrame(
+            {
+                "sequence": ["PEPTIDEK"],
+                "anchor_protein": ["P1"],
+                "run_file_name": ["fraction1"],
+                "is_decoy": [False],
+                "intensities": [
+                    [
+                        {"label": "TMT126", "intensity": 100.0},
+                        {"label": "TMT127N", "intensity": 200.0},
+                    ]
+                ],
+            }
+        ).to_parquet(feature_path, index=False)
+        sdrf_path = tmp_path / "experiment.sdrf.tsv"
+        pd.DataFrame(
+            {
+                "source name": ["sample-a", "sample-b"],
+                "comment[data file]": ["fraction1.raw", "fraction1.raw"],
+                "comment[label]": ["TMT126", "TMT127N"],
+                "factor value[disease]": ["control", "case"],
+            }
+        ).to_csv(sdrf_path, sep="\t", index=False)
+
+        result = _qpx_feature_to_peptide_df(feature_path, sdrf_path)
+
+        observed = result[["SampleID", "Condition", "NormIntensity"]].to_dict("records")
+        expected = [
+            {"SampleID": "sample-a", "Condition": "control", "NormIntensity": 100.0},
+            {"SampleID": "sample-b", "Condition": "case", "NormIntensity": 200.0},
+        ]
+        if observed != expected:
+            raise AssertionError(f"Unexpected SDRF mapping: {observed!r}")
+
+    def test_quantify_marks_condition_unavailable_without_sdrf(self, tmp_path):
+        """Standalone Feature input supplies an explicit missing condition."""
+        import pandas as pd
+
+        from qpx.cli.transform import _qpx_feature_to_peptide_df
+
+        feature_path = tmp_path / "feature.parquet"
+        pd.DataFrame(
+            {
+                "sequence": ["PEPTIDEK"],
+                "anchor_protein": ["P1"],
+                "run_file_name": ["run1"],
+                "intensities": [[{"label": "TMT126", "intensity": 100.0}]],
+            }
+        ).to_parquet(feature_path, index=False)
+
+        result = _qpx_feature_to_peptide_df(feature_path)
+
+        if result.loc[0, "Condition"] != "not available":
+            raise AssertionError("Missing SDRF condition was not marked unavailable")
 
 
 class TestTransformNormalizeAccessionsCLI:

--- a/tests/converters/test_channel_labels.py
+++ b/tests/converters/test_channel_labels.py
@@ -90,6 +90,26 @@ def test_multi_dot_run_names_match_sdrf_conversion(tmp_path):
     assert pq.read_table(run_output).column("run_file_name").to_pylist() == grouped
 
 
+@pytest.mark.parametrize("data_file", ["", "   "], ids=["missing", "blank"])
+def test_sdrf_run_paths_reject_missing_data_files(tmp_path, data_file):
+    """Missing run filenames must fail before producing mappings or output."""
+    from qpx.converters.sdrf import SdrfConverter
+    from qpx.core.sdrf import SDRFHandler
+
+    sdrf = tmp_path / "missing_data_file.sdrf.tsv"
+    sdrf.write_text(f"source name\tcomment[data file]\tcomment[label]\nS1\t{data_file}\tlabel free sample\n")
+    error = r"comment\[data file\].*input row\(s\): 2"
+
+    with pytest.raises(ValueError, match=error):
+        SDRFHandler(sdrf).get_sample_map_run()
+
+    run_output = tmp_path / "run.parquet"
+    with SdrfConverter(duckdb_threads=24) as converter:
+        with pytest.raises(ValueError, match=error):
+            converter.convert(str(sdrf), run_output=str(run_output))
+    assert not run_output.exists()
+
+
 from qpx.core.parquet_io import read_parquet_metadata
 from qpx.dataset import Dataset
 from qpx.writers.feature import FeatureWriter


### PR DESCRIPTION
## Summary

Fixes #185.

- Add the `Condition` column required by Mokume protein quantification.
- Add an optional `--sdrf` argument to map each QPX `(run_file_name, intensity label)` pair to its SDRF sample and condition.
- Preserve the existing `run::label` sample fallback when no SDRF is supplied, using `not available` as the condition.
- Reject duplicate or unmatched SDRF run/channel mappings.
- Validate that every SDRF row contains a non-empty `comment[data file]` value.