### PR TITLE
Add QuantMS MSstats conversion feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **QuantMS MSstats converter**: `qpxc convert quantms-msstats` converts a QuantMS-generated `*_msstats_in.csv` plus its authoritative SDRF into QPX Feature, Sample, Run, Dataset, Ontology, and Provenance views. LFQ/TMT/iTRAQ labels are canonicalized, channel rows are collapsed per measured Feature, and unsupported PSM/PG views are not fabricated.
 - **Spectronaut converter**: `qpxc convert spectronaut` — full support for Spectronaut report TSV files, producing feature.parquet and pg.parquet with DuckDB-accelerated batch processing
 - **CPTAC CDAP converter**: `qpxc convert cdap` — convert CPTAC CDAP `.psm` study directories to QPX psm/feature/pg/dataset/ontology/provenance views
 - **Full-spectra mz converter**: `qpxc convert mz` — convert a directory of mzML / `.mzML.gz` files to a single `mz.parquet`; each spectrum carries `run_file_name` + `scan` for linking back to PSM/feature

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ qpx/
 ├── cli/                    # Click CLI (entry point: qpx.cli.main:main)
 │   ├── main.py             # Top-level CLI group
 │   ├── pdc2qpx.py          # pdc2qpx command (PDC download + convert)
-│   └── convert.py          # convert subcommands (openms, openms-consensus, maxquant, diann, spectronaut, fragpipe, mzidentml, cdap, mz, sdrf)
+│   └── convert.py          # convert subcommands (openms, openms-consensus, quantms-msstats, maxquant, diann, spectronaut, fragpipe, mzidentml, cdap, mz, sdrf)
 ├── pipeline/               # High-level orchestration (pdc2qpx: download + CDAP + mz)
 ├── converters/             # Tool-specific converters
 │   ├── openms/             # OpenMS native QPX enrichment
@@ -259,6 +259,7 @@ qpx/
 │   ├── spectronaut/        # Spectronaut converter
 │   ├── fragpipe/           # FragPipe converter
 │   ├── mzidentml/          # mzIdentML converter
+│   ├── quantms_msstats/    # QuantMS *_msstats_in.csv + SDRF converter
 │   └── sdrf.py             # Shared SDRF converter
 ├── core/                   # Core logic & formats
 │   ├── data/               # Schema definitions (YAML + Python)

