### PR TITLE
feat(openms): report missed_cleavages

### DIFF
--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -219,7 +219,7 @@ def _convert_streaming(
     from collections import defaultdict
     from contextlib import ExitStack
 
-    from qpx.converters.openms_consensus.feature_adapter import _run_stem, consensus_enzyme, feature_map_info
+    from qpx.converters.openms_consensus.feature_adapter import _run_stem, feature_map_info, resolve_enzyme
     from qpx.converters.openms_consensus.pg_adapter import (
         _ProteinMaps,
         accession_to_group,
@@ -277,7 +277,7 @@ def _convert_streaming(
             seen=seen,
             batch=100_000,
             include_unassigned_psms=include_unassigned_psms,
-            enzyme=consensus_enzyme(cm),
+            enzyme=resolve_enzyme(cm, sdrf_path),
         )
         if fw is not None:
             written["feature"] = out / f"{output_prefix}.feature.parquet"
@@ -554,7 +554,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         include_unassigned_psms=True,
     ) -> dict:
         """feature/psm/pg via the in-memory pyopenms map (loaded once, iterated cheaply)."""
-        from qpx.converters.openms_consensus.feature_adapter import consensus_enzyme, feature_map_info
+        from qpx.converters.openms_consensus.feature_adapter import feature_map_info, resolve_enzyme
         from qpx.converters.openms_consensus.psm_adapter import _run_resolver, psm_records_for_pid
 
         cm = load_consensus_map(consensusxml_path)
@@ -573,7 +573,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
             group_map = accession_to_group(cm) if want_feature else None
             resolve_run = _run_resolver(cm) if want_psm else None
             seen: set = set()
-            enzyme = consensus_enzyme(cm)
+            enzyme = resolve_enzyme(cm, sdrf_path)
             feat_recs: list[dict] = []
             psm_recs: list[dict] = []
             for cf in cm:

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -100,21 +100,21 @@ def _should_stream(path: str) -> bool:
         return False
 
 
-def _cf_feature_psm_records(cf, map_info, group_map, resolve_run, seen, *, want_feature, want_psm):
+def _cf_feature_psm_records(cf, map_info, group_map, resolve_run, seen, *, want_feature, want_psm, enzyme=None):
     """Feature + PSM records for one consensus feature, cross-linked when both views
     are emitted. Shared by the streaming and in-memory paths so their output matches.
     """
     from qpx.converters.openms_consensus.feature_adapter import feature_records_for_cf
     from qpx.converters.openms_consensus.psm_adapter import _cf_element_runs, psm_records_for_pid
 
-    cf_feats = feature_records_for_cf(cf, map_info, group_map) if want_feature else []
+    cf_feats = feature_records_for_cf(cf, map_info, group_map, enzyme=enzyme) if want_feature else []
     cf_psms: list[dict] = []
     if want_psm:
         # Multi-run isobaric PIDs carry a local id_merge_index; the feature's
         # element runs disambiguate which run they belong to.
         cf_runs = _cf_element_runs(cf, map_info)
         for pid in cf.getPeptideIdentifications():
-            cf_psms.extend(psm_records_for_pid(pid, resolve_run, seen, cf_runs=cf_runs))
+            cf_psms.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme, cf_runs=cf_runs))
     # Stamp psm.feature_id only when both views are emitted (the FK references a
     # feature row written in this dataset). feature.psm_ids is the computed inverse.
     if want_feature and want_psm:
@@ -147,6 +147,7 @@ def _stream_feature_psm(
     seen,
     batch,
     include_unassigned_psms=True,
+    enzyme=None,
 ):
     """One ordered element/unassigned pass: write feature/psm in batches and
     accumulate the pg maps in place (the streaming path's inner loop)."""
