### PR TITLE
fix(writers): stage parquet writes and publish them atomically

### DIFF
--- a/qpx/writers/base.py
+++ b/qpx/writers/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import os
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Sequence
@@ -192,6 +193,12 @@ class BaseWriter:
         identity_composite: Optional[Sequence[str]] = None,
     ):
         self._path = Path(path)
+        # Bytes go to a sibling temp file and are moved onto _path only after a
+        # clean close. Opening the destination directly meant a converter that
+        # failed mid-run replaced an existing valid file with a truncated one and
+        # there was no way back (bigbio/qpx#288). A sibling keeps the rename on
+        # the same filesystem, so os.replace is atomic.
+        self._staging_path = self._path.with_name(f".{self._path.name}.{os.getpid()}.tmp")
         self._compression = compression
         self._batch_size = batch_size
         self._buffer: list[dict] = []
@@ -470,9 +477,38 @@ class BaseWriter:
         if self._writer:
             self._writer.close()
             self._writer = None
-        if validate and wrote_file:
-            self._validate_identity_uniqueness()
-            self._validate_referential()
+        if not wrote_file:
+            self._discard_staged()
+            return
+        if not validate:
+            # The body raised: leave whatever was already at the destination
+            # untouched and drop the partial file.
+            self._discard_staged()
+            return
+        # Validate the staged file, then publish it atomically. Validation runs
+        # BEFORE the rename so a file that fails its checks never reaches the
+        # destination.
+        self._validate_identity_uniqueness()
+        self._validate_referential()
+        self._promote_staged()
+
+    @property
+    def _validation_path(self) -> Path:
+        """Where the bytes currently live: the staging file until it is promoted."""
+        return self._staging_path if self._staging_path.exists() else self._path
+
+    def _promote_staged(self) -> None:
+        """Atomically move the staged file onto the destination."""
+        if not self._staging_path.exists():
+            return
+        os.replace(self._staging_path, self._path)
+
+    def _discard_staged(self) -> None:
+        """Remove the staged file, leaving any existing destination intact."""
+        try:
+            self._staging_path.unlink(missing_ok=True)
+        except OSError as exc:  # pragma: no cover - best effort cleanup
+            logger.warning("Could not remove staging file %s: %s", self._staging_path, exc)
 
     def _validate_referential(self) -> None:
         """Warn on pg referential / run-disjointness problems over the full file.
@@ -488,7 +524,7 @@ class BaseWriter:
         """
         if getattr(self._schema_class, "view_name", None) != "pg":
             return
-        issues = pg_referential_issues_from_parquet(str(self._path), self._schema_class.view_name, "warning")
+        issues = pg_referential_issues_from_parquet(str(self._validation_path), self._schema_class.view_name, "warning")
         for issue in issues:
             logger.warning("pg referential check '%s': %s", issue.check, issue.message)
 
@@ -510,7 +546,7 @@ class BaseWriter:
         )
         connection = duckdb.connect()
         try:
-            total_count, unique_count, null_count = connection.execute(query, [str(self._path)]).fetchone()
+            total_count, unique_count, null_count = connection.execute(query, [str(self._validation_path)]).fetchone()
         finally:
             connection.close()
 
@@ -545,8 +581,9 @@ class BaseWriter:
 
     def _ensure_writer(self):
         if self._writer is None:
+            self._staging_path.parent.mkdir(parents=True, exist_ok=True)
             self._writer = pq.ParquetWriter(
-                str(self._path),
+                str(self._staging_path),
                 schema=self.arrow_schema,
                 **self._parquet_write_options(),
             )

--- a/tests/unit/test_writers.py
+++ b/tests/unit/test_writers.py
@@ -248,3 +248,62 @@ def test_pg_write_dataframe_explodes_intensities(tmp_path):
     assert table.num_rows == 2, "intensities list should explode into one row per label"
     assert set(table.column("label").to_pylist()) == {"TMT126", "TMT127N"}
     assert set(table.column("intensity").to_pylist()) == {5000.0, 6000.0}
