### PR TITLE
fix(openms)!: keep unassigned PSMs by default and mark them

### DIFF
--- a/docs/spec/psm.md
+++ b/docs/spec/psm.md
@@ -111,6 +111,26 @@ Several fields in the PSM view use structures shared across other QPX views:
 - For details on `additional_scores` and score semantics, see [Scores](scores.md).
 - For details on `cv_params` usage and recommended terms, see [Scores & CV Terms](scores.md).
 
+!!! note "PSMs with no quantified feature"
+    A PSM whose `feature_id` is null is an identification that is not linked to any
+    quantified feature — in OpenMS terms, an *unassigned* PeptideIdentification: the
+    spectrum was identified, but no MS1 feature was detected or mapped at that
+    retention time and m/z.
+
+    These rows are real identifications, not low-quality ones. On a representative
+    label-free dataset they are 41% of PSM rows, their median posterior error
+    probability is *better* than that of assigned PSMs, and 15% of their
+    peptidoforms appear nowhere else in the file — so they are kept by default.
+
+    They carry a `psm_assignment` = `unassigned` cv_param, so a consumer can select
+    or exclude them explicitly rather than inferring the distinction from a null
+    `feature_id`. **A `psm` -> `feature` join is therefore expected to be partial**;
+    join on `feature_id IS NOT NULL`, or convert with
+    `--no-include-unassigned-psms` for a quantified-only PSM view.
+
+    The converse does not occur: a feature is never emitted without an
+    identification, so there are no unidentified rows in the feature view.
+
 ## Example
 
 ### Basic PSM Record

--- a/docs/spec/psm.md
+++ b/docs/spec/psm.md
@@ -120,10 +120,18 @@ Several fields in the PSM view use structures shared across other QPX views:
 
     This is a statement about quantification, not about identification quality.
     Such rows carry a sequence, a score and a spectrum reference like any other
-    PSM; on a representative label-free dataset they are 41% of PSM rows and their
-    median posterior error probability is *better* than that of quantified PSMs.
-    They are written by default because some of their peptidoforms appear nowhere
-    else in the file.
+    PSM, and their median posterior error probability is typically *better* than
+    that of quantified PSMs.
+
+    Most are redundant rather than lost. A producer links one identification to a
+    feature, so when the same precursor is fragmented repeatedly across its
+    elution peak only one PSM attaches to the feature and the rest do not — on a
+    representative label-free dataset 97% of unquantified rows have a quantified
+    counterpart for the same run, sequence and charge. The remainder are
+    identifications whose MS1 signal was too weak or too poorly resolved for a
+    feature to be extracted, which is why they skew towards low-abundance
+    modified peptides and lower charge states. They are written by default so the
+    minority that appear nowhere else are not silently discarded.
 
     Read the split through the API rather than reimplementing the predicate:
 

--- a/docs/spec/psm.md
+++ b/docs/spec/psm.md
@@ -111,22 +111,30 @@ Several fields in the PSM view use structures shared across other QPX views:
 - For details on `additional_scores` and score semantics, see [Scores](scores.md).
 - For details on `cv_params` usage and recommended terms, see [Scores & CV Terms](scores.md).
 
-!!! note "PSMs with no quantified feature"
-    A PSM whose `feature_id` is null is an identification that is not linked to any
-    quantified feature — in OpenMS terms, an *unassigned* PeptideIdentification: the
-    spectrum was identified, but no MS1 feature was detected or mapped at that
-    retention time and m/z.
+!!! note "A null `feature_id` means not quantified"
+    `feature_id` links a PSM to the quantified feature it belongs to. When it is
+    null, the PSM **was identified but not quantified** — no feature was detected
+    or mapped for it. In OpenMS terms this is an *unassigned*
+    PeptideIdentification: the spectrum was identified, but no MS1 feature was
+    found at that retention time and m/z.
 
-    These rows are real identifications, not low-quality ones. On a representative
-    label-free dataset they are 41% of PSM rows, their median posterior error
-    probability is *better* than that of assigned PSMs, and 15% of their
-    peptidoforms appear nowhere else in the file — so they are kept by default.
+    This is a statement about quantification, not about identification quality.
+    Such rows carry a sequence, a score and a spectrum reference like any other
+    PSM; on a representative label-free dataset they are 41% of PSM rows and their
+    median posterior error probability is *better* than that of quantified PSMs.
+    They are written by default because some of their peptidoforms appear nowhere
+    else in the file.
 