@@ -162,7 +163,14 @@ def _stream_feature_psm(
     for kind, obj in cm.iter_all():
         if kind == "element":
             cf_feats, cf_psms = _cf_feature_psm_records(
-                obj, map_info, group_map, resolve_run, seen, want_feature=fw is not None, want_psm=pw is not None
+                obj,
+                map_info,
+                group_map,
+                resolve_run,
+                seen,
+                want_feature=fw is not None,
+                want_psm=pw is not None,
+                enzyme=enzyme,
             )
             feat_buf.extend(cf_feats)
             psm_buf.extend(cf_psms)
@@ -172,7 +180,7 @@ def _stream_feature_psm(
         else:  # unassigned peptide identification
             if pw is not None and include_unassigned_psms:
                 # Unassigned PSMs map to no feature -> feature_id stays null.
-                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen))
+                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen, enzyme=enzyme))
             if maps is not None:
                 # Protein inference always sees every identification, whether or
                 # not the PSM rows are emitted: dropping evidence would change the
@@ -211,7 +219,7 @@ def _convert_streaming(
     from collections import defaultdict
     from contextlib import ExitStack
 
-    from qpx.converters.openms_consensus.feature_adapter import _run_stem, feature_map_info
+    from qpx.converters.openms_consensus.feature_adapter import _run_stem, consensus_enzyme, feature_map_info
     from qpx.converters.openms_consensus.pg_adapter import (
         _ProteinMaps,
         accession_to_group,
@@ -269,6 +277,7 @@ def _convert_streaming(
             seen=seen,
             batch=100_000,
             include_unassigned_psms=include_unassigned_psms,
+            enzyme=consensus_enzyme(cm),
         )
         if fw is not None:
             written["feature"] = out / f"{output_prefix}.feature.parquet"
@@ -545,7 +554,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         include_unassigned_psms=True,
     ) -> dict:
         """feature/psm/pg via the in-memory pyopenms map (loaded once, iterated cheaply)."""
-        from qpx.converters.openms_consensus.feature_adapter import feature_map_info
+        from qpx.converters.openms_consensus.feature_adapter import consensus_enzyme, feature_map_info
         from qpx.converters.openms_consensus.psm_adapter import _run_resolver, psm_records_for_pid
 
         cm = load_consensus_map(consensusxml_path)
@@ -564,17 +573,25 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
             group_map = accession_to_group(cm) if want_feature else None
             resolve_run = _run_resolver(cm) if want_psm else None
             seen: set = set()
+            enzyme = consensus_enzyme(cm)
             feat_recs: list[dict] = []
             psm_recs: list[dict] = []
             for cf in cm:
                 cf_feats, cf_psms = _cf_feature_psm_records(
-                    cf, map_info, group_map, resolve_run, seen, want_feature=want_feature, want_psm=want_psm
+                    cf,
+                    map_info,
+                    group_map,
+                    resolve_run,
+                    seen,
+                    want_feature=want_feature,
+                    want_psm=want_psm,
+                    enzyme=enzyme,
                 )
                 feat_recs.extend(cf_feats)
                 psm_recs.extend(cf_psms)
             if want_psm and include_unassigned_psms:
                 for pid in cm.getUnassignedPeptideIdentifications():
-                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen))
+                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme))
             if want_feature:
                 written["feature"] = _write_view(
                     FeatureWriter,

--- a/qpx/converters/openms_consensus/feature_adapter.py
+++ b/qpx/converters/openms_consensus/feature_adapter.py
@@ -11,12 +11,16 @@ the QPX feature schema. Protein-level quantity is not produced here.
 from __future__ import annotations
 
 import ast
+import logging
 import re
 from typing import Optional
 
 from qpx.converters.channel_labels import normalize_label
 from qpx.core.cleavage import count_missed_cleavages
 from qpx.core.files import run_file_stem as _run_stem
+
+# OpenMS isobaric channel labels look like ``tmt6plex_126`` / ``itraq4plex_114``.
+_log = logging.getLogger(__name__)
 
 # OpenMS isobaric channel labels look like ``tmt6plex_126`` / ``itraq4plex_114``.
 _CHANNEL_RE = re.compile(r"(tmt|itraq)\d*plex?_(\d+[NC]?)", re.IGNORECASE)
@@ -47,6 +51,47 @@ def mass_error_ppm(calculated_mz, observed_mz) -> float | None:
     if calculated_mz <= 0 or observed_mz <= 0:
         return None
     return float((observed_mz - calculated_mz) / calculated_mz * 1e6)
+
+
+def sdrf_enzyme(sdrf_path) -> str | None:
+    """First enzyme declared in the SDRF's ``comment[cleavage agent details]``.
+
+    The SDRF is the experiment's declared ground truth and is what the DIA-NN and
+    Spectronaut adapters already use, so preferring it here keeps missed-cleavage
+    counts consistent across converters rather than depending on which producer
+    wrote the file.
+    """
+    if not sdrf_path:
+        return None
+    try:
+        from qpx.core.sdrf import SDRFHandler
+
+        enzymes = SDRFHandler(str(sdrf_path)).get_enzymes()
+        if enzymes:
+            return str(enzymes[0])
+    except (OSError, KeyError, TypeError, ValueError):
+        _log.debug("Could not load enzyme from SDRF %s", sdrf_path)
+    return None
+
+
+def resolve_enzyme(cm, sdrf_path=None) -> str | None:
+    """Enzyme to count missed cleavages against: SDRF first, consensusXML second.
+
+    The SDRF wins because it is the declared experimental design and the other
+    converters already key on it. The consensusXML ``SearchParameters`` is the
+    fallback for a conversion run without an SDRF. A disagreement between the two
+    is a metadata inconsistency worth surfacing — the same treatment
+    :func:`check_channels_vs_sdrf` gives channel mismatches — but it is not fatal.
+    """
+    from_sdrf = sdrf_enzyme(sdrf_path)
+    from_xml = consensus_enzyme(cm)
+    if from_sdrf and from_xml and from_sdrf.strip().lower() != from_xml.strip().lower():
+        _log.warning(
+            "enzyme mismatch: SDRF declares %r, consensusXML SearchParameters says %r; using the SDRF for missed-cleavage counts",
+            from_sdrf,
+            from_xml,
+        )
+    return from_sdrf or from_xml
 
 
 def consensus_enzyme(cm) -> str | None:

--- a/qpx/converters/openms_consensus/feature_adapter.py
+++ b/qpx/converters/openms_consensus/feature_adapter.py
@@ -15,6 +15,7 @@ import re
 from typing import Optional
 
 from qpx.converters.channel_labels import normalize_label
+from qpx.core.cleavage import count_missed_cleavages
 from qpx.core.files import run_file_stem as _run_stem
 
 # OpenMS isobaric channel labels look like ``tmt6plex_126`` / ``itraq4plex_114``.
@@ -46,6 +47,36 @@ def mass_error_ppm(calculated_mz, observed_mz) -> float | None:
     if calculated_mz <= 0 or observed_mz <= 0:
         return None
     return float((observed_mz - calculated_mz) / calculated_mz * 1e6)
+
+
+def consensus_enzyme(cm) -> str | None:
+    """Digestion enzyme used for the search, or ``None`` when it is not recorded.
+
+    Read from the consensusXML ``<SearchParameters enzyme="...">``. Needed to count
+    missed cleavages, which the OpenMS path otherwise leaves null while the DIA-NN
+    path populates it (bigbio/qpx#300).
+
+    Works for both readers: the streaming map captures the attribute while parsing
+    its header, and a pyopenms ConsensusMap exposes it through the protein
+    identification's search parameters. ``unknown_enzyme`` counts as absent.
+    """
+    enzyme = getattr(cm, "_enzyme", None)
+    if not enzyme:
+        try:
+            prots = cm.getProteinIdentifications()
+            if prots:
+                params = prots[0].getSearchParameters()
+                digestion = getattr(params, "digestion_enzyme", None)
+                if digestion is not None:
+                    enzyme = digestion.getName()
+        except (AttributeError, IndexError, RuntimeError):
+            return None
+    if not enzyme:
+        return None
+    enzyme = str(enzyme).strip()
+    if not enzyme or enzyme.lower() in ("unknown_enzyme", "unknown", "no enzyme"):
+        return None
+    return enzyme
 
 
 def pep_of(hit) -> float | None:
@@ -403,7 +434,7 @@ def feature_map_info(cm) -> dict[int, tuple[str, str]]:
     return {idx: (_run_stem(headers[idx].filename), _map_label(headers[idx].label)) for idx in headers}
 
 
-def feature_records_for_cf(cf, map_info: dict[int, tuple[str, str]], group_map=None) -> list[dict]:
+def feature_records_for_cf(cf, map_info: dict[int, tuple[str, str]], group_map=None, enzyme=None) -> list[dict]:
     """Feature records for one consensus feature (one per run, channels as intensities).
 
     ``pg_accessions`` carries the full protein-group membership; the feature->pg
@@ -448,6 +479,9 @@ def feature_records_for_cf(cf, map_info: dict[int, tuple[str, str]], group_map=N
     # not proof of uniqueness, and claiming True there would invent information.
     unique = (len(group) == 1) if group else None
     error_ppm = mass_error_ppm(calculated_mz, observed_mz) if charge > 0 else None
+    # Missed cleavages are a property of the peptide and the search enzyme, both
+    # of which are in hand; the DIA-NN path already reports them (bigbio/qpx#300).
+    missed = count_missed_cleavages(sequence, enzyme) if enzyme else None
 
     records: list[dict] = []
     for run, entry in by_run.items():
@@ -469,6 +503,7 @@ def feature_records_for_cf(cf, map_info: dict[int, tuple[str, str]], group_map=N
                 "calculated_mz": calculated_mz,
                 "observed_mz": observed_mz,
                 "mass_error_ppm": error_ppm,
+                "missed_cleavages": missed,
                 "unique": unique,
                 "consensus_rt": consensus_rt,
                 "anchor_protein": anchor_protein,

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -30,6 +30,7 @@ from qpx.converters.openms_consensus.feature_adapter import (
 from qpx.converters.openms_consensus.feature_adapter import (
     pep_of as _pep_of,
 )
+from qpx.core.cleavage import count_missed_cleavages
 
 _log = logging.getLogger(__name__)
 
@@ -206,7 +207,7 @@ def consensus_psms_to_records(consensusxml_path: str | None = None, cm=None) -> 
     return records
 
 
-def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None) -> list[dict]:
+def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme=None) -> list[dict]:
     """PSM records for one PeptideIdentification (deduped via the shared ``seen`` set).
 
     ``cf_runs`` is the consensus feature's element-run set (passed for assigned
@@ -303,6 +304,7 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None) -> lis
                 "calculated_mz": calc_mz,
                 "observed_mz": obs_mz,
                 "mass_error_ppm": _mass_error_ppm(calc_mz, obs_mz),
