### PR TITLE
fix: address review findings on the writer staging and OpenMS fields

### DIFF
--- a/qpx/converters/openms_consensus/feature_adapter.py
+++ b/qpx/converters/openms_consensus/feature_adapter.py
@@ -30,20 +30,20 @@ _QVALUE_SCORE_TYPES = ("q-value", "qvalue", "fdr")
 def mass_error_ppm(calculated_mz, observed_mz) -> float | None:
     """Relative precursor mass error in ppm, or ``None`` when it is not measurable.
 
-    Only meaningful when *observed_mz* is a real measurement. A producer that has
-    no measured m/z and echoes the theoretical value back would yield a constant
-    0.0 ppm, which reads as perfect accuracy rather than as missing data — so an
-    exact match is reported as ``None`` rather than as a measured zero.
+    ``None`` is reserved for values that are absent or not measurable. Both m/z
+    values must be positive: ``feature_records_for_cf`` substitutes 0.0 when the
+    ConsensusFeature carries no m/z, and treating that as a measurement would
+    report roughly -1e6 ppm instead of "not measured".
 
-    Both m/z values must be positive. ``feature_records_for_cf`` substitutes 0.0
-    when the ConsensusFeature carries no m/z, and treating that as a measurement
-    would report roughly -1e6 ppm instead of "not measured".
+    An exact match returns ``0.0``, not ``None``. The OpenMS adapters are this
+    helper's only callers and their ``observed_mz`` is a real measurement, so a
+    zero error is a genuine result and must not be suppressed. (A producer that
+    echoed the theoretical m/z back would report a constant 0.0 ppm — but no such
+    producer reaches this function, and the guard cost real measurements.)
     """
     if calculated_mz is None or observed_mz is None:
         return None
     if calculated_mz <= 0 or observed_mz <= 0:
-        return None
-    if observed_mz == calculated_mz:
         return None
     return float((observed_mz - calculated_mz) / calculated_mz * 1e6)
 
@@ -423,9 +423,10 @@ def feature_records_for_cf(cf, map_info: dict[int, tuple[str, str]], group_map=N
     group = group_map.get(orig) if (group_map and orig is not None) else None
     anchor_protein = group[0] if group else orig
     pg_accessions = [{"accession": a, "start": None, "end": None, "pre": None, "post": None} for a in group] if group else None
-    # A peptide is unique when its group resolves to exactly one protein. The
-    # column was previously left null even though the membership is right here.
-    unique = (len(group) == 1) if group else (True if anchor_protein else None)
+    # A peptide is unique when its resolved group holds exactly one protein.
+    # With no resolved group the answer is unknown: a lone peptide evidence is
+    # not proof of uniqueness, and claiming True there would invent information.
+    unique = (len(group) == 1) if group else None
     error_ppm = mass_error_ppm(calculated_mz, observed_mz)
 
     records: list[dict] = []

--- a/qpx/writers/base.py
+++ b/qpx/writers/base.py
@@ -193,16 +193,24 @@ class BaseWriter:
         identity_composite: Optional[Sequence[str]] = None,
     ):
         self._path = Path(path)
+        # A per-instance nonce, not just the pid: two writers in the SAME process
+        # targeting one destination would otherwise share a staging file and
+        # corrupt each other.
         # Bytes go to a sibling temp file and are moved onto _path only after a
         # clean close. Opening the destination directly meant a converter that
         # failed mid-run replaced an existing valid file with a truncated one and
         # there was no way back (bigbio/qpx#288). A sibling keeps the rename on
         # the same filesystem, so os.replace is atomic.
-        self._staging_path = self._path.with_name(f".{self._path.name}.{os.getpid()}.tmp")
+        self._staging_path = self._path.with_name(f".{self._path.name}.{os.getpid()}.{uuid.uuid4().hex[:8]}.tmp")
         self._compression = compression
         self._batch_size = batch_size
         self._buffer: list[dict] = []
         self._writer: pq.ParquetWriter | None = None
+        # Set when a write raises. __exit__ sees the exception and discards, but a
+        # converter that catches its own write error and then calls close()
+        # normally would otherwise promote the partial file — publishing exactly
+        # the truncated output the staging was added to prevent (bigbio/qpx#288).
+        self._write_failed = False
         self._extra_columns = extra_columns or []
         # Override mode (e.g. consensusXML): re-derive the id even when the
         # producer supplied one, stashing the original as a cv_param so it is