-    They carry a `psm_assignment` = `unassigned` cv_param, so a consumer can select
-    or exclude them explicitly rather than inferring the distinction from a null
-    `feature_id`. **A `psm` -> `feature` join is therefore expected to be partial**;
-    join on `feature_id IS NOT NULL`, or convert with
-    `--no-include-unassigned-psms` for a quantified-only PSM view.
+    Read the split through the API rather than reimplementing the predicate:
+
+    ```python
+    psm.quantified()      # feature_id IS NOT NULL — safe to join to feature
+    psm.unquantified()    # feature_id IS NULL     — identified, not quantified
+    ```
+
+    **A `psm` -> `feature` join is therefore expected to be partial.** Join from
+    `psm.quantified()`, or convert with `--no-include-unassigned-psms` for a
+    quantified-only PSM view.
 
     The converse does not occur: a feature is never emitted without an
     identification, so there are no unidentified rows in the feature view.

--- a/qpx/cli/convert.py
+++ b/qpx/cli/convert.py
@@ -875,15 +875,18 @@ def convert_openms_cmd(**kwargs):
     help="PRIDE / ProteomeXchange accession (e.g. PXD001819)",
 )
 @click.option(
-    "--include-unassigned-psms",
-    is_flag=True,
-    default=False,
+    "--include-unassigned-psms/--no-include-unassigned-psms",
+    default=True,
+    show_default=True,
     help=(
-        "Also write identifications that are not linked to any consensus feature. "
-        "They are identified spectra but carry no quantification and their "
-        "feature_id is null, so a psm->feature join drops them anyway (41% of rows "
-        "on a real label-free dataset); they are omitted by default. Protein "
-        "inference always uses every identification either way."
+        "Write identifications that are not linked to any consensus feature. Kept "
+        "by default: they are real identifications (41% of PSM rows on a real "
+        "label-free dataset, with a better median PEP than the assigned ones, and "
+        "15% of their peptidoforms appear nowhere else). They are marked with a "
+        "psm_assignment=unassigned cv_param and have a null feature_id. Use "
+        "--no-include-unassigned-psms for a quantified-only PSM view. Features are "
+        "always identified regardless, and protein inference uses every "
+        "identification either way."
     ),
 )
 @click.option(

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -146,7 +146,7 @@ def _stream_feature_psm(
     map_run,
     seen,
     batch,
-    include_unassigned_psms=False,
+    include_unassigned_psms=True,
     enzyme=None,
 ):
     """One ordered element/unassigned pass: write feature/psm in batches and
@@ -180,7 +180,7 @@ def _stream_feature_psm(
         else:  # unassigned peptide identification
             if pw is not None and include_unassigned_psms:
                 # Unassigned PSMs map to no feature -> feature_id stays null.
-                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen, enzyme=enzyme))
+                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen, enzyme=enzyme, assigned=False))
             if maps is not None:
                 # Protein inference always sees every identification, whether or
                 # not the PSM rows are emitted: dropping evidence would change the
@@ -207,7 +207,7 @@ def _convert_streaming(
     creator,
     pg_top,
     compression="zstd",
-    include_unassigned_psms=False,
+    include_unassigned_psms=True,
 ) -> dict:
     """Single-pass, low-memory feature/psm/pg from a streamed consensusXML.
 
@@ -384,18 +384,27 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         streaming: Optional[bool] = None,
         project_accession: Optional[str] = None,
         compression: str = "zstd",
-        include_unassigned_psms: bool = False,
+        include_unassigned_psms: bool = True,
     ) -> dict[str, Path]:
         """Write the requested QPX views and return ``{structure: parquet path}``.
 
-        ``include_unassigned_psms`` (default ``False``) controls whether
+        ``include_unassigned_psms`` (default ``True``) controls whether
         identifications that are not linked to any consensus feature reach
-        ``psm.parquet``. They are identified spectra, but they carry no
-        quantification and their ``feature_id`` is null, so a ``psm -> feature``
-        join drops them anyway — 41% of rows on a real label-free dataset. The
-        default therefore emits a quantified-only PSM view; pass ``True`` to keep
-        them. Protein inference is unaffected either way: it always sees every
-        identification, because dropping evidence would change the protein groups.
+        ``psm.parquet``.
+
+        They are kept by default because they are real identifications: on a real
+        label-free dataset they are 41% of PSM rows, their median PEP is *better*
+        than the assigned ones, and 15% of their peptidoforms appear nowhere else
+        in the file. Dropping them would silently cost identification evidence.
+        They are marked with a ``psm_assignment=unassigned`` cv_param so a
+        consumer can select or exclude them without inferring it from a null
+        ``feature_id``.
+
+        Pass ``False`` for a quantified-only PSM view, where every row joins to a
+        feature. Note that features themselves are always identified — a
+        consensus feature with no peptide hit is never emitted — so this option
+        has no bearing on the feature view. Protein inference is unaffected
+        either way: it always sees every identification.
 
         ``structures`` selects which of feature/psm/pg/run/sample to emit. pg
         carries an interim unnormalized unique-peptide-sum intensity; ``pg_top``
@@ -551,7 +560,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         creator,
         pg_top,
         compression="zstd",
-        include_unassigned_psms=False,
+        include_unassigned_psms=True,
     ) -> dict:
         """feature/psm/pg via the in-memory pyopenms map (loaded once, iterated cheaply)."""
         from qpx.converters.openms_consensus.feature_adapter import feature_map_info, resolve_enzyme
@@ -591,7 +600,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
                 psm_recs.extend(cf_psms)
             if want_psm and include_unassigned_psms:
                 for pid in cm.getUnassignedPeptideIdentifications():
-                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme))
+                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme, assigned=False))
             if want_feature:
                 written["feature"] = _write_view(
                     FeatureWriter,

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -180,7 +180,7 @@ def _stream_feature_psm(
         else:  # unassigned peptide identification
             if pw is not None and include_unassigned_psms:
                 # Unassigned PSMs map to no feature -> feature_id stays null.
-                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen, enzyme=enzyme, assigned=False))
+                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen, enzyme=enzyme))
             if maps is not None:
                 # Protein inference always sees every identification, whether or
                 # not the PSM rows are emitted: dropping evidence would change the
@@ -396,9 +396,9 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         label-free dataset they are 41% of PSM rows, their median PEP is *better*
         than the assigned ones, and 15% of their peptidoforms appear nowhere else
         in the file. Dropping them would silently cost identification evidence.
-        They are marked with a ``psm_assignment=unassigned`` cv_param so a
-        consumer can select or exclude them without inferring it from a null
-        ``feature_id``.
+        A null ``feature_id`` is what marks them, and it means the PSM is **not
+        quantified** — not that it is unidentified. :meth:`PSM.quantified` and
+        :meth:`PSM.unquantified` expose that split directly.
 
         Pass ``False`` for a quantified-only PSM view, where every row joins to a
         feature. Note that features themselves are always identified — a
@@ -600,7 +600,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
                 psm_recs.extend(cf_psms)
             if want_psm and include_unassigned_psms:
                 for pid in cm.getUnassignedPeptideIdentifications():
-                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme, assigned=False))
+                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme))
             if want_feature:
                 written["feature"] = _write_view(
                     FeatureWriter,

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -246,8 +246,15 @@ def _psm_additional_scores(primary, hits, score, score_type, score_is_qvalue, hi
     return additional_scores, site_scores
 
 
-def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme=None) -> list[dict]:
+def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme=None, assigned=True) -> list[dict]:
     """PSM records for one PeptideIdentification (deduped via the shared ``seen`` set).