+                "missed_cleavages": (count_missed_cleavages(seq_obj.toUnmodifiedString(), enzyme) if enzyme else None),
                 "posterior_error_probability": pep,
                 "additional_scores": additional_scores or None,
                 "is_decoy": is_decoy,

--- a/qpx/converters/openms_consensus/streaming.py
+++ b/qpx/converters/openms_consensus/streaming.py
@@ -319,6 +319,7 @@ class StreamingConsensusMap:
         self._path = str(path)
         self._headers: dict[int, _ColHeader] = {}
         self._prots: list[_ProteinIdentification] = []
+        self._enzyme: str = ""
         self._ph_to_acc: dict[str, str] = {}
         self._parse_header()
 
@@ -332,6 +333,13 @@ class StreamingConsensusMap:
             tag = _localname(el.tag)
             if event == "end" and tag == "map":
                 self._headers[int(el.attrib["id"])] = _ColHeader(el.attrib.get("name", ""), el.attrib.get("label", ""))
+                el.clear()
+            elif event == "end" and tag == "SearchParameters":
+                # The enzyme used for the search; needed to count missed cleavages.
+                # Kept here because the streaming reader never revisits the header.
+                enzyme = el.attrib.get("enzyme", "")
+                if enzyme and not self._enzyme:
+                    self._enzyme = enzyme
                 el.clear()
             elif event == "start" and tag == "ProteinIdentification":
                 ph_hits = []

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -1125,3 +1125,52 @@ class TestMissedCleavages:
         feats, psms = self._features(tmp_path, f"mcnull_{stream}", _TMT_CONSENSUSXML, stream)
         assert feats and all(f["missed_cleavages"] is None for f in feats)
         assert psms and all(p["missed_cleavages"] is None for p in psms)
