### PR TITLE
change(openms)!: omit unassigned PSMs by default

### DIFF
--- a/qpx/cli/convert.py
+++ b/qpx/cli/convert.py
@@ -875,15 +875,15 @@ def convert_openms_cmd(**kwargs):
     help="PRIDE / ProteomeXchange accession (e.g. PXD001819)",
 )
 @click.option(
-    "--skip-unassigned-psms",
+    "--include-unassigned-psms",
     is_flag=True,
     default=False,
     help=(
-        "Omit identifications that are not linked to any consensus feature from "
-        "psm.parquet. They are identified spectra but carry no quantification and "
-        "their feature_id is null, so a psm->feature join drops them anyway (41% of "
-        "rows on a real label-free dataset). Protein inference is unaffected: it "
-        "always uses every identification."
+        "Also write identifications that are not linked to any consensus feature. "
+        "They are identified spectra but carry no quantification and their "
+        "feature_id is null, so a psm->feature join drops them anyway (41% of rows "
+        "on a real label-free dataset); they are omitted by default. Protein "
+        "inference always uses every identification either way."
     ),
 )
 @click.option(
@@ -903,7 +903,7 @@ def convert_openms_consensus_cmd(
     streaming,
     verbose,
     project_accession,
-    skip_unassigned_psms,
+    include_unassigned_psms,
     compression,
 ):
     """Convert an OpenMS consensusXML (+ SDRF) to QPX.
@@ -923,7 +923,7 @@ def convert_openms_consensus_cmd(
         consensusxml_path=str(consensusxml_path),
         output_folder=str(output_folder),
         output_prefix=output_prefix,
-        include_unassigned_psms=not skip_unassigned_psms,
+        include_unassigned_psms=include_unassigned_psms,
         sdrf_path=str(sdrf_path) if sdrf_path else None,
         structures=structs,
         pg_top=pg_top,

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -146,7 +146,7 @@ def _stream_feature_psm(
     map_run,
     seen,
     batch,
-    include_unassigned_psms=True,
+    include_unassigned_psms=False,
 ):
     """One ordered element/unassigned pass: write feature/psm in batches and
     accumulate the pg maps in place (the streaming path's inner loop)."""
@@ -199,7 +199,7 @@ def _convert_streaming(
     creator,
     pg_top,
     compression="zstd",
-    include_unassigned_psms=True,
+    include_unassigned_psms=False,
 ) -> dict:
     """Single-pass, low-memory feature/psm/pg from a streamed consensusXML.
 
@@ -375,18 +375,18 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         streaming: Optional[bool] = None,
         project_accession: Optional[str] = None,
         compression: str = "zstd",
-        include_unassigned_psms: bool = True,
+        include_unassigned_psms: bool = False,
     ) -> dict[str, Path]:
         """Write the requested QPX views and return ``{structure: parquet path}``.
 
-        ``include_unassigned_psms`` (default ``True``, preserving existing output)
-        controls whether identifications that are not linked to any consensus
-        feature reach ``psm.parquet``. They are identified spectra, but they carry
-        no quantification and their ``feature_id`` is null, so a ``psm -> feature``
-        join silently drops them — 41% of rows on a real label-free dataset. Set it
-        to ``False`` for a quantified-only PSM view. Protein inference is
-        unaffected either way: it always sees every identification, because
-        dropping evidence would change the protein groups.
+        ``include_unassigned_psms`` (default ``False``) controls whether
+        identifications that are not linked to any consensus feature reach
+        ``psm.parquet``. They are identified spectra, but they carry no
+        quantification and their ``feature_id`` is null, so a ``psm -> feature``
+        join drops them anyway — 41% of rows on a real label-free dataset. The
+        default therefore emits a quantified-only PSM view; pass ``True`` to keep
+        them. Protein inference is unaffected either way: it always sees every
+        identification, because dropping evidence would change the protein groups.
 
         ``structures`` selects which of feature/psm/pg/run/sample to emit. pg
         carries an interim unnormalized unique-peptide-sum intensity; ``pg_top``
@@ -542,7 +542,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         creator,
         pg_top,
         compression="zstd",
-        include_unassigned_psms=True,
+        include_unassigned_psms=False,
     ) -> dict:
         """feature/psm/pg via the in-memory pyopenms map (loaded once, iterated cheaply)."""
         from qpx.converters.openms_consensus.feature_adapter import feature_map_info

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -1035,10 +1035,32 @@ class TestSkipUnassignedPsms:
         return pq.read_table(str(out / "X.psm.parquet")).to_pylist()
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
-    def test_default_keeps_unassigned(self, tmp_path, stream):
+    def test_default_drops_unassigned(self, tmp_path, stream):
+        """The default PSM view is quantified-only."""
+        import pyarrow.parquet as pq
+
+        from qpx.converters.openms_consensus import converter as conv
+
+        path = tmp_path / f"default_{stream}.consensusXML"
+        path.write_text(self._XML_WITH_UNASSIGNED)
+        out = tmp_path / f"out_default_{stream}"
+        conv._should_stream = lambda _p, v=stream: v
+        OpenMSConsensusConverter().convert(
+            str(path),
+            str(out),
+            output_prefix="X",
+            structures=("feature", "psm", "pg"),
+            project_accession="X",
+        )
+        rows = pq.read_table(str(out / "X.psm.parquet")).to_pylist()
+        assert "UNASSIGNEDK" not in {r["sequence"] for r in rows}
+        assert all(r["feature_id"] is not None for r in rows)
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
+    def test_opt_in_keeps_unassigned(self, tmp_path, stream):
         rows = self._convert(tmp_path, f"keep_{stream}", include=True, stream=stream)
         seqs = {r["sequence"] for r in rows}
-        assert "UNASSIGNEDK" in seqs, "default must preserve existing output"
+        assert "UNASSIGNEDK" in seqs, "opt-in must restore them"
         assert any(r["feature_id"] is None for r in rows)
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])


### PR DESCRIPTION
Follow-up to #302: makes the quantified-only PSM view the **default** rather than opt-in.

## Change

Identifications that link to no consensus feature are no longer written to `psm.parquet` unless `--include-unassigned-psms` is passed.

They are identified spectra, but they carry no quantification and their `feature_id` is null, so a `psm -> feature` join drops them regardless. On PXD012255 that is **68,290 of 167,715 rows (41%)**:

```
default (now)            psm=99425   linked=99425  null=0      feature=99425  pg=6740
--include-unassigned     psm=167715  linked=99425  null=68290  feature=99425  pg=6740
```

Emitting them by default meant every consumer had to know to filter them out, and most would discover it only by finding their join had quietly lost 41% of the view.

The CLI flag is inverted with the default: `--skip-unassigned-psms` becomes `--include-unassigned-psms`, since a `--skip-` flag reads oddly once skipping is what happens anyway.

## Unchanged

Protein inference still sees every identification, so `pg` is byte-identical either way (6,740 rows on the run above, asserted by a test). `feature` is untouched.

## Breaking

`psm.parquet` from the OpenMS converter loses its unassigned rows unless the new flag is passed. Row counts drop for label-free datasets — for PXD012255, 167,715 -> 99,425. Isobaric datasets are largely unaffected in practice (MSV000085836 had 100% of PSMs linked).

Anyone who wants the previous output passes `--include-unassigned-psms`, or `include_unassigned_psms=True` on the API.

## Tests

The parametrised tests now assert the inverse of what they did in #302 — the default drops them on **both** converter paths, and the opt-in restores them — plus the existing check that `pg` does not change.

Full suite: **945 passed**. pre-commit clean.