+
+    ``assigned`` says whether this PeptideIdentification belongs to a consensus
+    feature. When it does not, the record is stamped with a
+    ``psm_assignment=unassigned`` cv_param: those rows are real identifications
+    that simply have no quantified feature, and the marker lets a consumer select
+    or exclude them explicitly instead of inferring it from a null ``feature_id``
+    (bigbio/qpx#299).
 
     ``cf_runs`` is the consensus feature's element-run set (passed for assigned
     PIDs); it lets :func:`_run_resolver` attribute a PID whose ``id_merge_index``
@@ -317,6 +324,7 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme
                 "rt": float(pid.getRT()) if pid.getRT() else None,
                 "calculated_mz": calc_mz,
                 "observed_mz": obs_mz,
+                "cv_params": (None if assigned else [{"cv_name": "psm_assignment", "cv_value": "unassigned"}]),
                 "mass_error_ppm": _mass_error_ppm(calc_mz, obs_mz),
                 "missed_cleavages": (count_missed_cleavages(seq_obj.toUnmodifiedString(), enzyme) if enzyme else None),
                 "posterior_error_probability": pep,

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -246,15 +246,8 @@ def _psm_additional_scores(primary, hits, score, score_type, score_is_qvalue, hi
     return additional_scores, site_scores
 
 
-def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme=None, assigned=True) -> list[dict]:
+def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme=None) -> list[dict]:
     """PSM records for one PeptideIdentification (deduped via the shared ``seen`` set).
-
-    ``assigned`` says whether this PeptideIdentification belongs to a consensus
-    feature. When it does not, the record is stamped with a
-    ``psm_assignment=unassigned`` cv_param: those rows are real identifications
-    that simply have no quantified feature, and the marker lets a consumer select
-    or exclude them explicitly instead of inferring it from a null ``feature_id``
-    (bigbio/qpx#299).
 
     ``cf_runs`` is the consensus feature's element-run set (passed for assigned
     PIDs); it lets :func:`_run_resolver` attribute a PID whose ``id_merge_index``
@@ -324,7 +317,6 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme
                 "rt": float(pid.getRT()) if pid.getRT() else None,
                 "calculated_mz": calc_mz,
                 "observed_mz": obs_mz,
-                "cv_params": (None if assigned else [{"cv_name": "psm_assignment", "cv_value": "unassigned"}]),
                 "mass_error_ppm": _mass_error_ppm(calc_mz, obs_mz),
                 "missed_cleavages": (count_missed_cleavages(seq_obj.toUnmodifiedString(), enzyme) if enzyme else None),
                 "posterior_error_probability": pep,

--- a/qpx/core/data/psm.py
+++ b/qpx/core/data/psm.py
@@ -23,3 +23,28 @@ class PSM(BaseStructure):
     def targets_only(self) -> "PSM":
         """Filter to target PSMs only (exclude decoys)."""
         return self.filter("is_decoy = false")
+
+    def quantified(self) -> "PSM":
+        """Filter to PSMs that are linked to a quantified feature.
+
+        ``feature_id`` is null when the identification maps to no feature — in
+        OpenMS terms an *unassigned* PeptideIdentification, where the spectrum was
+        identified but no MS1 feature was detected or mapped at that RT and m/z.
+        Those rows are about **quantification**, not identification quality: they
+        carry a sequence, a score and a spectrum reference like any other PSM.
+
+        Use this before joining ``psm`` to ``feature``, which is otherwise a
+        partial join — on a representative label-free dataset 41% of PSM rows have
+        no feature (bigbio/qpx#299).
+        """
+        return self.filter("feature_id IS NOT NULL")
+
+    def unquantified(self) -> "PSM":
+        """Filter to identified PSMs that have no quantified feature.
+
+        The complement of :meth:`quantified`. These are identifications without
+        quantification, not failed identifications — their median posterior error
+        probability is typically better than that of quantified PSMs, and some of
+        their peptidoforms appear nowhere else in the file.
+        """
+        return self.filter("feature_id IS NULL")

--- a/tests/converters/test_openms_consensus_options.py
+++ b/tests/converters/test_openms_consensus_options.py
@@ -56,8 +56,13 @@ class TestSkipUnassignedPsms:
         return pq.read_table(str(out / "X.psm.parquet")).to_pylist()
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
-    def test_default_drops_unassigned(self, tmp_path, stream):
-        """The default PSM view is quantified-only."""
+    def test_default_keeps_unassigned_and_marks_them(self, tmp_path, stream):
+        """Unassigned PSMs are kept by default and are self-identifying.
+
+        They are real identifications with no quantified feature, so the artifact
+        keeps them; the cv_param means a consumer can select them explicitly
+        rather than inferring intent from a null feature_id.
+        """
         import pyarrow.parquet as pq
 
         from qpx.converters.openms_consensus import converter as conv
@@ -74,15 +79,22 @@ class TestSkipUnassignedPsms:
             project_accession="X",
         )
         rows = pq.read_table(str(out / "X.psm.parquet")).to_pylist()
-        assert "UNASSIGNEDK" not in {r["sequence"] for r in rows}
-        assert all(r["feature_id"] is not None for r in rows)
+        unassigned = [r for r in rows if r["sequence"] == "UNASSIGNEDK"]
+        assert unassigned, "an unassigned PSM must be kept by default"
+        for record in unassigned:
+            assert record["feature_id"] is None
+            assert record["cv_params"] == [{"cv_name": "psm_assignment", "cv_value": "unassigned"}]
+        for record in (r for r in rows if r["sequence"] != "UNASSIGNEDK"):
+            assert record["feature_id"] is not None, "assigned PSMs still link to a feature"
+            marks = [p for p in (record["cv_params"] or []) if p["cv_name"] == "psm_assignment"]
+            assert not marks, "assigned PSMs must not carry the unassigned marker"
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
-    def test_opt_in_keeps_unassigned(self, tmp_path, stream):
-        rows = self._convert(tmp_path, f"keep_{stream}", include=True, stream=stream)
-        seqs = {r["sequence"] for r in rows}
-        assert "UNASSIGNEDK" in seqs, "opt-in must restore them"
-        assert any(r["feature_id"] is None for r in rows)
+    def test_opt_out_drops_unassigned(self, tmp_path, stream):
+        """--no-include-unassigned-psms gives a quantified-only PSM view."""
+        rows = self._convert(tmp_path, f"drop_{stream}", include=False, stream=stream)
+        assert "UNASSIGNEDK" not in {r["sequence"] for r in rows}
+        assert rows and all(r["feature_id"] is not None for r in rows)
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
     def test_option_drops_unassigned_on_both_paths(self, tmp_path, stream):

--- a/tests/converters/test_openms_consensus_options.py
+++ b/tests/converters/test_openms_consensus_options.py
@@ -56,12 +56,11 @@ class TestSkipUnassignedPsms:
         return pq.read_table(str(out / "X.psm.parquet")).to_pylist()
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
-    def test_default_keeps_unassigned_and_marks_them(self, tmp_path, stream):
-        """Unassigned PSMs are kept by default and are self-identifying.
+    def test_default_keeps_psms_with_no_quantified_feature(self, tmp_path, stream):
+        """They are identifications without quantification, so the artifact keeps them.
 
-        They are real identifications with no quantified feature, so the artifact
-        keeps them; the cv_param means a consumer can select them explicitly
-        rather than inferring intent from a null feature_id.
+        A null ``feature_id`` is the marker; ``PSM.quantified()`` /
+        ``PSM.unquantified()`` are the supported way to split on it.
         """
         import pyarrow.parquet as pq
 
@@ -79,15 +78,13 @@ class TestSkipUnassignedPsms:
             project_accession="X",
         )
         rows = pq.read_table(str(out / "X.psm.parquet")).to_pylist()
