### PR TITLE
Preserve PSM protein accessions in OpenMS consensus

### DIFF
--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -80,6 +80,20 @@ def _pep_of(hit) -> float | None:
     return None
 
 
+def _protein_accessions(hits) -> list[str] | None:
+    """Return the distinct protein evidence carried by all collapsed hits."""
+    accessions: list[str] = []
+    seen: set[str] = set()
+    for hit in hits:
+        for evidence in hit.getPeptideEvidences():
+            raw = evidence.getProteinAccession()
+            accession = raw.decode() if isinstance(raw, (bytes, bytearray)) else str(raw or "")
+            if accession and accession not in seen:
+                seen.add(accession)
+                accessions.append(accession)
+    return accessions or None
+
+
 def _append_unique_score(additional_scores: list[dict], name: str, value: float, higher_better: bool) -> None:
     """Append a score, disambiguating the name if it already occurs.
 
@@ -295,6 +309,7 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None) -> lis
                 "posterior_error_probability": pep,
                 "additional_scores": additional_scores or None,
                 "is_decoy": is_decoy,
+                "protein_accessions": _protein_accessions(hits),
             }
         )
     return records

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -383,6 +383,8 @@ def test_unassigned_isobaric_run_streaming_matches_pyopenms(tmp_path):
 
     for view in ("feature", "psm", "pg"):
         assert canon(wp[view]) == canon(ws[view]), f"{view} differs between pyopenms and streaming"
+    psm_accessions = pq.read_table(str(wp["psm"]), columns=["protein_accessions"]).column(0).to_pylist()
+    assert psm_accessions and all(accessions == ["P12345"] for accessions in psm_accessions)
 
 
 def test_consensus_psm_multihit_keeps_lowest_pep_and_merges_scores(tmp_path):
@@ -394,8 +396,12 @@ def test_consensus_psm_multihit_keeps_lowest_pep_and_merges_scores(tmp_path):
     # 1.0e-03 -> the second must win (lower PEP) even though it is not first.
     xml = _TMT_CONSENSUSXML.replace('score="0" sequence="PEPTIDEK"', 'score="1.5" sequence="PEPTIDEK"')
     xml = xml.replace('value="1.0e-03"', 'value="5.0e-02"')
+    xml = xml.replace(
+        "    </ProteinIdentification>",
+        '      <ProteinHit id="PH_1" accession="P67890" score="0" sequence=""></ProteinHit>\n    </ProteinIdentification>',
+    )
     second_hit = (
-        '        <PeptideHit score="2.7" sequence="PEPTIDEK" charge="2" protein_refs="PH_0">\n'
+        '        <PeptideHit score="2.7" sequence="PEPTIDEK" charge="2" protein_refs="PH_1">\n'
         '          <UserParam type="string" name="target_decoy" value="target"/>\n'
         '          <UserParam type="float" name="Posterior Error Probability_score" value="1.0e-03"/>\n'
         "        </PeptideHit>"
@@ -417,6 +423,7 @@ def test_consensus_psm_multihit_keeps_lowest_pep_and_merges_scores(tmp_path):
     score_values = [s["score_value"] for s in (rec["additional_scores"] or [])]
     assert any(v == pytest.approx(2.7) for v in score_values)  # kept hit's own search score
     assert any(v == pytest.approx(1.5) for v in score_values)  # the other engine's search score preserved
+    assert rec["protein_accessions"] == ["P12345", "P67890"]
 
 
 def test_consensus_psm_distinct_peptidoforms_both_emitted(tmp_path):


### PR DESCRIPTION
This pull request adds support for extracting and recording the distinct protein accessions associated with each PSM (peptide-spectrum match) during OpenMS consensus conversion. It introduces a helper function to collect protein accessions from peptide evidences, updates the main adapter to include this information in output records, and extends the test suite to verify correct behavior for both single- and multi-protein cases.

**Feature: Protein accession extraction and propagation**
- Added a new helper function `_protein_accessions` in `psm_adapter.py` to extract unique protein accessions from all peptide evidences in a set of hits, ensuring correct handling of byte and string types.
- Updated `psm_records_for_pid` in `psm_adapter.py` to include a `protein_accessions` field in each output record, populated using the new helper.

**Testing: Ensuring correct accession extraction**
- Enhanced the test `test_openms_consensus.py` to assert that all PSMs have the expected protein accessions, both for single-accession and multi-accession scenarios. [[1]](diffhunk://#diff-2edb205e3fb9daa874801f0b381fc6e7f35a63e4a8c9e8937609a7b2de46cda4R386-R387) [[2]](diffhunk://#diff-2edb205e3fb9daa874801f0b381fc6e7f35a63e4a8c9e8937609a7b2de46cda4R426)
- Modified test XML and peptide hit setup to cover multi-protein cases by injecting an additional protein hit and updating peptide hit references in the test for multi-hit consensus PSMs.