+
+
+class TestEnzymeResolution:
+    """SDRF first, consensusXML second — and say so when they disagree."""
+
+    class _Map:
+        def __init__(self, enzyme):
+            self._enzyme = enzyme
+
+        def getProteinIdentifications(self):
+            return []
+
+    def _sdrf(self, tmp_path, enzyme):
+        path = tmp_path / "x.sdrf.tsv"
+        path.write_text(f"source name\tcomment[data file]\tcomment[cleavage agent details]\nS1\trun_01.mzML\tNT={enzyme}\n")
+        return path
+
+    def test_sdrf_wins_over_the_consensusxml(self, tmp_path):
+        from qpx.converters.openms_consensus.feature_adapter import resolve_enzyme
+
+        assert resolve_enzyme(self._Map("Trypsin"), self._sdrf(tmp_path, "Lys-C")) == "Lys-C"
+
+    def test_falls_back_to_the_consensusxml_without_an_sdrf(self, tmp_path):
+        from qpx.converters.openms_consensus.feature_adapter import resolve_enzyme
+
+        assert resolve_enzyme(self._Map("Trypsin"), None) == "Trypsin"
+
+    def test_disagreement_is_reported(self, tmp_path, caplog):
+        import logging
+
+        from qpx.converters.openms_consensus.feature_adapter import resolve_enzyme
+
+        with caplog.at_level(logging.WARNING):
+            resolve_enzyme(self._Map("Trypsin"), self._sdrf(tmp_path, "Lys-C"))
+        assert any("enzyme mismatch" in r.message for r in caplog.records)
+
+    def test_agreement_is_quiet(self, tmp_path, caplog):
+        import logging
+
+        from qpx.converters.openms_consensus.feature_adapter import resolve_enzyme
+
+        with caplog.at_level(logging.WARNING):
+            assert resolve_enzyme(self._Map("Trypsin"), self._sdrf(tmp_path, "Trypsin")) == "Trypsin"
+        assert not any("enzyme mismatch" in r.message for r in caplog.records)
+
+    def test_no_source_at_all_is_none(self):
+        from qpx.converters.openms_consensus.feature_adapter import resolve_enzyme
+
+        assert resolve_enzyme(self._Map("unknown_enzyme"), None) is None