-        unassigned = [r for r in rows if r["sequence"] == "UNASSIGNEDK"]
-        assert unassigned, "an unassigned PSM must be kept by default"
-        for record in unassigned:
-            assert record["feature_id"] is None
-            assert record["cv_params"] == [{"cv_name": "psm_assignment", "cv_value": "unassigned"}]
-        for record in (r for r in rows if r["sequence"] != "UNASSIGNEDK"):
-            assert record["feature_id"] is not None, "assigned PSMs still link to a feature"
-            marks = [p for p in (record["cv_params"] or []) if p["cv_name"] == "psm_assignment"]
-            assert not marks, "assigned PSMs must not carry the unassigned marker"
+        unquantified = [r for r in rows if r["sequence"] == "UNASSIGNEDK"]
+        assert unquantified, "a PSM with no quantified feature must be kept by default"
+        assert all(r["feature_id"] is None for r in unquantified)
+        assert all(r["sequence"] and r["posterior_error_probability"] is not None for r in unquantified), (
+            "they are identifications, so they carry a sequence and a score"
+        )
+        assert all(r["feature_id"] is not None for r in rows if r["sequence"] != "UNASSIGNEDK")
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
     def test_opt_out_drops_unassigned(self, tmp_path, stream):

--- a/tests/unit/test_psm_api.py
+++ b/tests/unit/test_psm_api.py
@@ -1,0 +1,42 @@
+"""PSM.quantified() / PSM.unquantified() — the supported split on feature_id."""
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from qpx.core.data import PSM
+
+
+@pytest.fixture(name="psm_file")
+def _psm_file(tmp_path):
+    """A tiny psm.parquet with two quantified rows and one unquantified."""
+    from tests.conftest import make_psm_record
+
+    records = []
+    for i, feature_id in enumerate((111, 222, None)):
+        record = dict(make_psm_record())
+        record["psm_id"] = 900 + i
+        record["sequence"] = f"PEPTIDE{i}"
+        record["feature_id"] = feature_id
+        records.append(record)
+    schema = PSM._schema_class.get_arrow_schema()
+    table = pa.Table.from_pylist([{k: r.get(k) for k in schema.names} for r in records], schema=schema)
+    path = tmp_path / "x.psm.parquet"
+    pq.write_table(table, path)
+    return path
+
+
+def test_quantified_keeps_only_linked_rows(psm_file):
+    psm = PSM.from_file(psm_file)
+    assert psm.count() == 3
+    assert psm.quantified().count() == 2
+    assert psm.quantified().to_df()["feature_id"].notna().all()
+
+
+def test_unquantified_is_the_complement(psm_file):
+    psm = PSM.from_file(psm_file)
+    assert psm.unquantified().count() == 1
+    # pandas renders a null int64 as NaN, not None.
+    assert psm.unquantified().to_df()["feature_id"].isna().all()
+    assert psm.quantified().count() + psm.unquantified().count() == psm.count()

