### PR TITLE
feat(openms): add --skip-unassigned-psms to omit PSMs that link to no feature

### DIFF
--- a/qpx/cli/convert.py
+++ b/qpx/cli/convert.py
@@ -875,6 +875,18 @@ def convert_openms_cmd(**kwargs):
     help="PRIDE / ProteomeXchange accession (e.g. PXD001819)",
 )
 @click.option(
+    "--skip-unassigned-psms",
+    is_flag=True,
+    default=False,
+    help=(
+        "Omit identifications that are not linked to any consensus feature from "
+        "psm.parquet. They are identified spectra but carry no quantification and "
+        "their feature_id is null, so a psm->feature join drops them anyway (41% of "
+        "rows on a real label-free dataset). Protein inference is unaffected: it "
+        "always uses every identification."
+    ),
+)
+@click.option(
     "--compression",
     type=click.Choice(["zstd", "snappy", "gzip", "none"], case_sensitive=False),
     default="zstd",
@@ -891,6 +903,7 @@ def convert_openms_consensus_cmd(
     streaming,
     verbose,
     project_accession,
+    skip_unassigned_psms,
     compression,
 ):
     """Convert an OpenMS consensusXML (+ SDRF) to QPX.
@@ -910,6 +923,7 @@ def convert_openms_consensus_cmd(
         consensusxml_path=str(consensusxml_path),
         output_folder=str(output_folder),
         output_prefix=output_prefix,
+        include_unassigned_psms=not skip_unassigned_psms,
         sdrf_path=str(sdrf_path) if sdrf_path else None,
         structures=structs,
         pg_top=pg_top,

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -133,7 +133,21 @@ def _write_view(writer_cls, path, records, *, creator, compression, identity_com
     return path
 
 
-def _stream_feature_psm(cm, fw, pw, *, map_info, group_map, resolve_run, maps, pep_intensity, map_run, seen, batch):
+def _stream_feature_psm(
+    cm,
+    fw,
+    pw,
+    *,
+    map_info,
+    group_map,
+    resolve_run,
+    maps,
+    pep_intensity,
+    map_run,
+    seen,
+    batch,
+    include_unassigned_psms=True,
+):
     """One ordered element/unassigned pass: write feature/psm in batches and
     accumulate the pg maps in place (the streaming path's inner loop)."""
     from qpx.converters.openms_consensus.pg_adapter import (
@@ -156,10 +170,13 @@ def _stream_feature_psm(cm, fw, pw, *, map_info, group_map, resolve_run, maps, p
                 accumulate_cf_maps(obj, map_run, maps)
                 accumulate_cf_intensity(obj, map_info, pep_intensity)
         else:  # unassigned peptide identification
-            if pw is not None:
+            if pw is not None and include_unassigned_psms:
                 # Unassigned PSMs map to no feature -> feature_id stays null.
                 psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen))
             if maps is not None:
+                # Protein inference always sees every identification, whether or
+                # not the PSM rows are emitted: dropping evidence would change the
+                # protein groups, which is not what this option is for.
                 accumulate_unassigned_maps(obj, resolve_run, maps)
         if fw is not None and len(feat_buf) >= batch:
             fw.write_batch(feat_buf)
@@ -173,7 +190,17 @@ def _stream_feature_psm(cm, fw, pw, *, map_info, group_map, resolve_run, maps, p
         pw.write_batch(psm_buf)
 
 
-def _convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression="zstd") -> dict:
+def _convert_streaming(
+    consensusxml_path,
+    out,
+    output_prefix,
+    structures,
+    sdrf_path,
+    creator,
+    pg_top,
+    compression="zstd",
+    include_unassigned_psms=True,
+) -> dict:
     """Single-pass, low-memory feature/psm/pg from a streamed consensusXML.
 
     One ordered ``iter_all()`` pass over the elements + unassigned IDs feeds the
@@ -241,6 +268,7 @@ def _convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_p
             map_run=map_run,
             seen=seen,
             batch=100_000,
+            include_unassigned_psms=include_unassigned_psms,
         )
         if fw is not None:
             written["feature"] = out / f"{output_prefix}.feature.parquet"
@@ -347,8 +375,18 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         streaming: Optional[bool] = None,
         project_accession: Optional[str] = None,
         compression: str = "zstd",
+        include_unassigned_psms: bool = True,
     ) -> dict[str, Path]:
         """Write the requested QPX views and return ``{structure: parquet path}``.
+
+        ``include_unassigned_psms`` (default ``True``, preserving existing output)
+        controls whether identifications that are not linked to any consensus
+        feature reach ``psm.parquet``. They are identified spectra, but they carry
+        no quantification and their ``feature_id`` is null, so a ``psm -> feature``
+        join silently drops them — 41% of rows on a real label-free dataset. Set it
+        to ``False`` for a quantified-only PSM view. Protein inference is
+        unaffected either way: it always sees every identification, because
+        dropping evidence would change the protein groups.
 
         ``structures`` selects which of feature/psm/pg/run/sample to emit. pg
         carries an interim unnormalized unique-peptide-sum intensity; ``pg_top``
@@ -378,14 +416,32 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
                 # feature/psm/pg together and writes in batches, so the whole map is
                 # never in memory and the file is parsed once (not once per view).
                 written.update(
-                    _convert_streaming(consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression)
+                    _convert_streaming(
+                        consensusxml_path,
+                        out,
+                        output_prefix,
+                        structures,
+                        sdrf_path,
+                        creator,
+                        pg_top,
+                        compression,
+                        include_unassigned_psms,
+                    )
                 )
             else:
                 # In-memory path: pyopenms loads the map once (fast for smaller files);
                 # the adapters iterate it cheaply. Output is identical either way.
                 written.update(
                     self._convert_in_memory(
-                        consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression
+                        consensusxml_path,
+                        out,
+                        output_prefix,
+                        structures,
+                        sdrf_path,
+                        creator,
+                        pg_top,
+                        compression,
+                        include_unassigned_psms,
                     )
                 )
 
@@ -478,7 +534,15 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
 
     @staticmethod
     def _convert_in_memory(
-        consensusxml_path, out, output_prefix, structures, sdrf_path, creator, pg_top, compression="zstd"
+        consensusxml_path,
+        out,
+        output_prefix,
+        structures,
+        sdrf_path,
+        creator,
+        pg_top,
+        compression="zstd",
+        include_unassigned_psms=True,
     ) -> dict:
         """feature/psm/pg via the in-memory pyopenms map (loaded once, iterated cheaply)."""
         from qpx.converters.openms_consensus.feature_adapter import feature_map_info
@@ -508,7 +572,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
                 )
                 feat_recs.extend(cf_feats)
                 psm_recs.extend(cf_psms)
-            if want_psm:
+            if want_psm and include_unassigned_psms:
                 for pid in cm.getUnassignedPeptideIdentifications():
                     psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen))
             if want_feature:

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -991,3 +991,83 @@ def test_openms_consensus_identity_retains_all_spectrum_references(tmp_path, str
     assert table.column("scan").to_pylist() == [[42, 43]]
     assert table.column("consensus_rt").to_pylist() == pytest.approx([100.123456])
     assert table.schema.metadata[b"identity_composite"] == (b"peptidoform,charge,run_file_name,rt,scan,observed_mz,consensus_rt")
+
+
+class TestSkipUnassignedPsms:
+    """`include_unassigned_psms=False` drops PSMs that link to no feature.
+
+    Unassigned identifications carry no quantification and their feature_id is
+    null, so a psm->feature join silently drops them anyway — 41% of rows on a
+    real label-free dataset (bigbio/qpx#299). The option makes that explicit.
+    """
+
+    _XML_WITH_UNASSIGNED = _TMT_CONSENSUSXML.replace(
+        "</consensusElementList>",
+        """</consensusElementList>
+  <UnassignedPeptideIdentification identification_run_ref="PI_0" score_type=""
+    higher_score_better="true" significance_threshold="0" MZ="500.25" RT="200"
+    spectrum_reference="controllerType=0 controllerNumber=1 scan=99">
+    <PeptideHit score="0" sequence="UNASSIGNEDK" charge="2" protein_refs="PH_0">
+      <UserParam type="string" name="target_decoy" value="target"/>
+      <UserParam type="float" name="Posterior Error Probability_score" value="1.0e-03"/>
+    </PeptideHit>
+  </UnassignedPeptideIdentification>""",
+    )
+
+    @staticmethod
+    def _convert(tmp_path, name, *, include, stream):
+        import pyarrow.parquet as pq
+
+        from qpx.converters.openms_consensus import converter as conv
+
+        path = tmp_path / f"{name}.consensusXML"
+        path.write_text(TestSkipUnassignedPsms._XML_WITH_UNASSIGNED)
+        out = tmp_path / f"out_{name}"
+        conv._should_stream = lambda _p, v=stream: v
+        OpenMSConsensusConverter().convert(
+            str(path),
+            str(out),
+            output_prefix="X",
+            structures=("feature", "psm", "pg"),
+            project_accession="X",
+            include_unassigned_psms=include,
+        )
+        return pq.read_table(str(out / "X.psm.parquet")).to_pylist()
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
+    def test_default_keeps_unassigned(self, tmp_path, stream):
+        rows = self._convert(tmp_path, f"keep_{stream}", include=True, stream=stream)
+        seqs = {r["sequence"] for r in rows}
+        assert "UNASSIGNEDK" in seqs, "default must preserve existing output"
+        assert any(r["feature_id"] is None for r in rows)
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
+    def test_option_drops_unassigned_on_both_paths(self, tmp_path, stream):
+        rows = self._convert(tmp_path, f"drop_{stream}", include=False, stream=stream)
+        seqs = {r["sequence"] for r in rows}
+        assert "UNASSIGNEDK" not in seqs, "unassigned PSM was still written"
+        assert rows, "assigned PSMs must survive"
+        assert all(r["feature_id"] is not None for r in rows), "every remaining PSM links to a feature"
+
+    def test_protein_inference_is_unaffected(self, tmp_path):
+        """Dropping PSM rows must not change the protein groups."""
+        import pyarrow.parquet as pq
+
+        from qpx.converters.openms_consensus import converter as conv
+
+        counts = []
+        for include in (True, False):
+            path = tmp_path / f"pg_{include}.consensusXML"
+            path.write_text(self._XML_WITH_UNASSIGNED)
+            out = tmp_path / f"pgout_{include}"
+            conv._should_stream = lambda _p: False
+            OpenMSConsensusConverter().convert(
+                str(path),
+                str(out),
+                output_prefix="X",
+                structures=("feature", "psm", "pg"),
+                project_accession="X",
+                include_unassigned_psms=include,
+            )
+            counts.append(pq.read_table(str(out / "X.pg.parquet")).num_rows)
+        assert counts[0] == counts[1], "pg output changed when only PSM rows were filtered"


### PR DESCRIPTION
Addresses #299 by making the behaviour explicit and optional.

## What the 41% actually are

Confirmed from the code and from real data: they are **unassigned PeptideIdentifications** — identified spectra that belong to no consensus feature, so they carry no quantification and their `feature_id` is null (`converter.py`: *"Unassigned PSMs map to no feature -> feature_id stays null"*). Not a defect, but nothing surfaced it, and a `psm -> feature` join drops them without a word.

## The option

`--skip-unassigned-psms` (API: `include_unassigned_psms=False`) omits them from `psm.parquet`. Measured on PXD012255 (291 MB consensusXML, real quantms output):

```
include (default)  psm=167715  linked=99425  null=68290  feature=99425  pg=6740
skip-unassigned    psm=99425   linked=99425  null=0      feature=99425  pg=6740
```

Every remaining PSM links to a feature, and `feature` is untouched.

## Two deliberate constraints

**Default unchanged.** Existing output is identical unless the flag is passed.

**Protein inference is not gated.** `accumulate_unassigned_maps` still runs, so every identification contributes evidence to protein grouping — dropping it would change the protein groups, which is not what this option is for. The real run above confirms `pg` is identical either way (6,740 rows), and a test asserts it.

## Both paths

The streaming reader (used above the 4 GB threshold) and the in-memory path each had their own unassigned-PSM loop; both are gated, and the tests are parametrised over both. Gating only the in-memory path would have left the option silently ineffective on exactly the large datasets where it matters most.

## Naming

The flag says *unassigned*, not *unidentified*. These rows **are** identified — they have peptide hits and scores; what they lack is a link to a quantified feature. Calling them unidentified in the API would have been wrong.

## Also in scope, and not done

**#284's spec** needs no change from me — the DIA-NN semantics were already corrected on `dev` (`feature.md` now states that DIA-NN reports a precursor-level q-value, keeps it in `additional_scores` as `precursor_qvalue`, and leaves `peptide_qvalue` null). I checked before editing rather than duplicating that work.

**#300** is not addressed here. The clearest candidate, `missed_cleavages` on the OpenMS path, is feasible — the enzyme is in the consensusXML (`enzyme="trypsin"` in real quantms output) — but the streaming reader parses no `SearchParameters` at all, so it needs new XML parsing on that path as well as the pyopenms call on the other. That is a feature in its own right, not a quick win, and mixing it into this PR would make two unrelated changes.

Full suite: **941 passed**. pre-commit clean.