--- a/tests/converters/test_openms_consensus.py
+++ b/tests/converters/test_openms_consensus.py
@@ -1071,3 +1071,57 @@ class TestSkipUnassignedPsms:
             )
             counts.append(pq.read_table(str(out / "X.pg.parquet")).num_rows)
         assert counts[0] == counts[1], "pg output changed when only PSM rows were filtered"
+
+
+class TestMissedCleavages:
+    """OpenMS output must report missed cleavages, as the DIA-NN path does.
+
+    The value is a property of the peptide and the search enzyme, both of which
+    the converter has: the enzyme is in the consensusXML SearchParameters
+    (bigbio/qpx#300).
+    """
+
+    # PEPTIDEK has no internal K/R; PEPKTIDEK has one internal K -> 1 missed cleavage.
+    _TRYPSIN = _TMT_CONSENSUSXML.replace('enzyme="unknown_enzyme"', 'enzyme="Trypsin"')
+    _TRYPSIN_MISSED = _TRYPSIN.replace('sequence="PEPTIDEK"', 'sequence="PEPKTIDEK"')
+
+    @staticmethod
+    def _features(tmp_path, name, xml, stream):
+        import pyarrow.parquet as pq
+
+        from qpx.converters.openms_consensus import converter as conv
+
+        path = tmp_path / f"{name}.consensusXML"
+        path.write_text(xml)
+        out = tmp_path / f"out_{name}"
+        conv._should_stream = lambda _p, v=stream: v
+        OpenMSConsensusConverter().convert(
+            str(path),
+            str(out),
+            output_prefix="X",
+            structures=("feature", "psm", "pg"),
+            project_accession="X",
+        )
+        return (
+            pq.read_table(str(out / "X.feature.parquet")).to_pylist(),
+            pq.read_table(str(out / "X.psm.parquet")).to_pylist(),
+        )
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
+    def test_zero_missed_cleavages(self, tmp_path, stream):
+        feats, psms = self._features(tmp_path, f"mc0_{stream}", self._TRYPSIN, stream)
+        assert feats and all(f["missed_cleavages"] == 0 for f in feats)
+        assert psms and all(p["missed_cleavages"] == 0 for p in psms)
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
+    def test_one_missed_cleavage(self, tmp_path, stream):
+        feats, psms = self._features(tmp_path, f"mc1_{stream}", self._TRYPSIN_MISSED, stream)
+        assert feats and all(f["missed_cleavages"] == 1 for f in feats)
+        assert psms and all(p["missed_cleavages"] == 1 for p in psms)
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
+    def test_unknown_enzyme_leaves_it_null(self, tmp_path, stream):
+        """No usable enzyme means unknown, not a guessed zero."""
+        feats, psms = self._features(tmp_path, f"mcnull_{stream}", _TMT_CONSENSUSXML, stream)
+        assert feats and all(f["missed_cleavages"] is None for f in feats)
+        assert psms and all(p["missed_cleavages"] is None for p in psms)