--- a/tests/unit/test_psm_api.py
+++ b/tests/unit/test_psm_api.py
@@ -1,6 +1,5 @@
 """PSM.quantified() / PSM.unquantified() — the supported split on feature_id."""
 
-import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest


### PR DESCRIPTION
Closes #299. Reverts the default flipped in #303, and adds the annotation that makes these rows self-describing.

## Why the revert

#303 was made on a misreading of the request. The ask was to exclude **features with no identification** — but the OpenMS converter has never emitted those:

```python
pids = cf.getPeptideIdentifications()
if not pids or not pids[0].getHits():
    return []                      # feature_adapter.py:497
```

Confirmed on a real conversion: of 99,425 feature rows, **0** lack a sequence, peptidoform or protein. There was nothing to filter.

What #303 actually excluded was the mirror image — identifications with no quantified *feature*. Both surface as a null on one side of the `psm <-> feature` join, which is how the two got conflated.

## Why those rows are worth keeping

Measured on PXD012255 with unassigned PSMs retained:

```
PSM rows        total 167,715   assigned 99,425   unassigned 68,290 (40.7%)
unassigned have a sequence / PEP / scan reference          100% / 100% / 100%
median PEP      assigned 0.00217        unassigned 0.000902
distinct peptidoforms, unassigned                          13,893
  ... also quantified elsewhere                            11,824 (85.1%)
  ... appearing ONLY as unassigned                          2,069 (14.9%)
```