+
+
+class TestAtomicWrites:
+    """A failed conversion must not destroy an existing valid file.
+
+    The writer used to open the destination directly, so a converter that died
+    mid-run left a truncated file where a good one had been (bigbio/qpx#288).
+    This is not hypothetical: a 5,798-run DIA conversion was killed three times
+    mid-write, twice by a full filesystem.
+    """
+
+    # batch_size defaults to 1,000,000, so a single buffered record never reaches
+    # disk and nothing is at risk. Flush on every record so the writer really has
+    # an open file when the failure lands — that is the situation being tested.
+    BATCH = 1
+
+    @classmethod
+    def _write_one(cls, path):
+        with FeatureWriter(str(path), batch_size=cls.BATCH) as w:
+            w.write_batch([make_feature_record()])
+
+    def test_existing_file_survives_a_failed_write(self, tmp_path):
+        path = tmp_path / "x.feature.parquet"
+        self._write_one(path)
+        good_bytes = path.read_bytes()
+
+        with pytest.raises(RuntimeError):
+            with FeatureWriter(str(path), batch_size=self.BATCH) as w:
+                w.write_batch([make_feature_record()])
+                raise RuntimeError("converter blew up mid-run")
+
+        assert path.read_bytes() == good_bytes, "the previous valid file was modified"
+        assert parquet_row_count(str(path)) == 1
+
+    def test_no_staging_files_are_left_behind(self, tmp_path):
+        path = tmp_path / "y.feature.parquet"
+        self._write_one(path)
+        with pytest.raises(RuntimeError):
+            with FeatureWriter(str(path), batch_size=self.BATCH) as w:
+                w.write_batch([make_feature_record()])
+                raise RuntimeError("boom")
+
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name != path.name]
+        assert leftovers == [], f"staging files left behind: {leftovers}"
+
+    def test_successful_write_publishes_to_the_destination(self, tmp_path):
+        path = tmp_path / "z.feature.parquet"
+        self._write_one(path)
+        assert path.exists()
+        assert parquet_row_count(str(path)) == 1
+        assert [p.name for p in tmp_path.iterdir()] == [path.name]
+
+    def test_failed_write_leaves_no_file_when_there_was_none(self, tmp_path):
+        path = tmp_path / "fresh.feature.parquet"
+        with pytest.raises(RuntimeError):
+            with FeatureWriter(str(path), batch_size=self.BATCH) as w:
+                w.write_batch([make_feature_record()])
+                raise RuntimeError("boom")
+        assert not path.exists(), "a partial file was published for a failed run"


### PR DESCRIPTION
Closes #288.

## The bug

`ParquetWriter` opened the destination path directly:

```python
self._writer = pq.ParquetWriter(str(self._path), ...)
```

so a converter that failed partway through had already replaced an existing valid file with a truncated one, and there was no rollback.

This is not hypothetical. A 5,798-run DIA conversion (PXD030304) was killed three times mid-write — twice on `Errno 122 Disk quota exceeded` inside pyarrow's `write_table`, once OOM-killed. Each attempt left a partial `feature.parquet` where a good one had been.

## The fix

Write to a sibling temp file (`.<name>.<pid>.tmp`) and `os.replace()` it onto the destination only after a clean close. A sibling keeps the rename on the same filesystem, so the swap is atomic. On failure the staged file is removed and whatever was at the destination is untouched.

Validation now reads the **staged** file and runs **before** the rename, via a small `_validation_path` property — so a file that fails its own identity or referential checks never reaches the destination either. That is a slight tightening of previous behaviour, where a file failing `_validate_identity_uniqueness` was already sitting at the destination by the time the check ran.

Because this lives in `BaseWriter`, every converter and `Dataset.save_structure()` gets it at once.

## Tests

Four tests in `TestAtomicWrites`:

- an existing valid file is byte-identical after a failed write;
- no staging files are left behind;
- a successful write publishes to the destination and nothing else;
- a failed write on a fresh path publishes nothing.

**Worth noting how these tests were made honest.** My first version passed against the *unfixed* code, because `batch_size` defaults to 1,000,000 — a single buffered record never reaches disk, so the destination was never at risk and the test proved nothing. They now use `batch_size=1` to force a real flush, which puts an open file handle on the destination before the failure. With that, two of the four fail against `dev`:

```
AssertionError: the previous valid file was modified
```

and all four pass with the fix.

Full suite: **870 passed**. pre-commit clean.
