### PR TITLE
fix(cli): derive structure choices from the canonical registry

### DIFF
--- a/qpx/cli/query.py
+++ b/qpx/cli/query.py
@@ -17,6 +17,8 @@ from typing import Optional
 
 import click
 
+from qpx.dataset import Dataset
+
 logger = logging.getLogger("qpx.cli.query")
 
 # Shared option for the dataset path
@@ -28,17 +30,9 @@ _dataset_path_option = click.option(
 )
 
 # Valid QPX data structure names
-_VALID_STRUCTURES = [
-    "psm",
-    "feature",
-    "pg",
-    "mz",
-    "sample",
-    "run",
-    "dataset",
-    "ontology",
-    "provenance",
-]
+# Derived from the canonical registry so a new structure cannot be supported
+# by the library while the CLI silently rejects it (bigbio/qpx#289).
+_VALID_STRUCTURES = Dataset.structure_names()
 
 
 # ---------------------------------------------------------------------------

--- a/qpx/cli/validate.py
+++ b/qpx/cli/validate.py
@@ -17,19 +17,13 @@ from typing import Optional
 
 import click
 
+from qpx.dataset import Dataset
+
 logger = logging.getLogger("qpx.cli.validate")
 
-_VALID_STRUCTURES = [
-    "psm",
-    "feature",
-    "pg",
-    "mz",
-    "sample",
-    "run",
-    "dataset",
-    "ontology",
-    "provenance",
-]
+# Derived from the canonical registry so a new structure cannot be supported
+# by the library while the CLI silently rejects it (bigbio/qpx#289).
+_VALID_STRUCTURES = Dataset.structure_names()
 
 
 @click.command("validate")

--- a/qpx/dataset.py
+++ b/qpx/dataset.py
@@ -66,6 +66,17 @@ class Dataset:
         "pepmap": (PepMap, ".pepmap.parquet"),
     }
 
+    @classmethod
+    def structure_names(cls) -> list[str]:
+        """Every structure name QPX knows about, in registry order.
+
+        The single source of truth for anything that needs to enumerate
+        structures — CLI choices in particular. Hand-maintained copies drifted:
+        ``pepmap`` was registered here and exposed on the API while both CLIs
+        rejected it (bigbio/qpx#289).
+        """
+        return list(cls._STRUCTURE_REGISTRY)
+
     def __init__(
         self,
         path: str | Path,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -294,3 +294,32 @@ class TestOntologyCLI:
         runner = CliRunner()
         result = runner.invoke(qpx_main, ["ontology", "build", "--help"])
         _assert_help(result, "--source", "--all-sources")
+
+
+class TestStructureChoicesMatchTheRegistry:
+    """CLI structure choices must be derived, not hand-maintained.
+
+    pepmap was registered in Dataset._STRUCTURE_REGISTRY and exposed on the
+    public API while both CLIs rejected it, because each kept its own literal
+    list (bigbio/qpx#289).
+    """
+
+    def test_validate_offers_every_registered_structure(self):
+        from qpx.cli.validate import _VALID_STRUCTURES
+        from qpx.dataset import Dataset
+
+        assert set(_VALID_STRUCTURES) == set(Dataset._STRUCTURE_REGISTRY)
+
+    def test_query_offers_every_registered_structure(self):
+        from qpx.cli.query import _VALID_STRUCTURES
+        from qpx.dataset import Dataset
+
+        assert set(_VALID_STRUCTURES) == set(Dataset._STRUCTURE_REGISTRY)
+
+    def test_pepmap_is_accepted(self):
+        """The structure that exposed the drift."""
+        from qpx.cli.query import _VALID_STRUCTURES as query_structures
+        from qpx.cli.validate import _VALID_STRUCTURES as validate_structures
+
+        assert "pepmap" in validate_structures
+        assert "pepmap" in query_structures


### PR DESCRIPTION
Closes #289.

## The drift

`pepmap` is a first-class structure:

- `Dataset._STRUCTURE_REGISTRY` — `"pepmap": (PepMap, ".pepmap.parquet")`
- `Dataset.pepmap` property
- `"pepmap": ("PepMapWriter", ".pepmap.parquet")` in the writer registry

but **both** CLIs kept their own literal list and neither included it, so `qpx validate --structure pepmap` and `qpx query --structure pepmap` rejected a structure the library fully supports.

Three hand-maintained copies of the same list, free to drift independently — and one already had.

## The fix

Add `Dataset.structure_names()` next to the registry and have both CLIs derive `_VALID_STRUCTURES` from it. A new structure now reaches the CLI automatically.

## Tests

Two tests assert each CLI's choices equal the registry exactly, plus one naming `pepmap` specifically as the structure that exposed the problem. Against `dev` the set comparison fails:

```
AssertionError: assert {'dataset', '...venance', ...} == {'dataset', '...p', 'pg', ...}
```

Full suite: **897 passed** (unit + cli + converters + integration). pre-commit clean.