They are not low-quality: their median PEP is **better** than the assigned rows, consistent with confident MS2 identifications whose MS1 feature simply was not detected or mapped. And 2,069 peptidoforms exist nowhere else in the file, so excluding them by default cost real identification evidence — for a requirement that was never made.

## What this PR does

- **Default returns to including them.** The CLI flag becomes a proper pair, `--include-unassigned-psms` / `--no-include-unassigned-psms`, defaulting to include. A quantified-only PSM view is still one flag away.
- **Unassigned PSMs are marked** with a `psm_assignment` = `unassigned` cv_param, so a consumer can select or exclude them explicitly instead of inferring intent from a null `feature_id`. Assigned rows are asserted not to carry the marker.
- **`docs/spec/psm.md` documents the semantics** — what a null `feature_id` means, that a `psm -> feature` join is expected to be partial, and that the converse never occurs because features are always identified. That was #299's remaining ask, which #302/#303 never addressed.

## Breaking

`psm.parquet` row counts return to their pre-#303 values (167,715 rather than 99,425 on PXD012255). Since #303 has not been released to `main`, no published artifact has the reduced shape — this restores the long-standing behaviour rather than changing it again for downstream users.

Both converter paths are covered, parametrised over in-memory and streaming.

Full suite: **957 passed**. pre-commit clean.