--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -112,6 +112,7 @@ The `convert` command group provides converters for multiple proteomics software
 - [cdap](#cdap) - Convert CPTAC CDAP `.psm` files to QPX format
 - [mz](#mz) - Convert an mzML spectra directory to QPX `mz.parquet` (full spectra)
 - [sdrf](#sdrf) - Convert SDRF to sample and run parquet files
+- [quantms-msstats](#quantms-msstats) - Convert QuantMS `*_msstats_in.csv` plus SDRF to QPX
 
 ---
 
@@ -716,6 +717,50 @@ print(generate_example(convert_sdrf_cmd, "Convert SDRF metadata with default set
 - Ensure SDRF file follows the PRIDE SDRF specifications
 - Use verbose mode to diagnose parsing issues
 - The converter automatically maps SDRF characteristics to QPX ontology terms
+
+---
+
+## quantms-msstats
+
+Convert a QuantMS-generated `*_msstats_in.csv` table and its SDRF metadata to
+QPX. The SDRF is required and is authoritative for run, sample, and label
+mapping.
+
+### Description {#quantms-msstats-description}
+
+```python exec="1" html="1" session="doc_utils"
+from qpx.cli.convert import convert_quantms_msstats_cmd
+
+print(generate_description(convert_quantms_msstats_cmd))
+```
+
+### Parameters {#quantms-msstats-parameters}
+
+```python exec="1" html="1" session="doc_utils"
+from qpx.cli.convert import convert_quantms_msstats_cmd
+
+print(generate_params_table(convert_quantms_msstats_cmd))
+```
+
+### Usage Example {#quantms-msstats-example}
+
+```bash
+qpxc convert quantms-msstats \
+    --msstats-file PXD007683.sdrf_openms_design_msstats_in.csv \
+    --sdrf-file PXD007683.sdrf.tsv \
+    --output-folder ./qpx_output \
+    --project-accession PXD007683
+```
+
+### Output and validation {#quantms-msstats-output}
+
+- Produces `feature`, `sample`, `run`, `dataset`, `ontology`, and `provenance` Parquet files.
+- Does not produce `psm.parquet` because MSstats does not contain complete spectrum-identification evidence.
+- Does not produce `pg.parquet`; protein aggregation remains a downstream analysis step.
+- Supports QuantMS `ProteinName`, `PeptideSequence`, `Charge`/`PrecursorCharge`, `Intensity`, `Run`/`Reference`, optional `RetentionTime`, and optional `Channel` columns.
+- Resolves `Run` and `Reference` through SDRF aliases and rejects missing, ambiguous, or conflicting mappings.
+- Collapses TMT/iTRAQ channel rows into one Feature while retaining RT and scan location when present.
+- Rejects conflicting intensity values for the same Feature and channel instead of selecting or summing them.
 
 ---
 

--- a/docs/spec/converter-coverage.md
+++ b/docs/spec/converter-coverage.md
@@ -8,10 +8,10 @@ This page lists which QPX data views each converter produces. Use it to see at a
 |-----------|:---:|:-------:|:--:|:------:|:------:|:---:|:-------:|:--------:|:----------:|:--:|
 | **MaxQuant** | Yes | Yes | Yes | No | If SDRF | If SDRF | Yes | If SDRF | No | No |
 | **FragPipe** | Yes | Yes | Yes | No | If SDRF | If SDRF | Yes | If SDRF | No | No |
-| **DIA-NN** | No | Yes | Yes | No | If SDRF | If SDRF | Yes | If SDRF | No | No |
+| **DIA-NN** | No | Yes | Yes | No | Yes | Yes | Yes | If terms | Yes | No |
 | **Spectronaut** | No | Yes | Yes | No | If SDRF | If SDRF | Yes | Yes | Yes | No |
 | **OpenMS native QPX** | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | No |
-| **OpenMS consensusXML** | Yes | Yes | Yes | No | If SDRF | If SDRF | No | No | No | No |
+| **OpenMS consensusXML** | Yes | Yes | Yes | No | If SDRF | If SDRF | Yes | If terms | Yes | No |
 | **CDAP** | Yes | Yes | Yes | No | If PDC | If PDC | Yes | Yes | Yes | No |
 | **mzIdentML** | Yes | No | No | Yes | If SDRF | If SDRF | Yes | Yes | Yes | No |
 | **QuantMS MSstats** | No | Yes | No | No | Yes | Yes | Yes | Yes | Yes | No |
@@ -19,7 +19,8 @@ This page lists which QPX data views each converter produces. Use it to see at a
 
 - **Yes** — the converter produces this view.
 - **No** — the converter does not produce this view (e.g. DIA-NN has no PSM view; mzIdentML has no Feature/PG).
-- **If SDRF** — the view is produced only when an SDRF file is provided (sample and run metadata). SDRF is optional except for the `qpxc convert openms` command, which requires it.
+- **If SDRF** — the view is produced only when an SDRF file is provided. Whether SDRF is optional or required depends on the converter; see its CLI contract below.
+- **If terms** — the view is produced when the converter discovers resolvable ontology entries.
 - **If PDC** — CPTAC/PDC studies ship no SDRF, and CDAP `.psm` files carry no sample metadata. When run through `qpxc pdc2qpx` (default), the sample/run views are built from PDC GraphQL metadata, which also recovers the TMT/iTRAQ channel → biological-sample mapping. Disable with `--no-metadata`.
 
 > The `mz` (full-spectra) view is produced by the standalone `qpxc convert mz` command, or automatically by `qpxc pdc2qpx --include-spectra`; it is not emitted by the per-tool converters above.
@@ -45,7 +46,7 @@ This page lists which QPX data views each converter produces. Use it to see at a
 |-----------|----------------|
 | MaxQuant | msms.txt, evidence.txt, proteinGroups.txt |
 | FragPipe | psm.tsv, combined_ion, combined_protein |
-| DIA-NN | report (tsv), pg_matrix (optional) |
+| DIA-NN | report (TSV or Parquet), pg_matrix (optional); required SDRF |
 | Spectronaut | report.tsv; optional SDRF |
 | OpenMS native QPX | `-out_qpx` Parquet directory; SDRF; optional companion consensusXML |
 | OpenMS consensusXML | consensusXML; optional SDRF |

--- a/docs/spec/converter-coverage.md
+++ b/docs/spec/converter-coverage.md
@@ -14,6 +14,7 @@ This page lists which QPX data views each converter produces. Use it to see at a
 | **OpenMS consensusXML** | Yes | Yes | Yes | No | If SDRF | If SDRF | No | No | No | No |
 | **CDAP** | Yes | Yes | Yes | No | If PDC | If PDC | Yes | Yes | Yes | No |
 | **mzIdentML** | Yes | No | No | Yes | If SDRF | If SDRF | Yes | Yes | Yes | No |
+| **QuantMS MSstats** | No | Yes | No | No | Yes | Yes | Yes | Yes | Yes | No |
 | **SDRF** | No | No | No | No | Yes | Yes | No | Optional | No | No |
 
 - **Yes** — the converter produces this view.
@@ -35,6 +36,7 @@ This page lists which QPX data views each converter produces. Use it to see at a
 | OpenMS consensusXML | `qpxc convert openms-consensus` |
 | CDAP | `qpxc convert cdap` |
 | mzIdentML | `qpxc convert mzidentml` |
+| QuantMS MSstats | `qpxc convert quantms-msstats` |
 | SDRF only | `qpxc convert sdrf` |
 
 ## Input files (summary)
@@ -49,6 +51,7 @@ This page lists which QPX data views each converter produces. Use it to see at a
 | OpenMS consensusXML | consensusXML; optional SDRF |
 | CDAP | CPTAC CDAP `.psm` files in one study directory |
 | mzIdentML | .mzid / .mzid.gz; optional MGF or mzML (file/folder) for spectra; optional SDRF |
+| QuantMS MSstats | QuantMS-generated `*_msstats_in.csv`; required SDRF |
 | SDRF | Single SDRF TSV file |
 
 For field-level mappings from each tool’s columns to QPX, see [Tool Field Mappings](tool-mappings.md).

--- a/docs/spec/tool-mappings.md
+++ b/docs/spec/tool-mappings.md
@@ -32,23 +32,23 @@ The PSM (Peptide Spectrum Match) view captures spectrum-level identification res
 
 The Feature view captures quantified peptide features with intensity data. Features aggregate information across scans and are the primary view for DIA and label-free quantification workflows.
 
-| QPX Field | MaxQuant | DIA-NN | FragPipe |
-|---|---|---|---|
-| `sequence` | Sequence | Stripped.Sequence | Peptide |
-| `peptidoform` | Modified sequence | Modified.Sequence | Modified Peptide |
-| `charge` | Charge | Precursor.Charge | --- |
-| `is_decoy` | Reverse | --- | --- |
-| `calculated_mz` | --- | --- | Calculated M/Z |
-| `observed_mz` | m/z | --- | --- |
-| `rt` | Retention time | RT | --- |
-| `rt_start` | --- | RT.Start | --- |
-| `rt_stop` | --- | RT.Stop | --- |
-| `predicted_rt` | --- | Predicted.RT | --- |
-| `intensities` | Intensity | Precursor.Quantity | Intensity |
-| `pg_accessions` | Proteins | Protein.Group | --- |
-| `anchor_protein` | --- | --- | --- |
-| `pg_positions` | --- | --- | --- |
-| `run_file_name` | Raw file | Run | --- |
+| QPX Field | MaxQuant | DIA-NN | FragPipe | QuantMS MSstats |
+|---|---|---|---|---|
+| `sequence` | Sequence | Stripped.Sequence | Peptide | PeptideSequence (unmodified) |
+| `peptidoform` | Modified sequence | Modified.Sequence | Modified Peptide | PeptideSequence (ProForma-normalized) |
+| `charge` | Charge | Precursor.Charge | --- | Charge / PrecursorCharge |
+| `is_decoy` | Reverse | --- | --- | ProteinName prefix |
+| `calculated_mz` | --- | --- | Calculated M/Z | --- |
+| `observed_mz` | m/z | --- | --- | --- |
+| `rt` | Retention time | RT | --- | RetentionTime |
+| `rt_start` | --- | RT.Start | --- | --- |
+| `rt_stop` | --- | RT.Stop | --- | --- |
+| `predicted_rt` | --- | Predicted.RT | --- | --- |
+| `intensities` | Intensity | Precursor.Quantity | Intensity | Intensity + Channel |
+| `pg_accessions` | Proteins | Protein.Group | --- | ProteinName |
+| `anchor_protein` | --- | --- | --- | First ProteinName accession |
+| `pg_positions` | --- | --- | --- | --- |
+| `run_file_name` | Raw file | Run | --- | Reference / Run resolved through SDRF |
 
 ## Protein Group Field Mappings
 

--- a/qpx/cli/convert.py
+++ b/qpx/cli/convert.py
@@ -12,6 +12,7 @@ Subcommands:
     qpxc convert spectronaut — Spectronaut report to QPX
     qpxc convert cdap       — CPTAC CDAP .psm files to QPX
     qpxc convert sdrf       — SDRF to sample.parquet + run.parquet
+    qpxc convert quantms-msstats — QuantMS MSstats + SDRF to QPX
 """
 
 from __future__ import annotations
@@ -984,6 +985,110 @@ def convert_sdrf_cmd(
         )
 
     click.echo(f"SDRF conversion complete. Output: {output_folder}")
+
+
+# ---------------------------------------------------------------------------
+# QuantMS MSstats
+# ---------------------------------------------------------------------------
+
+
+@convert.command("quantms-msstats")
+@click.option(
+    "--msstats-file",
+    help="QuantMS-generated *_msstats_in.csv file path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--sdrf-file",
+    help="SDRF metadata file path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--output-folder",
+    help="Output directory for generated QPX files",
+    required=True,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+@click.option("--output-prefix", help="Prefix for output file names")
+@click.option(
+    "--project-accession",
+    help="PRIDE / ProteomeXchange accession (e.g. PXD007683)",
+)
+@click.option(
+    "--max-memory",
+    help="Maximum DuckDB memory limit",
+    default="16GB",
+    show_default=True,
+)
+@click.option(
+    "--max-cpus",
+    help="Maximum number of DuckDB threads",
+    default=4,
+    show_default=True,
+    type=int,
+)
+@click.option(
+    "--batch-size",
+    help="Number of Feature records written per batch",
+    default=50_000,
+    show_default=True,
+    type=click.IntRange(min=1),
+)
+@click.option(
+    "--compression",
+    type=click.Choice(["zstd", "snappy", "gzip", "none"], case_sensitive=False),
+    default="zstd",
+    show_default=True,
+    help="Parquet compression codec.",
+)
+@click.option("--verbose", help="Enable verbose logging", is_flag=True)
+def convert_quantms_msstats_cmd(
+    msstats_file: Path,
+    sdrf_file: Path,
+    output_folder: Path,
+    output_prefix: Optional[str],
+    project_accession: Optional[str],
+    max_memory: str,
+    max_cpus: int,
+    batch_size: int,
+    compression: str,
+    verbose: bool,
+):
+    """Convert QuantMS MSstats and SDRF inputs to QPX.
+
+    Produces Feature, Sample, Run, Dataset, Provenance, and Ontology Parquet
+    files. MSstats does not contain the evidence required to produce PSM or
+    protein-group views, so those views are intentionally not generated.
+
+    \b
+    Example:
+        qpxc convert quantms-msstats \
+            --msstats-file PXD007683.sdrf_openms_design_msstats_in.csv \
+            --sdrf-file PXD007683.sdrf.tsv \
+            --output-folder ./qpx_output
+    """
+    if verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    from qpx.converters.quantms_msstats import QuantmsMsstatsConverter
+
+    converter = QuantmsMsstatsConverter(
+        max_memory=max_memory,
+        max_cpus=max_cpus,
+        compression=compression,
+    )
+    prefix = converter.convert(
+        msstats_file=msstats_file,
+        sdrf_file=sdrf_file,
+        output_folder=output_folder,
+        output_prefix=output_prefix,
+        project_accession=project_accession,
+        batch_size=batch_size,
+    )
+    _log_summary(output_folder)
+    click.echo(f"QuantMS MSstats conversion complete. Output prefix: {prefix}")
 
 
 # ---------------------------------------------------------------------------

--- a/qpx/converters/__init__.py
+++ b/qpx/converters/__init__.py
@@ -26,6 +26,8 @@ from qpx.converters.maxquant.psm_adapter import MaxQuantPsmAdapter
 from qpx.converters.mzidentml.psm_adapter import MzIdentMLPsmAdapter
 from qpx.converters.openms.converter import OpenMSConverter
 from qpx.converters.orchestrator import BaseOrchestrator, build_dataset_record
+from qpx.converters.quantms_msstats.converter import QuantmsMsstatsConverter
+from qpx.converters.quantms_msstats.feature_adapter import QuantmsMsstatsFeatureAdapter
 from qpx.converters.sdrf import SdrfConverter
 from qpx.converters.spectronaut.converter import SpectronautConverter
 from qpx.converters.spectronaut.feature_adapter import SpectronautFeatureAdapter
@@ -61,6 +63,9 @@ __all__ = [
     "MzIdentMLPsmAdapter",
     # OpenMS
     "OpenMSConverter",
+    # QuantMS MSstats
+    "QuantmsMsstatsFeatureAdapter",
+    "QuantmsMsstatsConverter",
     # Spectronaut
     "SpectronautFeatureAdapter",
     "SpectronautPgAdapter",

--- a/qpx/converters/quantms_msstats/__init__.py
+++ b/qpx/converters/quantms_msstats/__init__.py
@@ -1,0 +1,6 @@
+"""QuantMS MSstats input converter."""
+
+from qpx.converters.quantms_msstats.converter import QuantmsMsstatsConverter
+from qpx.converters.quantms_msstats.feature_adapter import QuantmsMsstatsFeatureAdapter
+
+__all__ = ["QuantmsMsstatsConverter", "QuantmsMsstatsFeatureAdapter"]

--- a/qpx/converters/quantms_msstats/converter.py
+++ b/qpx/converters/quantms_msstats/converter.py
@@ -1,0 +1,155 @@
+"""Orchestrate QuantMS MSstats and SDRF conversion to QPX."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+
+from qpx._version import __version__
+from qpx.converters.orchestrator import BaseOrchestrator
+from qpx.converters.quantms_msstats.feature_adapter import (
+    FEATURE_IDENTITY_COMPOSITE,
+    QuantmsMsstatsFeatureAdapter,
+)
+from qpx.converters.sdrf import SdrfConverter
+from qpx.core.constants import FEATURE, ONTOLOGY, RUN, SAMPLE
+from qpx.core.scores import field_ontology_entries
+
+logger = logging.getLogger(__name__)
+
+
+def _sha256(path: str | Path) -> str:
+    """Return the SHA-256 digest of one input file."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+class QuantmsMsstatsConverter(BaseOrchestrator):
+    """Convert QuantMS legacy MSstats plus SDRF input to QPX Parquet."""
+
+    def __init__(
+        self,
+        max_memory: str = "16GB",
+        max_cpus: int = 4,
+        compression: str = "zstd",
+    ):
+        self._max_memory = max_memory
+        self._max_cpus = max_cpus
+        self._compression = compression
+
+    def convert(
+        self,
+        msstats_file: str | Path,
+        sdrf_file: str | Path,
+        output_folder: str | Path,
+        output_prefix: str | None = None,
+        project_accession: str | None = None,
+        batch_size: int = 50_000,
+    ) -> str:
+        """Run Feature, SDRF, and metadata conversion."""
+        msstats_file = Path(msstats_file)
+        sdrf_file = Path(sdrf_file)
+        output_folder = Path(output_folder)
+        output_folder.mkdir(parents=True, exist_ok=True)
+        prefix = output_prefix or msstats_file.stem.removesuffix(".sdrf_openms_design_msstats_in")
+        if not prefix:
+            prefix = "quantms_msstats"
+
+        feature_path = output_folder / f"{prefix}.feature.parquet"
+        with QuantmsMsstatsFeatureAdapter(
+            duckdb_memory=self._max_memory,
+            duckdb_threads=self._max_cpus,
+            compression=self._compression,
+        ) as adapter:
+            adapter.convert(
+                msstats_path=str(msstats_file),
+                sdrf_path=str(sdrf_file),
+                output_path=str(feature_path),
+                chunksize=batch_size,
+            )
+            resolved = adapter.get_resolved_columns()
+
+        with SdrfConverter(
+            duckdb_memory=self._max_memory,
+            duckdb_threads=self._max_cpus,
+            compression=self._compression,
+        ) as sdrf_converter:
+            sdrf_converter.convert(
+                sdrf_path=str(sdrf_file),
+                sample_output=str(output_folder / f"{prefix}.sample.parquet"),
+                run_output=str(output_folder / f"{prefix}.run.parquet"),
+            )
+            ontology_entries = sdrf_converter.run_ontology_entries()
+
+        ontology_entries.extend(
+            field_ontology_entries(
+                view=FEATURE,
+                resolved_mappings=resolved,
+                tool_name="QuantMS/MSstats",
+            )
+        )
+        self._write_ontology(output_folder, prefix, ontology_entries)
+        provenance_records = self.provenance_records(msstats_file, sdrf_file, resolved)
+        self._write_provenance(output_folder, prefix, provenance_records)
+        self._write_dataset(
+            output_folder,
+            prefix,
+            project_accession,
+            software_name="QuantMS/MSstats",
+            software_version=None,
+            provenance_records=provenance_records,
+        )
+        return prefix
+
+    @staticmethod
+    def provenance_records(
+        msstats_file: Path,
+        sdrf_file: Path,
+        resolved: dict[str, str],
+    ) -> list[dict]:
+        """Build source and conversion provenance records."""
+        output_views = [FEATURE, SAMPLE, RUN, ONTOLOGY]
+        config = json.dumps(
+            {
+                "source_columns": resolved,
+                "identity_composite": list(FEATURE_IDENTITY_COMPOSITE),
+                "missing_values": "typed null; scan uses an empty list when unavailable",
+                "protein_aggregation": "not performed",
+                "unique_peptide": ("true only when a sequence maps to one ProteinName value containing one accession"),
+            },
+            sort_keys=True,
+        )
+        return [
+            {
+                "step_order": 1,
+                "step_category": "quantification",
+                "step_name": "quantms_msstats_feature_quantification",
+                "tool_name": "QuantMS/MSstats",
+                "tool_version": None,
+                "tool_uri": "https://github.com/bigbio/quantms",
+                "parameters": None,
+                "config": None,
+                "output_views": [FEATURE],
+            },
+            {
+                "step_order": 2,
+                "step_category": "format_conversion",
+                "step_name": "quantms_msstats_to_qpx",
+                "tool_name": "qpx",
+                "tool_version": __version__,
+                "tool_uri": "https://github.com/bigbio/qpx",
+                "parameters": [
+                    {"key": "msstats_file", "value": msstats_file.name},
+                    {"key": "msstats_sha256", "value": _sha256(msstats_file)},
+                    {"key": "sdrf_file", "value": sdrf_file.name},
+                    {"key": "sdrf_sha256", "value": _sha256(sdrf_file)},
+                ],
+                "config": config,
+                "output_views": output_views,
+            },
+        ]

--- a/qpx/converters/quantms_msstats/feature_adapter.py
+++ b/qpx/converters/quantms_msstats/feature_adapter.py
@@ -140,7 +140,14 @@ class QuantmsMsstatsFeatureAdapter(BaseConverter):
             sql_build(
                 """
                 CREATE OR REPLACE VIEW _msstats_input AS
-                SELECT * FROM read_csv_auto('$path', header=true, all_varchar=true)
+                SELECT * FROM read_csv_auto(
+                    '$path',
+                    header=true,
+                    all_varchar=true,
+                    delim=',',
+                    quote='"',
+                    escape='"'
+                )
                 """,
                 path=safe_path,
             )

--- a/qpx/converters/quantms_msstats/feature_adapter.py
+++ b/qpx/converters/quantms_msstats/feature_adapter.py
@@ -1,0 +1,543 @@
+"""Convert QuantMS ``*_msstats_in.csv`` tables to QPX Features."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable
+
+import pandas as pd
+
+from qpx.converters.base import BaseConverter
+from qpx.converters.channel_labels import (
+    experiment_type_from_labels,
+    normalize_label,
+    read_sdrf_labels,
+    resolve_channel_labels,
+)
+from qpx.converters.openms_consensus.feature_adapter import to_modifications, to_proforma
+from qpx.core.files import run_file_stem
+from qpx.core.sdrf import validate_sdrf_data_files
+from qpx.core.sql import escape_path, sql_build, validate_identifier, validate_table
+from qpx.writers.feature import FeatureWriter
+
+logger = logging.getLogger(__name__)
+
+FEATURE_IDENTITY_COMPOSITE = ("run_file_name", "peptidoform", "charge", "rt", "scan")
+
+_RUN_ALIAS_COLUMNS = (
+    "comment[data file]",
+    "comment[file uri]",
+    "comment[associated file uri]",
+    "assay name",
+)
+_RUN_EXTENSION = re.compile(
+    r"^(.*)\.(?:mzml(?:\.gz)?|mzxml|raw|d|wiff|mgf|dia)(?:$|[._\s])",
+    re.IGNORECASE,
+)
+_DECOY_PREFIXES = ("decoy_", "rev_", "reverse_")
+
+
+def _run_alias_key(value: object) -> str:
+    """Return the normalized run key used to match MSstats and SDRF values."""
+    basename = str(value).strip().replace("\\", "/").rsplit("/", maxsplit=1)[-1].lower()
+    match = _RUN_EXTENSION.match(basename)
+    if match:
+        return match.group(1)
+    return run_file_stem(basename).lower()
+
+
+def _split_proteins(values: Iterable[str]) -> list[str]:
+    """Return distinct protein accessions in deterministic source order."""
+    accessions: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        for value in str(raw).split(";"):
+            accession = value.strip()
+            if accession and accession not in seen:
+                seen.add(accession)
+                accessions.append(accession)
+    return accessions
+
+
+def _is_decoy(accessions: list[str]) -> bool:
+    """Return true only when every reported protein is a decoy accession."""
+    return bool(accessions) and all(accession.lower().startswith(_DECOY_PREFIXES) for accession in accessions)
+
+
+def _as_channel_position(value: object) -> int | None:
+    """Parse a one-based integer MSstats channel position."""
+    try:
+        numeric = float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    position = int(numeric)
+    return position if numeric == position and position > 0 else None
+
+
+def _parse_peptide(raw: str) -> tuple[str, str, list[dict] | None]:
+    """Convert an OpenMS peptide string into QPX sequence/PTM fields."""
+    import pyopenms as oms
+
+    try:
+        aa_sequence = getattr(oms, "AASequence").fromString(raw)
+    except RuntimeError as exc:
+        raise ValueError(f"Invalid QuantMS PeptideSequence value: {raw!r}") from exc
+    sequence = aa_sequence.toUnmodifiedString()
+    peptidoform = to_proforma(aa_sequence)
+    if not sequence or not peptidoform:
+        raise ValueError(f"Invalid QuantMS PeptideSequence value: {raw!r}")
+    return sequence, peptidoform, to_modifications(aa_sequence) or None
+
+
+class QuantmsMsstatsFeatureAdapter(BaseConverter):
+    """Convert one QuantMS MSstats input table into ``feature.parquet``."""
+
+    _COLUMN_ALIASES = {
+        "protein": ("ProteinName",),
+        "peptide": ("PeptideSequence",),
+        "charge": ("Charge", "PrecursorCharge"),
+        "intensity": ("Intensity",),
+        "run": ("Run",),
+        "reference": ("Reference",),
+        "channel": ("Channel",),
+        "rt": ("RetentionTime",),
+    }
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._columns: dict[str, str | None] = {}
+        self._resolved: dict[str, str] = {}
+        self._modifications: dict[str, list[dict] | None] = {}
+
+    def convert(
+        self,
+        msstats_path: str,
+        sdrf_path: str,
+        output_path: str,
+        chunksize: int = 50_000,
+        creator: str = "quantms-msstats",
+    ) -> None:
+        """Validate and convert a QuantMS MSstats table."""
+        self._load_msstats(msstats_path)
+        self._resolve_columns()
+        aliases, valid_pairs = self._load_sdrf_context(sdrf_path)
+        self._register_frame("_run_aliases", aliases)
+        self._register_frame("_valid_run_labels", valid_pairs)
+        channel_map = self._build_channel_map(sdrf_path)
+        if channel_map is not None:
+            self._register_frame("_channel_map", channel_map)
+        self._register_peptides()
+        self._create_normalized_table(channel_map is not None)
+        self._validate_normalized_rows()
+        self._validate_run_labels()
+        self._validate_feature_groups()
+        self._write_features(output_path, chunksize, creator)
+
+    def _load_msstats(self, path: str) -> None:
+        safe_path = escape_path(path)
+        self._conn.execute(
+            sql_build(
+                """
+                CREATE OR REPLACE VIEW _msstats_input AS
+                SELECT * FROM read_csv_auto('$path', header=true, all_varchar=true)
+                """,
+                path=safe_path,
+            )
+        )
+        count = self._conn.execute("SELECT count(*) FROM _msstats_input").fetchone()[0]
+        if count == 0:
+            raise ValueError("QuantMS MSstats input contains no data rows")
+        self.logger.info("Loaded %d QuantMS MSstats rows from %s", count, path)
+
+    def _resolve_columns(self) -> None:
+        available = {
+            row[0]
+            for row in self._conn.execute(
+                "SELECT column_name FROM information_schema.columns WHERE table_name='_msstats_input'"
+            ).fetchall()
+        }
+        required = {"protein", "peptide", "charge", "intensity"}
+        for field, aliases in self._COLUMN_ALIASES.items():
+            self._columns[field] = next((name for name in aliases if name in available), None)
+            if field in required and self._columns[field] is None:
+                raise ValueError(f"QuantMS MSstats input is missing required column: {' or '.join(aliases)}")
+        if self._columns["run"] is None and self._columns["reference"] is None:
+            raise ValueError("QuantMS MSstats input requires a Run or Reference column")
+
+        self._resolved = {
+            "anchor_protein": self._columns["protein"],
+            "pg_accessions": self._columns["protein"],
+            "sequence": self._columns["peptide"],
+            "peptidoform": self._columns["peptide"],
+            "charge": self._columns["charge"],
+            "intensities": self._columns["intensity"],
+        }
+        if self._columns["rt"]:
+            self._resolved["rt"] = self._columns["rt"]
+        if self._columns["reference"]:
+            self._resolved["scan"] = self._columns["reference"]
+        if self._columns["channel"]:
+            self._resolved["intensity_label"] = self._columns["channel"]
+
+    @staticmethod
+    def _load_sdrf_context(path: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+        sdrf = pd.read_csv(path, sep="\t", dtype=str)
+        sdrf.columns = sdrf.columns.str.strip().str.lower()
+        required = {"source name", "comment[data file]", "comment[label]"}
+        missing = sorted(required - set(sdrf.columns))
+        if missing:
+            raise ValueError(f"SDRF input is missing required column(s): {', '.join(missing)}")
+        validate_sdrf_data_files(sdrf)
+
+        alias_to_run: dict[str, str] = {}
+        valid_pairs: list[dict[str, str]] = []
+        seen_pairs: dict[tuple[str, str], str] = {}
+        for row in sdrf.to_dict("records"):
+            data_file = str(row["comment[data file]"]).strip()
+            run_file_name = run_file_stem(data_file)
+            label = normalize_label(str(row["comment[label]"]).strip())
+            sample = str(row["source name"]).strip()
+            if not run_file_name or not label or not sample:
+                raise ValueError("SDRF source name, data file, and label values must be non-empty")
+
+            pair = (run_file_name, label)
+            previous = seen_pairs.get(pair)
+            if previous is not None:
+                raise ValueError(
+                    f"SDRF run {run_file_name!r} maps canonical label {label!r} more than once: {previous!r} and {sample!r}"
+                )
+            seen_pairs[pair] = sample
+            valid_pairs.append({"run_file_name": run_file_name, "label": label})
+
+            for column in _RUN_ALIAS_COLUMNS:
+                value = row.get(column)
+                if value is None or pd.isna(value) or not str(value).strip():
+                    continue
+                key = _run_alias_key(value)
+                if not key:
+                    continue
+                existing = alias_to_run.get(key)
+                if existing is not None and existing != run_file_name:
+                    raise ValueError(f"SDRF run alias {key!r} maps to both {existing!r} and {run_file_name!r}")
+                alias_to_run[key] = run_file_name
+
+        if not alias_to_run:
+            raise ValueError("SDRF input contains no usable run aliases")
+        aliases = pd.DataFrame(
+            sorted(alias_to_run.items()),
+            columns=["alias_key", "run_file_name"],
+        )
+        return aliases, pd.DataFrame(valid_pairs)
+
+    def _build_channel_map(self, sdrf_path: str) -> pd.DataFrame | None:
+        raw_labels = read_sdrf_labels(sdrf_path)
+        experiment_type = experiment_type_from_labels(raw_labels)
+        channel_column = self._columns["channel"]
+        raw_channels = self._raw_channels(channel_column)
+
+        if experiment_type == "LFQ":
+            if raw_channels:
+                raise ValueError("LFQ SDRF conflicts with non-empty MSstats Channel values")
+            return None
+        if channel_column is None:
+            raise ValueError(f"{experiment_type} QuantMS MSstats input requires a Channel column")
+        if not raw_channels:
+            raise ValueError(f"{experiment_type} QuantMS MSstats input contains no Channel values")
+
+        records = self._channel_records(experiment_type, raw_labels, raw_channels)
+        return pd.DataFrame(records)
+
+    def _raw_channels(self, channel_column: str | None) -> list[str]:
+        """Return distinct non-empty MSstats channel values."""
+        if channel_column is None:
+            return []
+        column = validate_identifier(channel_column)
+        return [
+            str(row[0]).strip()
+            for row in self._conn.execute(
+                sql_build(
+                    "SELECT DISTINCT trim(CAST($channel AS VARCHAR)) FROM _msstats_input "
+                    "WHERE NULLIF(trim(CAST($channel AS VARCHAR)), '') IS NOT NULL",
+                    channel=column,
+                )
+            ).fetchall()
+        ]
+
+    @staticmethod
+    def _channel_records(
+        experiment_type: str,
+        raw_labels: set[str] | None,
+        raw_channels: list[str],
+    ) -> list[dict]:
+        """Resolve source channel values to canonical QPX labels."""
+        numeric_positions = [position for value in raw_channels if (position := _as_channel_position(value))]
+        position_map = resolve_channel_labels(experiment_type, raw_labels, numeric_positions)
+        declared = {normalize_label(value) for value in raw_labels or set()}
+        order_by_label = {label: order for order, label in position_map.items()}
+
+        records: list[dict] = []
+        for raw in raw_channels:
+            position = _as_channel_position(raw)
+            label = position_map.get(position) if position is not None else normalize_label(raw)
+            if not label or label not in declared:
+                raise ValueError(f"MSstats Channel {raw!r} does not match an SDRF {experiment_type} label")
+            records.append(
+                {
+                    "source_channel": raw,
+                    "canonical_label": label,
+                    "channel_order": order_by_label.get(label, position or 0),
+                }
+            )
+        return records
+
+    def _register_peptides(self) -> None:
+        peptide_column = validate_identifier(self._columns["peptide"])
+        rows = self._conn.execute(
+            sql_build(
+                "SELECT DISTINCT trim(CAST($peptide AS VARCHAR)) FROM _msstats_input",
+                peptide=peptide_column,
+            )
+        ).fetchall()
+        records: list[dict[str, str]] = []
+        for (raw_value,) in rows:
+            raw = str(raw_value or "").strip()
+            sequence, peptidoform, modifications = _parse_peptide(raw)
+            self._modifications[raw] = modifications
+            records.append(
+                {
+                    "peptide_raw": raw,
+                    "sequence": sequence,
+                    "peptidoform": peptidoform,
+                }
+            )
+        self._register_frame("_peptide_lookup", pd.DataFrame(records))
+
+    def _create_normalized_table(self, is_isobaric: bool) -> None:
+        protein = validate_identifier(self._columns["protein"])
+        peptide = validate_identifier(self._columns["peptide"])
+        charge = validate_identifier(self._columns["charge"])
+        intensity = validate_identifier(self._columns["intensity"])
+        run = validate_identifier(self._columns["run"]) if self._columns["run"] else None
+        reference = validate_identifier(self._columns["reference"]) if self._columns["reference"] else None
+        channel = validate_identifier(self._columns["channel"]) if self._columns["channel"] else None
+        rt = validate_identifier(self._columns["rt"]) if self._columns["rt"] else None
+
+        run_expr = f"m.{run}" if run else "NULL::VARCHAR"
+        reference_expr = f"m.{reference}" if reference else "NULL::VARCHAR"
+        run_key = self._run_key_expression(run_expr)
+        reference_key = self._run_key_expression(reference_expr)
+        rt_expr = f"TRY_CAST(m.{rt} AS FLOAT)" if rt else "NULL::FLOAT"
+        scan_expr = (
+            f"TRY_CAST(regexp_extract(COALESCE(m.{reference}, ''), '(?i)scan=([0-9]+)', 1) AS INTEGER)"
+            if reference
+            else "NULL::INTEGER"
+        )
+        if is_isobaric:
+            channel_join = f"LEFT JOIN _channel_map cm ON trim(CAST(m.{channel} AS VARCHAR)) = cm.source_channel"
+            label_expr = "cm.canonical_label"
+            order_expr = "cm.channel_order"
+        else:
+            channel_join = ""
+            label_expr = "'LFQ'"
+            order_expr = "1"
+
+        query = sql_build(
+            """
+            CREATE OR REPLACE TEMP TABLE _normalized AS
+            SELECT trim(CAST(m.$protein AS VARCHAR)) AS protein_raw,
+                   trim(CAST(m.$peptide AS VARCHAR)) AS peptide_raw,
+                   p.sequence,
+                   p.peptidoform,
+                   TRY_CAST(m.$charge AS SMALLINT) AS charge,
+                   COALESCE(rr.run_file_name, ru.run_file_name) AS run_file_name,
+                   rr.run_file_name AS reference_file,
+                   ru.run_file_name AS run_file,
+                   TRY_CAST(m.$intensity AS FLOAT) AS intensity,
+                   $rt_expr AS rt,
+                   $scan_expr AS scan_number,
+                   $reference_expr AS reference_raw,
+                   $label_expr AS intensity_label,
+                   $order_expr AS channel_order,
+                   count(DISTINCT trim(CAST(m.$protein AS VARCHAR)))
+                     OVER (PARTITION BY p.sequence) = 1
+                     AND NOT contains(trim(CAST(m.$protein AS VARCHAR)), ';') AS is_unique
+            FROM _msstats_input m
+            LEFT JOIN _run_aliases rr ON rr.alias_key = $reference_key
+            LEFT JOIN _run_aliases ru ON ru.alias_key = $run_key
+            LEFT JOIN _peptide_lookup p
+              ON p.peptide_raw = trim(CAST(m.$peptide AS VARCHAR))
+            $channel_join
+            """,
+            protein=protein,
+            peptide=peptide,
+            charge=charge,
+            intensity=intensity,
+            rt_expr=rt_expr,
+            scan_expr=scan_expr,
+            reference_expr=reference_expr,
+            label_expr=label_expr,
+            order_expr=order_expr,
+            reference_key=reference_key,
+            run_key=run_key,
+            channel_join=channel_join,
+        )
+        self._conn.execute(query)
+
+    @staticmethod
+    def _run_key_expression(column: str) -> str:
+        basename = "regexp_extract(replace(lower(coalesce(" + column + ", '')), '\\\\', '/'), '([^/]+)$', 1)"
+        return (
+            "CASE WHEN regexp_matches(" + basename + ", '\\.(mzml(?:\\.gz)?|mzxml|raw|d|wiff|mgf|dia)(?:$|[._\\s])') "
+            "THEN regexp_extract(" + basename + ", '^(.*)(?:\\.(?:mzml(?:\\.gz)?|mzxml|raw|d|wiff|mgf|dia))(?:$|[._\\s])', 1) "
+            "ELSE regexp_replace(" + basename + ", '\\.(?:mzml(?:\\.gz)?|mzxml|raw|d|wiff|mgf|dia)$', '') END"
+        )
+
+    def _validate_normalized_rows(self) -> None:
+        total, invalid, unresolved, conflicts = self._conn.execute(
+            """
+            SELECT count(*),
+                   count(*) FILTER (
+                       WHERE NULLIF(protein_raw, '') IS NULL
+                          OR NULLIF(peptidoform, '') IS NULL
+                          OR NULLIF(sequence, '') IS NULL
+                          OR charge IS NULL OR charge <= 0
+                          OR intensity IS NULL OR NOT isfinite(intensity)
+                          OR NULLIF(intensity_label, '') IS NULL
+                   ),
+                   count(*) FILTER (WHERE run_file_name IS NULL),
+                   count(*) FILTER (
+                       WHERE reference_file IS NOT NULL AND run_file IS NOT NULL
+                         AND reference_file <> run_file
+                   )
+            FROM _normalized
+            """
+        ).fetchone()
+        if invalid:
+            raise ValueError(f"{invalid} of {total} QuantMS MSstats rows contain invalid required values")
+        if unresolved:
+            raise ValueError(f"{unresolved} of {total} QuantMS MSstats rows cannot be mapped to an SDRF data file")
+        if conflicts:
+            raise ValueError(f"{conflicts} QuantMS MSstats rows map Run and Reference to different SDRF files")
+
+    def _validate_run_labels(self) -> None:
+        count, run_file_name, label = self._conn.execute(
+            """
+            SELECT count(*), min(n.run_file_name), min(n.intensity_label)
+            FROM _normalized n
+            LEFT JOIN _valid_run_labels v
+              ON v.run_file_name = n.run_file_name AND v.label = n.intensity_label
+            WHERE v.run_file_name IS NULL
+            """
+        ).fetchone()
+        if count:
+            raise ValueError(f"{count} QuantMS MSstats rows have no SDRF sample for run {run_file_name!r} and label {label!r}")
+
+    def _validate_feature_groups(self) -> None:
+        conflict_count = self._conn.execute(
+            """
+            SELECT count(*) FROM (
+                SELECT run_file_name, peptidoform, charge, rt, scan_number, intensity_label
+                FROM _normalized
+                GROUP BY ALL
+                HAVING count(DISTINCT intensity) > 1
+            )
+            """
+        ).fetchone()[0]
+        if conflict_count:
+            raise ValueError(f"{conflict_count} Feature/channel group(s) contain conflicting intensity values")
+
+        location_count = self._conn.execute(
+            """
+            SELECT count(*) FROM (
+                SELECT run_file_name, peptidoform, charge, rt, scan_number
+                FROM _normalized
+                GROUP BY ALL
+                HAVING count(DISTINCT reference_raw) FILTER (WHERE reference_raw IS NOT NULL) > 1
+            )
+            """
+        ).fetchone()[0]
+        if location_count:
+            raise ValueError(
+                f"{location_count} Feature group(s) collapse distinct Reference values; "
+                "the MSstats input lacks a sufficient RT/scan locator"
+            )
+
+    def _write_features(self, output_path: str, chunksize: int, creator: str) -> None:
+        query = """
+            WITH per_channel AS (
+                SELECT run_file_name, peptide_raw, sequence, peptidoform, charge, rt, scan_number,
+                       intensity_label, min(channel_order) AS channel_order,
+                       first(intensity ORDER BY intensity) AS intensity
+                FROM _normalized
+                GROUP BY ALL
+            ), proteins AS (
+                SELECT run_file_name, peptidoform, charge, rt, scan_number,
+                       list(DISTINCT protein_raw ORDER BY protein_raw) AS protein_names,
+                       bool_and(is_unique) AS is_unique
+                FROM _normalized
+                GROUP BY ALL
+            )
+            SELECT c.run_file_name, c.peptide_raw, c.sequence, c.peptidoform, c.charge,
+                   c.rt, c.scan_number,
+                   list(c.intensity_label ORDER BY c.channel_order, c.intensity_label) AS labels,
+                   list(c.intensity ORDER BY c.channel_order, c.intensity_label) AS intensity_values,
+                   p.protein_names, p.is_unique
+            FROM per_channel c
+            JOIN proteins p
+              ON p.run_file_name = c.run_file_name
+             AND p.peptidoform = c.peptidoform
+             AND p.charge = c.charge
+             AND p.rt IS NOT DISTINCT FROM c.rt
+             AND p.scan_number IS NOT DISTINCT FROM c.scan_number
+            GROUP BY c.run_file_name, c.peptide_raw, c.sequence, c.peptidoform,
+                     c.charge, c.rt, c.scan_number, p.protein_names, p.is_unique
+            ORDER BY c.run_file_name, c.peptidoform, c.charge, c.rt, c.scan_number
+        """
+        written = 0
+        with FeatureWriter(
+            output_path,
+            creator=creator,
+            compression=self._compression,
+            batch_size=chunksize,
+            identity_composite=FEATURE_IDENTITY_COMPOSITE,
+        ) as writer:
+            for batch in self._query_batched(query, chunksize):
+                records = [self._feature_record(row) for row in batch.to_pylist()]
+                writer.write_batch(records)
+                written += len(records)
+        if not written:
+            raise ValueError("QuantMS MSstats conversion produced no Feature rows")
+        self.logger.info("Wrote %d Features to %s", written, output_path)
+
+    def _feature_record(self, row: dict) -> dict:
+        accessions = _split_proteins(row["protein_names"] or [])
+        pg_accessions = [
+            {"accession": accession, "start": None, "end": None, "pre": None, "post": None} for accession in accessions
+        ]
+        scan_number = row["scan_number"]
+        return {
+            "sequence": row["sequence"],
+            "peptidoform": row["peptidoform"],
+            "modifications": self._modifications[row["peptide_raw"]],
+            "charge": row["charge"],
+            "is_decoy": _is_decoy(accessions),
+            "calculated_mz": None,
+            "observed_mz": None,
+            "run_file_name": row["run_file_name"],
+            "scan": [scan_number] if scan_number is not None else [],
+            "rt": row["rt"],
+            "intensities": [
+                {"label": label, "intensity": intensity}
+                for label, intensity in zip(row["labels"], row["intensity_values"], strict=True)
+            ],
+            "pg_accessions": pg_accessions,
+            "anchor_protein": accessions[0] if accessions else None,
+            "unique": row["is_unique"],
+            "id_run_file_name": row["run_file_name"],
+        }
+
+    def _register_frame(self, name: str, frame: pd.DataFrame) -> None:
+        table = validate_table(name)
+        self._conn.execute(sql_build("DROP TABLE IF EXISTS $table", table=table))
+        self._conn.from_df(frame).create(table)

--- a/tests/converters/test_quantms_msstats_converter.py
+++ b/tests/converters/test_quantms_msstats_converter.py
@@ -1,0 +1,285 @@
+"""Regression tests for QuantMS MSstats plus SDRF conversion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from qpx.cli.main import qpx_main
+from qpx.converters.quantms_msstats import QuantmsMsstatsConverter
+from qpx.core.data import FeatureSchema
+
+_TMT6_LABELS = ["TMT126", "TMT127", "TMT128", "TMT129", "TMT130", "TMT131"]
+
+
+def _write_sdrf(path: Path, runs: dict[str, list[str]]) -> None:
+    records = []
+    sample_number = 1
+    for run_file, labels in runs.items():
+        for label in labels:
+            records.append(
+                {
+                    "source name": f"S{sample_number}",
+                    "comment[data file]": run_file,
+                    "comment[label]": label,
+                    "characteristics[organism]": "Homo sapiens",
+                    "characteristics[organism part]": "cell",
+                    "characteristics[biological replicate]": str(sample_number),
+                }
+            )
+            sample_number += 1
+    pd.DataFrame(records).to_csv(path, sep="\t", index=False)
+
+
+def _convert(msstats: Path, sdrf: Path, output: Path, prefix: str = "test") -> Path:
+    QuantmsMsstatsConverter(max_cpus=24).convert(
+        msstats_file=msstats,
+        sdrf_file=sdrf,
+        output_folder=output,
+        output_prefix=prefix,
+        project_accession="PXDTEST",
+        batch_size=2,
+    )
+    return output / f"{prefix}.feature.parquet"
+
+
+def test_lfq_conversion_writes_only_supported_views(tmp_path):
+    """LFQ rows map through SDRF without fabricating PSM or PG output."""
+    sdrf = tmp_path / "lfq.sdrf.tsv"
+    msstats = tmp_path / "lfq_msstats_in.csv"
+    output = tmp_path / "output"
+    _write_sdrf(
+        sdrf,
+        {
+            "run1.mzML": ["label free sample"],
+            "run2.mzML": ["label free sample"],
+        },
+    )
+    pd.DataFrame(
+        [
+            {
+                "ProteinName": "P1",
+                "PeptideSequence": "PEPTIDEK",
+                "PrecursorCharge": 2,
+                "Run": 1,
+                "Intensity": 100.0,
+                "Reference": "run1.mzML",
+            },
+            {
+                "ProteinName": "P1;P2",
+                "PeptideSequence": "PEPTM(Oxidation)IDEK",
+                "PrecursorCharge": 3,
+                "Run": 2,
+                "Intensity": 200.0,
+                "Reference": "run2.mzML",
+            },
+        ]
+    ).to_csv(msstats, index=False)
+
+    feature_path = _convert(msstats, sdrf, output)
+    table = pq.read_table(feature_path)
+
+    assert table.num_rows == 2
+    assert not FeatureSchema.validate(table)
+    assert table.column("run_file_name").to_pylist() == ["run1", "run2"]
+    assert table.column("peptidoform").to_pylist() == [
+        "PEPTIDEK",
+        "PEPTM[UNIMOD:35]IDEK",
+    ]
+    assert table.column("unique").to_pylist() == [True, False]
+    assert [values[0]["label"] for values in table.column("intensities").to_pylist()] == ["LFQ", "LFQ"]
+    assert sum(values[0]["intensity"] for values in table.column("intensities").to_pylist()) == 300.0
+    assert len(set(table.column("feature_id").to_pylist())) == 2
+
+    expected = {
+        "test.feature.parquet",
+        "test.sample.parquet",
+        "test.run.parquet",
+        "test.dataset.parquet",
+        "test.provenance.parquet",
+        "test.ontology.parquet",
+    }
+    assert {path.name for path in output.iterdir()} == expected
+    assert not (output / "test.psm.parquet").exists()
+    assert not (output / "test.pg.parquet").exists()
+
+    metadata = pq.ParquetFile(feature_path).metadata.metadata
+    assert metadata[b"identity_composite"] == b"run_file_name,peptidoform,charge,rt,scan"
+    provenance = pq.read_table(output / "test.provenance.parquet").to_pylist()
+    config = json.loads(provenance[1]["config"])
+    assert config["protein_aggregation"] == "not performed"
+
+
+def test_tmt_channels_collapse_without_merging_locations(tmp_path):
+    """TMT channel rows collapse per scan/RT while distinct Features remain separate."""
+    sdrf = tmp_path / "tmt.sdrf.tsv"
+    msstats = tmp_path / "tmt_msstats_in.csv"
+    output = tmp_path / "output"
+    _write_sdrf(sdrf, {"plex.mzML": _TMT6_LABELS})
+
+    rows = []
+    for scan, rt in ((1, 100.0), (2, 101.0)):
+        for channel in range(1, 7):
+            rows.append(
+                {
+                    "ProteinName": "P1;P2",
+                    "PeptideSequence": ".(TMT6plex)PEPTIDEK",
+                    "Charge": 2,
+                    "Channel": channel,
+                    "RetentionTime": rt,
+                    "Run": 1,
+                    "Intensity": scan * 100 + channel,
+                    "Reference": f"plex.mzML_controllerType=0 controllerNumber=1 scan={scan}",
+                }
+            )
+    pd.DataFrame(rows).to_csv(msstats, index=False)
+
+    table = pq.read_table(_convert(msstats, sdrf, output))
+
+    assert table.num_rows == 2
+    assert table.column("peptidoform").to_pylist() == [
+        "[UNIMOD:737]-PEPTIDEK",
+        "[UNIMOD:737]-PEPTIDEK",
+    ]
+    assert table.column("scan").to_pylist() == [[1], [2]]
+    assert table.column("rt").to_pylist() == [100.0, 101.0]
+    intensities = table.column("intensities").to_pylist()
+    assert [[entry["label"] for entry in values] for values in intensities] == [
+        _TMT6_LABELS,
+        _TMT6_LABELS,
+    ]
+    assert sum(entry["intensity"] for values in intensities for entry in values) == sum(row["Intensity"] for row in rows)
+
+
+def test_run_reference_conflict_is_rejected(tmp_path):
+    """Run and Reference may not resolve to different SDRF data files."""
+    sdrf = tmp_path / "test.sdrf.tsv"
+    msstats = tmp_path / "test.csv"
+    _write_sdrf(
+        sdrf,
+        {
+            "run1.mzML": ["label free sample"],
+            "run2.mzML": ["label free sample"],
+        },
+    )
+    pd.DataFrame(
+        [
+            {
+                "ProteinName": "P1",
+                "PeptideSequence": "PEPTIDEK",
+                "Charge": 2,
+                "Run": "run1",
+                "Reference": "run2.mzML",
+                "Intensity": 100.0,
+            }
+        ]
+    ).to_csv(msstats, index=False)
+
+    with pytest.raises(ValueError, match="Run and Reference to different SDRF files"):
+        _convert(msstats, sdrf, tmp_path / "output")
+
+
+def test_unmapped_run_is_rejected(tmp_path):
+    """Every quantitative row must resolve to a run declared by the SDRF."""
+    sdrf = tmp_path / "test.sdrf.tsv"
+    msstats = tmp_path / "test.csv"
+    _write_sdrf(sdrf, {"run1.mzML": ["label free sample"]})
+    pd.DataFrame(
+        [
+            {
+                "ProteinName": "P1",
+                "PeptideSequence": "PEPTIDEK",
+                "Charge": 2,
+                "Run": "missing-run",
+                "Intensity": 100.0,
+            }
+        ]
+    ).to_csv(msstats, index=False)
+
+    with pytest.raises(ValueError, match="cannot be mapped to an SDRF data file"):
+        _convert(msstats, sdrf, tmp_path / "output")
+
+
+@pytest.mark.parametrize("intensity", ["NaN", "inf", "-inf", "not-a-number"])
+def test_nonfinite_intensity_is_rejected(tmp_path, intensity):
+    """Invalid and non-finite quantities must not enter QPX output."""
+    sdrf = tmp_path / "test.sdrf.tsv"
+    msstats = tmp_path / "test.csv"
+    _write_sdrf(sdrf, {"run1.mzML": ["label free sample"]})
+    pd.DataFrame(
+        [
+            {
+                "ProteinName": "P1",
+                "PeptideSequence": "PEPTIDEK",
+                "Charge": 2,
+                "Run": "run1",
+                "Intensity": intensity,
+            }
+        ]
+    ).to_csv(msstats, index=False)
+
+    with pytest.raises(ValueError, match="contain invalid required values"):
+        _convert(msstats, sdrf, tmp_path / "output")
+
+
+def test_conflicting_feature_channel_intensity_is_rejected(tmp_path):
+    """A Feature/channel key cannot silently select one of two intensities."""
+    sdrf = tmp_path / "test.sdrf.tsv"
+    msstats = tmp_path / "test.csv"
+    _write_sdrf(sdrf, {"run1.mzML": ["label free sample"]})
+    base = {
+        "ProteinName": "P1",
+        "PeptideSequence": "PEPTIDEK",
+        "Charge": 2,
+        "Run": "run1",
+        "Reference": "run1.mzML",
+    }
+    pd.DataFrame([{**base, "Intensity": 100.0}, {**base, "Intensity": 101.0}]).to_csv(msstats, index=False)
+
+    with pytest.raises(ValueError, match="conflicting intensity values"):
+        _convert(msstats, sdrf, tmp_path / "output")
+
+
+def test_cli_quantms_msstats(tmp_path):
+    """The public CLI exposes and runs the QuantMS MSstats converter."""
+    sdrf = tmp_path / "test.sdrf.tsv"
+    msstats = tmp_path / "test.csv"
+    output = tmp_path / "output"
+    _write_sdrf(sdrf, {"run1.mzML": ["label free sample"]})
+    pd.DataFrame(
+        [
+            {
+                "ProteinName": "P1",
+                "PeptideSequence": "PEPTIDEK",
+                "Charge": 2,
+                "Run": "run1",
+                "Intensity": 100.0,
+            }
+        ]
+    ).to_csv(msstats, index=False)
+
+    result = CliRunner().invoke(
+        qpx_main,
+        [
+            "convert",
+            "quantms-msstats",
+            "--msstats-file",
+            str(msstats),
+            "--sdrf-file",
+            str(sdrf),
+            "--output-folder",
+            str(output),
+            "--output-prefix",
+            "cli",
+            "--max-cpus",
+            "24",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (output / "cli.feature.parquet").exists()

--- a/tests/converters/test_quantms_msstats_converter.py
+++ b/tests/converters/test_quantms_msstats_converter.py
@@ -115,6 +115,37 @@ def test_lfq_conversion_writes_only_supported_views(tmp_path):
     assert config["protein_aggregation"] == "not performed"
 
 
+def test_quoted_comma_after_csv_sniff_sample_is_parsed(tmp_path):
+    """A late quoted comma must not change the inferred CSV dialect."""
+    sdrf = tmp_path / "lfq.sdrf.tsv"
+    msstats = tmp_path / "lfq_msstats_in.csv"
+    output = tmp_path / "output"
+    _write_sdrf(sdrf, {"run1.mzML": ["label free sample"]})
+
+    common = {
+        "ProteinName": "P1",
+        "PeptideSequence": "PEPTIDEK",
+        "Charge": 2,
+        "Run": "run1",
+        "Intensity": 100.0,
+    }
+    rows = [common] * 20_481
+    rows.append(
+        {
+            **common,
+            "ProteinName": "Interleukin-8,",
+            "PeptideSequence": "QUOTEDK",
+            "Intensity": 200.0,
+        }
+    )
+    pd.DataFrame(rows).to_csv(msstats, index=False)
+
+    table = pq.read_table(_convert(msstats, sdrf, output))
+
+    assert table.num_rows == 2
+    assert "Interleukin-8," in table.column("anchor_protein").to_pylist()
+
+
 def test_tmt_channels_collapse_without_merging_locations(tmp_path):
     """TMT channel rows collapse per scan/RT while distinct Features remain separate."""
     sdrf = tmp_path / "tmt.sdrf.tsv"


### PR DESCRIPTION
This pull request adds support for converting QuantMS-generated MSstats input files (plus SDRF metadata) into QPX format. It introduces a new CLI subcommand, integrates the converter into the codebase, and provides comprehensive documentation and field mapping updates. The main focus is on enabling streamlined, standards-compliant import of QuantMS MSstats data, with robust handling of label mapping, feature collapsing, and provenance tracking.

The most important changes are:

**New QuantMS MSstats Converter Functionality:**
- Added a new CLI subcommand `qpxc convert quantms-msstats` that converts QuantMS-generated `*_msstats_in.csv` files and their authoritative SDRF into QPX Feature, Sample, Run, Dataset, Ontology, and Provenance views, with appropriate handling of LFQ/TMT/iTRAQ labels and robust feature/channel collapsing. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR26) [[2]](diffhunk://#diff-52efb50b14aca0f9d74700c212c4ed051f2dbb763896192a2590b8e8bbd87bc0R15) [[3]](diffhunk://#diff-52efb50b14aca0f9d74700c212c4ed051f2dbb763896192a2590b8e8bbd87bc0R990-R1093) [[4]](diffhunk://#diff-3d835992ab841f423d26151ff77ab9e9369f48a5612a058586f0fc3de4863883R1-R155)

**Codebase Integration:**
- Registered the new converter and its feature adapter in the `qpx.converters` package, including an explicit module and `__all__` export for discoverability and import convenience. [[1]](diffhunk://#diff-d32a786c76407000ba6740190f13d1549c3bbf408a226cb187c79e2e4153f3c9R29-R30) [[2]](diffhunk://#diff-d32a786c76407000ba6740190f13d1549c3bbf408a226cb187c79e2e4153f3c9R66-R68) [[3]](diffhunk://#diff-dc480052b055085bc036cdbc61cf725f667572f49e7b61b9c64bc5152a01177aR1-R6)

**Documentation and Guide Updates:**
- Updated the user guide and CLI documentation to describe the new `quantms-msstats` command, including usage, parameters, and output behavior. [[1]](diffhunk://#diff-345329da6dec64f43706873c72fb1e1277dcae9e661aa069c4a44883d05d0c52R115) [[2]](diffhunk://#diff-345329da6dec64f43706873c72fb1e1277dcae9e661aa069c4a44883d05d0c52R723-R766)
- Updated the `README.md` and converter coverage/specification pages to reflect the new converter and its supported QPX data views and input requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L251-R251) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R262) [[3]](diffhunk://#diff-6306517cd8d5feb33d5cee13944771afba508f031b18f5afd3095dcf6a5a0048R17) [[4]](diffhunk://#diff-6306517cd8d5feb33d5cee13944771afba508f031b18f5afd3095dcf6a5a0048R39) [[5]](diffhunk://#diff-6306517cd8d5feb33d5cee13944771afba508f031b18f5afd3095dcf6a5a0048R54)

**Field Mapping and Standardization:**
- Extended the QPX tool field mapping documentation to include QuantMS MSstats, detailing how MSstats columns map to QPX feature fields, including handling of sequence, charge, intensities, and run/channel resolution.

These changes collectively enable streamlined, standards-compliant import of QuantMS MSstats data into QPX, with clear user guidance and robust provenance tracking.