@@ -422,8 +430,19 @@ class BaseWriter:
             base = self._schema_class.get_arrow_schema()
         return base.with_metadata(self._file_metadata)
 
+    def _guard(self, fn, *args, **kwargs):
+        """Run a write, latching failure so close() can never promote the result."""
+        try:
+            return fn(*args, **kwargs)
+        except BaseException:
+            self._write_failed = True
+            raise
+
     def write_batch(self, records: list[dict]):
         """Accumulate records and flush when batch_size is reached."""
+        return self._guard(self._write_batch, records)
+
+    def _write_batch(self, records: list[dict]):
         self._buffer.extend(records)
         while len(self._buffer) >= self._batch_size:
             batch = self._buffer[: self._batch_size]
@@ -437,6 +456,9 @@ class BaseWriter:
         (derived from the identity_composite) before validation, so callers may
         pass tables whose id column is absent or null.
         """
+        return self._guard(self._write_table, table)
+
+    def _write_table(self, table: pa.Table):
         table = self._fill_identity_table(table)
         errors = self._schema_class.validate(table, strict=False)
         if errors:
@@ -465,8 +487,11 @@ class BaseWriter:
         self.write_table(table)
 
     def close(self):
-        """Flush buffered rows, close the file, and validate its identity PK."""
-        self._close(validate=True)
+        """Flush buffered rows, close the file, and validate its identity PK.
+
+        A write that already failed is never promoted, however close() is reached.
+        """
+        self._close(validate=not self._write_failed)
 
     def _close(self, *, validate: bool) -> None:
         """Close the writer, discarding buffered rows after a body error."""

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -1018,16 +1018,16 @@ def test_mass_error_ppm_is_computed_from_the_two_mz_values():
     assert mass_error_ppm(500.0, 499.995) == pytest.approx(-10.0, abs=1e-6)
 
 
-def test_mass_error_ppm_is_none_when_not_measurable():
-    """An echoed theoretical m/z must not be reported as 0.0 ppm.
+def test_mass_error_ppm_is_none_only_when_not_measurable():
+    """None means absent or unmeasurable — never a real zero.
 
-    A producer with no measured m/z that returns the calculated value would
-    otherwise yield a constant 0.0, which reads as perfect mass accuracy instead
-    of as missing data.
+    An exact match is a genuine 0.0 ppm here: the OpenMS adapters are the only
+    callers and their observed_mz is a measurement, so suppressing it would throw
+    away a real result.
     """
     from qpx.converters.openms_consensus.feature_adapter import mass_error_ppm
 
-    assert mass_error_ppm(456.55, 456.55) is None
+    assert mass_error_ppm(456.55, 456.55) == 0.0
     assert mass_error_ppm(456.55, None) is None
     assert mass_error_ppm(None, 456.55) is None
     assert mass_error_ppm(0.0, 456.55) is None
@@ -1046,3 +1046,33 @@ def test_mass_error_ppm_rejects_non_positive_mz():
     assert mass_error_ppm(0.0, 456.55) is None
     assert mass_error_ppm(456.55, -1.0) is None
     assert mass_error_ppm(-456.55, 456.55) is None
+
+
+def test_unique_is_unknown_without_a_resolved_group(tmp_path):
+    """No resolved group means unknown, not unique.
+
+    A lone peptide evidence is not proof that the peptide maps to one protein, so
+    an unresolved group must leave `unique` null rather than claiming True.
+    Exercised by passing an empty group_map: anchor_protein still resolves from
+    the peptide evidence, but no membership is known.
+    """
+    from qpx.converters.openms_consensus.feature_adapter import (
+        feature_map_info,
+        feature_records_for_cf,
+        load_consensus_map,
+    )
+
+    path = tmp_path / "in.consensusXML"
+    path.write_text(_TMT_CONSENSUSXML)
+    cm = load_consensus_map(str(path))
+    map_info = feature_map_info(cm)
+    cf = list(cm)[0]
+
+    unresolved = feature_records_for_cf(cf, map_info, group_map={})
+    assert unresolved, "expected at least one feature record"
+    for record in unresolved:
+        assert record["anchor_protein"] == "P12345", "anchor still resolves from peptide evidence"
+        assert record["unique"] is None, "unique must be unknown when no group resolved"
+
+    resolved = feature_records_for_cf(cf, map_info, group_map={"P12345": ["P12345"]})
+    assert all(record["unique"] is True for record in resolved), "a resolved group of one is unique"