---

## Update: API logic instead of a cv_param

Two corrections on review, both right:

**An invented CV term is worse than none.** `psm_assignment=unassigned` is not a controlled-vocabulary term. `cv_params` is for real CV terms, and minting one to encode something already derivable from the data is the wrong trade — it adds a second source of truth that can drift from `feature_id`. Removed.

**And the distinction is about quantification, not identification.** A null `feature_id` means the PSM *was identified but never quantified*, because no feature was detected or mapped for it. Calling it "unassigned" in the artifact framed it as a property of the identification, which is what caused the confusion this whole thread started from.

So the predicate lives in the API instead, next to the existing `targets_only()` / `by_run()` filters:

```python
psm.quantified()      # feature_id IS NOT NULL — safe to join to feature
psm.unquantified()    # feature_id IS NULL     — identified, not quantified
```

Consumers no longer reimplement `feature_id IS NULL` or have to guess what a null means, and there is exactly one source of truth. `docs/spec/psm.md` is reframed around quantification and shows the two calls rather than describing a marker.

Unchanged from the first pass: the default keeps these rows, and the CLI pair is `--include-unassigned-psms` / `--no-include-unassigned-psms`.

Full suite: **959 passed**. pre-commit clean.


---

## Correction: why these rows exist, measured rather than assumed

I justified keeping them partly on "15% of their peptidoforms appear nowhere else". That is true but overstates the loss, and it was not the main reason. Investigating the OpenMS side gives a better answer.

**97.3% of unassigned rows are redundant, not lost.**

```
of unassigned rows, share whose (run, sequence, charge)
ALSO has an assigned row:                        97.3%
```

ProteomicsLFQ links **one** PeptideIdentification to a ConsensusFeature. When the same precursor is fragmented several times across its elution peak — normal in DDA — one PSM attaches to the feature and the rest stay unassigned. They are duplicate evidence for something already quantified, not failed quantifications.

That reconciles with the earlier peptidoform figure: 97.3% of unassigned **rows** are redundant while 14.9% of distinct unassigned **peptidoforms** are unique, because the unique ones are rare rows. Excluding them costs far less than the 41% headline suggests — but it is not zero.

**The remainder is targeted extraction failing.** `quantms` runs ProteomicsLFQ with:

```
targeted_only             = true
feature_with_id_min_score = 0.10
lfq_intensity_threshold   = 1000
```

so FeatureFinderIdentification attempts an MS1 extraction at each identification's RT/mz, and produces nothing where the signal is too weak or the elution profile too poor. The data matches that mechanism:

```
phospho:  assigned 38.5%   unassigned 59.4%
charge 2  unassigned 46.9%       charge 4  unassigned 27.2%
charge 3  unassigned 38.3%       charge 5  unassigned 21.3%
```

Phosphopeptides are enriched among the unassigned (lower abundance, poorer MS1), and 2+ precursors fail most, consistent with co-elution and interference.

## Revised rationale for the default

Not "we would lose 41% of identifications" — we would not. Rather:

- the rows are overwhelmingly redundant, so keeping them harms nothing;
- the genuinely unique identifications (2,069 peptidoforms) are preserved rather than silently dropped;
- `PSM.quantified()` makes the split explicit and cheap, so a consumer wanting a quantification view pays nothing for their presence;
- and excluding them was never what was asked for — the original request was about features with no identification, which the converter has never emitted.

## Incidental finding, not a qpx issue

The unassigned fraction varies from 21.7% to **95.0%** across the 40 runs of PXD012255:

```
Phospho_redissolve_final_19   4,437 PSMs   95.0% unassigned
Phospho_redissolve_final_01   4,868        85.1%
Phospho_redissolve_final_10   9,941        75.7%
...
Phospho_redissolve_final_21   4,391        21.7%   (best)

the 3 worst runs contribute 23.3% of all unassigned rows
```

A run where 95% of identifications yield no quantifiable feature has an MS1 problem of its own. That is a property of the dataset, not of this converter, and is worth raising separately against the reanalysis rather than here.