### PR DESCRIPTION
Addresses the clearest item in #300: `missed_cleavages` was populated by the DIA-NN converter and left null by the OpenMS one.

## Why it was possible

The value is a property of the peptide and the search enzyme, and both are in hand. Real quantms consensusXML records the enzyme:

```
$ grep -oE 'enzyme="[^"]*"' PXD012255...consensusXML | sort -u
enzyme="trypsin"
```

`consensus_enzyme()` reads it from either reader and normalises the absent cases.

## The streaming path needed work

The streaming reader parsed **no `SearchParameters` at all**. It now captures the attribute while walking the header, because it never revisits it. Without that, the field would have stayed null on exactly the large datasets that take the streaming path — the same trap as the unassigned-PSM option in #302, where gating only the in-memory path would have made the flag silently useless above 4 GB.

## Null stays meaningful

A missing, empty or `unknown_enzyme` value leaves the field null rather than guessing `0`. No enzyme means *unknown*, not *no missed cleavages* — the same rule applied to `mass_error_ppm` and `unique` in earlier PRs.

## Tests

Six tests, parametrised over both readers:

- `PEPTIDEK` under trypsin -> `0` in feature and psm;
- `PEPKTIDEK` (one internal K) -> `1`;
- `unknown_enzyme` -> `None`.

## A regression I introduced and the suite caught

While editing, a string replacement swallowed the `if charge > 0` guard on `mass_error_ppm`, undoing `f5b5eac` (*fix(openms): handle chargeless consensus PSMs*). `test_zero_charge_feature_has_no_mass_error` failed and I restored it. Flagging it because it was a contributor's fix, not mine, and it would have been an easy thing to miss in review.

Full suite: **949 passed**. pre-commit clean.

## Still open in #300

The remaining inconsistencies each need a decision rather than an implementation — `pg.contaminant` (DIA-NN reports no per-PG contaminant flag), `pg.pg_names` / `gg_*` (need the FASTA on the OpenMS side), `feature.cv_params`, `rt_start`/`rt_stop`, `id_run_file_name`. Worth resolving as a converter-coverage table in the spec so a null is self-explaining rather than ambiguous between "no data" and "not implemented".


---

## Update: the SDRF is now the primary source

Good catch on review — the SDRF carries `comment[cleavage agent details]`, and the **DIA-NN and Spectronaut adapters already key on it** via `SDRFHandler.get_enzymes()`. Reading it here too is what actually makes the counts consistent across converters, which was the point of #300; resolving only from the consensusXML would have left OpenMS counting against a different source than every other producer.

`resolve_enzyme(cm, sdrf_path)` now does:

1. **SDRF** `comment[cleavage agent details]` — the declared experimental design, and what the other adapters use;
2. **consensusXML `SearchParameters`** — fallback for a conversion run without an SDRF;
3. otherwise `None`, leaving `missed_cleavages` null.

**When the two disagree the SDRF wins and the mismatch is logged**, mirroring how `check_channels_vs_sdrf` treats a channel mismatch: a metadata inconsistency worth surfacing, not a reason to fail a conversion. Silently preferring one would hide a real problem — a wrong SDRF, or a search run with different parameters than declared.

Five more tests cover the precedence, the fallback, the warning on disagreement, silence on agreement, and the no-source case.

Full suite: **954 passed**. pre-commit clean.