--- a/tests/unit/test_writers.py
+++ b/tests/unit/test_writers.py
@@ -307,3 +307,32 @@ class TestAtomicWrites:
                 w.write_batch([make_feature_record()])
                 raise RuntimeError("boom")
         assert not path.exists(), "a partial file was published for a failed run"
+
+    def test_close_after_a_caught_write_error_does_not_publish(self, tmp_path):
+        """A converter that swallows its own write error must not publish.
+
+        __exit__ discards when it sees an exception, but a caller that catches the
+        error itself and then calls close() normally reached the promote path —
+        publishing the truncated file the staging exists to prevent.
+        """
+        path = tmp_path / "caught.feature.parquet"
+        self._write_one(path)
+        good_bytes = path.read_bytes()
+
+        writer = FeatureWriter(str(path), batch_size=self.BATCH)
+        writer.write_batch([make_feature_record()])
+        try:
+            writer.write_batch([{"not": "a valid record"}])
+        except Exception:
+            pass  # the converter swallows it
+        writer.close()
+
+        assert path.read_bytes() == good_bytes, "a partial file was published after a caught error"
+        assert [p.name for p in tmp_path.iterdir()] == [path.name]
+
+    def test_two_writers_in_one_process_do_not_share_a_staging_file(self, tmp_path):
+        """The staging name must be unique per writer, not per process."""
+        path = tmp_path / "shared.feature.parquet"
+        a = FeatureWriter(str(path), batch_size=self.BATCH)
+        b = FeatureWriter(str(path), batch_size=self.BATCH)
+        assert a._staging_path != b._staging_path, "two writers would corrupt each other's staging file"


### PR DESCRIPTION
Four MAJOR findings from a CodeRabbit pass over `dev` (raised while reviewing #296). All four are in code I added in #285/#294, and all four hold up against the source. Worth stating plainly: one of them **partially defeats the fix it belongs to**.

## 1. `close()` after a caught write error published a partial file

`__exit__` discards when it sees an exception, but that is not the only route to `close()`:

```python
writer.write_batch(good)
try:
    writer.write_batch(bad)     # converter swallows its own error
except Exception:
    pass
writer.close()                  # -> _close(validate=True) -> _promote_staged()
```

The truncated file was promoted onto the destination — exactly the outcome #288's staging was added to prevent, reached through a different door. Public writes now run through a guard that latches the failure, and `close()` refuses to validate or promote once it is set.

## 2. The staging filename collided within a process

`.{name}.{pid}.tmp` is not unique: two writers in the same process targeting one destination share a staging file and corrupt each other. Added a per-instance nonce.

## 3. `mass_error_ppm` suppressed real zeros

I justified returning `None` on an exact match with "a producer that echoes the theoretical m/z back would report a constant 0.0 ppm". That reasoning was misapplied: **the OpenMS adapters are this helper's only callers**, and their `observed_mz` comes from `cf.getMZ()` — a measurement. The guard discarded a genuine 0.0 ppm to protect against a producer that cannot reach the function. An exact match now returns `0.0`; `None` stays reserved for absent or non-positive values.

## 4. `unique` invented information

```python
unique = (len(group) == 1) if group else (True if anchor_protein else None)   # before
```

With no resolved group this claimed `True` from the mere presence of an anchor protein. A lone peptide evidence is not proof that a peptide maps to one protein — an unresolved group is *unknown*, not unique. Now `None`.

## Tests

Four tests, each verified to fail against current `dev` and pass with the fix:

- a caught write error followed by `close()` leaves the previous valid file byte-identical and publishes nothing;
- two writers on one destination get different staging paths;
- `mass_error_ppm(456.55, 456.55) == 0.0`, with `None` only for absent/non-positive;
- `unique` is `None` for an unresolved group and `True` for a resolved group of one — behavioural, driving the real `feature_records_for_cf` with an empty `group_map` (my first attempt asserted on source text, which tests nothing).

Full suite: **920 passed**. pre-commit clean.

## Suggested ordering

These land in `dev`, so merging this before #296 carries the corrections through to `main` in one release rather than shipping the known defects and following up.
