### PR TITLE
fix(integrity): checksum Hive-partitioned files and key them relative to the dataset root

### DIFF
--- a/qpx/dataset.py
+++ b/qpx/dataset.py
@@ -1083,9 +1083,12 @@ class Dataset:
         path = Path(self.path)
         checksums, row_counts, sizes = {}, {}, {}
 
-        # Parquet files
-        for f in sorted(path.glob("*.parquet")):
-            name = f.name
+        # Parquet files. rglob, not glob: Hive-partitioned structures live in
+        # subdirectories (feature/run_file_name=.../part-0.parquet) and a
+        # non-recursive scan silently left them unchecksummed, so the integrity
+        # record claimed to cover data it had never read (bigbio/qpx#287).
+        for f in sorted(path.rglob("*.parquet")):
+            name = f.relative_to(path).as_posix()
             sizes[name] = f.stat().st_size
             sha = hashlib.sha256()
             with open(f, "rb") as fh:
@@ -1098,8 +1101,8 @@ class Dataset:
                 row_counts[name] = -1
 
         # H5AD files (AnnData from downstream tools)
-        for f in sorted(path.glob("*.h5ad")):
-            name = f.name
+        for f in sorted(path.rglob("*.h5ad")):
+            name = f.relative_to(path).as_posix()
             sizes[name] = f.stat().st_size
             sha = hashlib.sha256()
             with open(f, "rb") as fh:
@@ -1158,7 +1161,15 @@ class Dataset:
         for name, expected_sha in stored_checksums.items():
             if name.endswith(dataset_suffix):
                 continue
-            fpath = path / name
+            # Keys are dataset-root-relative POSIX paths. Resolve and confirm the
+            # result stays inside the dataset before reading it, so a crafted or
+            # corrupted key cannot walk outside the directory being verified.
+            fpath = (path / name).resolve()
+            try:
+                fpath.relative_to(path.resolve())
+            except ValueError:
+                errors.append(f"Integrity entry escapes the dataset directory: {name}")
+                continue
             if not fpath.exists():
                 errors.append(f"Missing file: {name}")
                 continue

--- a/tests/integration/test_integrity.py
+++ b/tests/integration/test_integrity.py
@@ -110,3 +110,56 @@ class TestVerifyIntegrity:
         result = ds.verify_integrity()
         assert any("No dataset.parquet" in e for e in result["errors"])
         ds.close()
+
+
+class TestPartitionedIntegrity:
+    """Integrity must cover Hive-partitioned structures too.
+
+    compute_integrity() used a non-recursive glob, so files under
+    feature/run_file_name=.../part-0.parquet were never checksummed: the record
+    claimed to cover data it had never read (bigbio/qpx#287).
+    """
+
+    @staticmethod
+    def _partition(dataset_dir, tmp_path):
+        """Copy a dataset and rewrite its feature file as a partitioned directory."""
+        import shutil
+
+        import pyarrow.parquet as pq
+
+        out = tmp_path / "partitioned"
+        shutil.copytree(dataset_dir, out)
+        original = next(out.glob("*.feature.parquet"))
+        table = pq.read_table(original)
+        part_dir = out / "feature" / "run_file_name=run_a"
+        part_dir.mkdir(parents=True)
+        pq.write_table(table, part_dir / "part-0.parquet")
+        original.unlink()
+        return out, (part_dir / "part-0.parquet")
+
+    def test_partitioned_files_are_checksummed(self, dataset_dir, tmp_path):
+        import qpx
+
+        out, part_file = self._partition(dataset_dir, tmp_path)
+        ds = qpx.open_dataset(str(out))
+        result = ds.compute_integrity()
+        ds.close()
+
+        key = part_file.relative_to(out).as_posix()
+        assert key in result["file_checksums"], f"partitioned file not checksummed; keys were {sorted(result['file_checksums'])}"
+        assert result["file_sizes_bytes"][key] == part_file.stat().st_size
+        assert result["file_row_counts"][key] > 0
+
+    def test_keys_are_root_relative_posix_paths(self, dataset_dir, tmp_path):
+        """Keys must be relative to the dataset root so the record stays portable."""
+        import qpx
+
+        out, _ = self._partition(dataset_dir, tmp_path)
+        ds = qpx.open_dataset(str(out))
+        result = ds.compute_integrity()
+        ds.close()
+
+        for key in result["file_checksums"]:
+            assert not key.startswith("/"), f"absolute path leaked into the record: {key}"
+            assert "\\" not in key, f"non-POSIX separator in the record: {key}"
+            assert (out / key).exists(), f"key does not resolve under the dataset root: {key}"


### PR DESCRIPTION
Closes #287.

## The bug

```python
for f in sorted(path.glob("*.parquet")):     # non-recursive
    name = f.name
```

The project supports Hive-partitioned structures, so `feature/run_file_name=.../part-0.parquet` was never scanned. A modified or missing partition passed `verify_integrity()` silently — the record asserted coverage of data it had never read, which is worse than having no record at all.

## The fix

- `rglob("*.parquet")` instead of `glob`, same for the `.h5ad` scan.
- Keys become **dataset-root-relative POSIX paths** (`feature/run_file_name=run_a/part-0.parquet`) rather than bare filenames, so the record is portable across machines and platforms and can distinguish two partitions with the same basename.
- `verify_integrity()` resolves each key and confirms the result stays inside the dataset directory before reading it, so a crafted or corrupted key cannot walk outside the tree under verification.

## Tests

`TestPartitionedIntegrity` rewrites a fixture's feature file as a partitioned directory and asserts the part file is checksummed, sized and row-counted. Without the fix:

```
AssertionError: partitioned file not checksummed; keys were
['exp.dataset.parquet', 'exp.pg.parquet', 'exp.run.parquet', 'exp.sample.parquet']
```

A second test pins the key format — no absolute paths, no backslashes, every key resolving under the dataset root.

Full suite: **868 passed**. pre-commit clean.

## Compatibility

Records written before this change key single-file structures by bare filename, which is identical to the new root-relative form for files at the dataset root — so existing records still verify. Only partitioned datasets change, and those were not covered at all before.
