### PR TITLE
fix(diann): derive mass_error_ppm instead of leaving it null

### DIFF
--- a/qpx/converters/diann/feature_adapter.py
+++ b/qpx/converters/diann/feature_adapter.py
@@ -385,12 +385,27 @@ class DiannFeatureAdapter(DiaNNBaseAdapter):
             else "NULL::FLOAT AS observed_mz"
         )
 
+        # mass_error_ppm: prefer a reported column, otherwise DERIVE it. DIA-NN
+        # emits no mass-error column, so this was always null even though both
+        # inputs are present — on PXD030304 22% of rows carry an observed m/z that
+        # genuinely differs from the theoretical one, and that error was discarded
+        # (bigbio/qpx#298). Guarded on both values being positive: calculated_mz is
+        # COALESCEd to 0.0 above, and observed_mz is null when the report has no
+        # Precursor.Mz, so an unmeasured row stays null rather than dividing by zero
+        # or reporting a fabricated error. The formula matches docs/spec/feature.md.
         mass_error_col = resolved.get("mass_error_ppm")
-        parts.append(
-            f"{_safe_float_sql(mass_error_col)} AS mass_error_ppm"
-            if mass_error_col and has_column(mass_error_col)
-            else "NULL::FLOAT AS mass_error_ppm"
-        )
+        if mass_error_col and has_column(mass_error_col):
+            parts.append(f"{_safe_float_sql(mass_error_col)} AS mass_error_ppm")
+        elif observed_mz_col and has_column(observed_mz_col):
+            observed_expr = _safe_float_sql(observed_mz_col)
+            parts.append(
+                "CASE WHEN lk.calculated_mz > 0 AND "
+                f"({observed_expr}) > 0 "
+                f"THEN CAST((({observed_expr}) - lk.calculated_mz) / lk.calculated_mz * 1e6 AS FLOAT) "
+                "END AS mass_error_ppm"
+            )
+        else:
+            parts.append("NULL::FLOAT AS mass_error_ppm")
 
         predicted_rt_col = resolved.get("predicted_rt")
         parts.append(
@@ -837,6 +852,19 @@ class DiannFeatureAdapter(DiaNNBaseAdapter):
             merged_parts.append(group_df)
 
         merged_df = pd.concat(merged_parts, ignore_index=True)
+
+        # Recompute the mass error for rows whose observed_mz was only just
+        # backfilled from the mzML. The SQL derives it before this merge runs, so
+        # without this those rows keep a null error while carrying both m/z
+        # (bigbio/qpx#298). Only null errors are filled; a reported value wins.
+        if {"calculated_mz", "observed_mz", "mass_error_ppm"} <= set(merged_df.columns):
+            calc = pd.to_numeric(merged_df["calculated_mz"], errors="coerce")
+            obs = pd.to_numeric(merged_df["observed_mz"], errors="coerce")
+            derivable = merged_df["mass_error_ppm"].isna() & (calc > 0) & (obs > 0)
+            if derivable.any():
+                merged_df.loc[derivable, "mass_error_ppm"] = ((obs[derivable] - calc[derivable]) / calc[derivable] * 1e6).astype(
+                    "float32"
+                )
         # Rebuild Arrow table preserving the original schema for non-scan columns
         return pa.Table.from_pandas(merged_df, schema=table.schema, preserve_index=False)
 

--- a/tests/converters/test_diann_converter.py
+++ b/tests/converters/test_diann_converter.py
@@ -238,6 +238,30 @@ class TestDiaNNFeatureConversion:
         errors = FeatureSchema.validate(feature_table)
         assert not errors, f"Schema validation errors: {errors}"
 
+    def test_mass_error_ppm_is_null_without_a_measured_mz(self, feature_table):
+        """Null only when there is nothing to measure (bigbio/qpx#298).
+
+        DIA-NN emits no mass-error column, so the value must be derived from the
+        two m/z. This fixture carries no Precursor.Mz, so observed_mz is null and
+        the ppm must be null too - never a fabricated 0.0.
+        """
+        assert "mass_error_ppm" in feature_table.schema.names
+        observed = feature_table.column("observed_mz").to_pylist()
+        errors = feature_table.column("mass_error_ppm").to_pylist()
+        for obs, err in zip(observed, errors):
+            if obs is None:
+                assert err is None, "mass error reported without a measured m/z"
+
+    def test_mass_error_ppm_matches_the_spec_formula(self, feature_table):
+        """Whenever both m/z are positive the value is 1e6*(obs-calc)/calc."""
+        calc = feature_table.column("calculated_mz").to_pylist()
+        obs = feature_table.column("observed_mz").to_pylist()
+        err = feature_table.column("mass_error_ppm").to_pylist()
+        for c, o, e in zip(calc, obs, err):
+            if c and o and c > 0 and o > 0:
+                assert e is not None, "both m/z present but no mass error emitted"
+                assert abs(e - (o - c) / c * 1e6) < 0.5, f"{e} does not match the spec formula"
+
     def test_precursor_qvalue_stays_in_additional_scores(self, feature_table):
         """DIA-NN Q.Value is not mislabeled as a peptide-level q-value."""
         assert all(value is None for value in feature_table.column("peptide_qvalue").to_pylist())


### PR DESCRIPTION
Closes #298.

## The bug

The DIA-NN adapter only emitted `mass_error_ppm` when the report carried a column of that name:

```python
mass_error_col = resolved.get("mass_error_ppm")
parts.append(
    f"{_safe_float_sql(mass_error_col)} AS mass_error_ppm"
    if mass_error_col and has_column(mass_error_col)
    else "NULL::FLOAT AS mass_error_ppm"          # <- always this
)
```

DIA-NN emits no such column, so the field was **always null** — while `calculated_mz` and `observed_mz` sat right there at 100%. On PXD030304 (231,621,074 rows) a 300k sample showed:

```
observed_mz vs calculated_mz:  identical = 233,804   different = 66,196
```

**22% of rows carry a genuinely measured m/z** whose error was being thrown away.

I introduced this gap in #285 by adding `mass_error_ppm` to the OpenMS adapter only, on the reasoning that DIA-NN echoes the theoretical m/z into `observed_mz`. That is true of the small test fixture, whose `observed_mz` is entirely null — and false on a real report. I never checked the assumption against real data.

## The fix

Derive it in SQL with the formula `docs/spec/feature.md` already documents, guarded on both m/z being positive — `calculated_mz` is COALESCEd to 0.0 upstream and `observed_mz` is null without a `Precursor.Mz`, so an unmeasured row stays null rather than dividing by zero or reporting a fabricated error. A reported column, if one ever appears, still wins.

**A test caught a second half I had missed:** `_merge_scan_info_arrow` backfills `observed_mz` from the mzML *after* the SQL runs, so those rows kept a null error while carrying both m/z. The value is now recomputed after the merge, filling only nulls.

## Verification against a ground truth

Rather than assert the code matches itself, I injected a known error: a fixture given `Precursor.Mz` at exactly **+5 ppm** from the theoretical value, with 50 rows deliberately left without one.

```
unmodified subset (547 rows):   median = 5.000 ppm        (injected +5.000)
self-consistency vs spec formula: max deviation 0.059 ppm
rows without Precursor.Mz:      50 injected -> 50 null    (no fabricated zeros)
```

The median is over unmodified peptides only: my injection keyed the m/z on the stripped sequence, so modified peptides got a deliberately wrong theoretical value and skew the mean. Two earlier readings of this check looked like failures and were both my own broken analysis — one keyed on the wrong sequence, one had a pandas masking bug.

New tests assert the null-without-measurement rule and the spec formula on every row where both m/z are positive.

Full suite: **938 passed**. pre-commit clean.

## Not included

#299 (41% orphaned LFQ `psm.feature_id`) and #300 (cross-converter field inconsistencies) are left for separate changes — #299 needs a decision about whether the orphans are unassigned PSMs by design, and #300 is a set of per-field decisions rather than one fix.
