### PR TITLE
Keep unassigned PSMs by default and improve quantification handling

### DIFF
--- a/docs/spec/psm.md
+++ b/docs/spec/psm.md
@@ -111,41 +111,30 @@ Several fields in the PSM view use structures shared across other QPX views:
 - For details on `additional_scores` and score semantics, see [Scores](scores.md).
 - For details on `cv_params` usage and recommended terms, see [Scores & CV Terms](scores.md).
 
-!!! note "A null `feature_id` means not quantified"
-    `feature_id` links a PSM to the quantified feature it belongs to. When it is
-    null, the PSM **was identified but not quantified** — no feature was detected
-    or mapped for it. In OpenMS terms this is an *unassigned*
-    PeptideIdentification: the spectrum was identified, but no MS1 feature was
-    found at that retention time and m/z.
+!!! note "A null `feature_id` means no linked feature"
+    `feature_id` records a PSM's feature link in the exported dataset. A null
+    value means no link is recorded; it does not establish identification
+    quality or whether the precursor was quantified.
 
-    This is a statement about quantification, not about identification quality.
-    Such rows carry a sequence, a score and a spectrum reference like any other
-    PSM, and their median posterior error probability is typically *better* than
-    that of quantified PSMs.
+    OpenMS unassigned PeptideIdentifications are retained by default to preserve
+    identification evidence. Some repeat evidence for a precursor linked through
+    another spectrum, while others have no detected or mapped feature. Also,
+    when only the PSM view is exported, **all `feature_id` values are null**, even
+    for identifications assigned to a consensus feature in the source.
 
-    Most are redundant rather than lost. A producer links one identification to a
-    feature, so when the same precursor is fragmented repeatedly across its
-    elution peak only one PSM attaches to the feature and the rest do not — on a
-    representative label-free dataset 97% of unquantified rows have a quantified
-    counterpart for the same run, sequence and charge. The remainder are
-    identifications whose MS1 signal was too weak or too poorly resolved for a
-    feature to be extracted, which is why they skew towards low-abundance
-    modified peptides and lower charge states. They are written by default so the
-    minority that appear nowhere else are not silently discarded.
-
-    Read the split through the API rather than reimplementing the predicate:
+    The API filters the recorded links:
 
     ```python
-    psm.quantified()      # feature_id IS NOT NULL — safe to join to feature
-    psm.unquantified()    # feature_id IS NULL     — identified, not quantified
+    psm.with_feature()     # feature_id IS NOT NULL
+    psm.without_feature()  # feature_id IS NULL
     ```
 
-    **A `psm` -> `feature` join is therefore expected to be partial.** Join from
-    `psm.quantified()`, or convert with `--no-include-unassigned-psms` for a
-    quantified-only PSM view.
+    **A `psm` -> `feature` join is expected to be partial.** When both views are
+    present, join from `psm.with_feature()` on `feature_id`. The conversion option
+    `--no-include-unassigned-psms` excludes source unassigned identifications;
+    it does not populate feature links when the feature view is not exported.
 
-    The converse does not occur: a feature is never emitted without an
-    identification, so there are no unidentified rows in the feature view.
+    The OpenMS consensus converter omits features without peptide hits.
 
 ## Example
 

--- a/docs/spec/psm.md
+++ b/docs/spec/psm.md
@@ -111,6 +111,26 @@ Several fields in the PSM view use structures shared across other QPX views:
 - For details on `additional_scores` and score semantics, see [Scores](scores.md).
 - For details on `cv_params` usage and recommended terms, see [Scores & CV Terms](scores.md).
 
+!!! note "PSMs with no quantified feature"
+    A PSM whose `feature_id` is null is an identification that is not linked to any
+    quantified feature — in OpenMS terms, an *unassigned* PeptideIdentification: the
+    spectrum was identified, but no MS1 feature was detected or mapped at that
+    retention time and m/z.
+
+    These rows are real identifications, not low-quality ones. On a representative
+    label-free dataset they are 41% of PSM rows, their median posterior error
+    probability is *better* than that of assigned PSMs, and 15% of their
+    peptidoforms appear nowhere else in the file — so they are kept by default.
+
+    They carry a `psm_assignment` = `unassigned` cv_param, so a consumer can select
+    or exclude them explicitly rather than inferring the distinction from a null
+    `feature_id`. **A `psm` -> `feature` join is therefore expected to be partial**;
+    join on `feature_id IS NOT NULL`, or convert with
+    `--no-include-unassigned-psms` for a quantified-only PSM view.
+
+    The converse does not occur: a feature is never emitted without an
+    identification, so there are no unidentified rows in the feature view.
+
 ## Example
 
 ### Basic PSM Record

--- a/docs/spec/psm.md
+++ b/docs/spec/psm.md
@@ -120,10 +120,18 @@ Several fields in the PSM view use structures shared across other QPX views:
 
     This is a statement about quantification, not about identification quality.
     Such rows carry a sequence, a score and a spectrum reference like any other
-    PSM; on a representative label-free dataset they are 41% of PSM rows and their
-    median posterior error probability is *better* than that of quantified PSMs.
-    They are written by default because some of their peptidoforms appear nowhere
-    else in the file.
+    PSM, and their median posterior error probability is typically *better* than
+    that of quantified PSMs.
+
+    Most are redundant rather than lost. A producer links one identification to a
+    feature, so when the same precursor is fragmented repeatedly across its
+    elution peak only one PSM attaches to the feature and the rest do not — on a
+    representative label-free dataset 97% of unquantified rows have a quantified
+    counterpart for the same run, sequence and charge. The remainder are
+    identifications whose MS1 signal was too weak or too poorly resolved for a
+    feature to be extracted, which is why they skew towards low-abundance
+    modified peptides and lower charge states. They are written by default so the
+    minority that appear nowhere else are not silently discarded.
 
     Read the split through the API rather than reimplementing the predicate:
 

--- a/docs/spec/psm.md
+++ b/docs/spec/psm.md
@@ -111,22 +111,30 @@ Several fields in the PSM view use structures shared across other QPX views:
 - For details on `additional_scores` and score semantics, see [Scores](scores.md).
 - For details on `cv_params` usage and recommended terms, see [Scores & CV Terms](scores.md).
 
-!!! note "PSMs with no quantified feature"
-    A PSM whose `feature_id` is null is an identification that is not linked to any
-    quantified feature — in OpenMS terms, an *unassigned* PeptideIdentification: the
-    spectrum was identified, but no MS1 feature was detected or mapped at that
-    retention time and m/z.
+!!! note "A null `feature_id` means not quantified"
+    `feature_id` links a PSM to the quantified feature it belongs to. When it is
+    null, the PSM **was identified but not quantified** — no feature was detected
+    or mapped for it. In OpenMS terms this is an *unassigned*
+    PeptideIdentification: the spectrum was identified, but no MS1 feature was
+    found at that retention time and m/z.
 
-    These rows are real identifications, not low-quality ones. On a representative
-    label-free dataset they are 41% of PSM rows, their median posterior error
-    probability is *better* than that of assigned PSMs, and 15% of their
-    peptidoforms appear nowhere else in the file — so they are kept by default.
+    This is a statement about quantification, not about identification quality.
+    Such rows carry a sequence, a score and a spectrum reference like any other
+    PSM; on a representative label-free dataset they are 41% of PSM rows and their
+    median posterior error probability is *better* than that of quantified PSMs.
+    They are written by default because some of their peptidoforms appear nowhere
+    else in the file.
 
-    They carry a `psm_assignment` = `unassigned` cv_param, so a consumer can select
-    or exclude them explicitly rather than inferring the distinction from a null
-    `feature_id`. **A `psm` -> `feature` join is therefore expected to be partial**;
-    join on `feature_id IS NOT NULL`, or convert with
-    `--no-include-unassigned-psms` for a quantified-only PSM view.
+    Read the split through the API rather than reimplementing the predicate:
+
+    ```python
+    psm.quantified()      # feature_id IS NOT NULL — safe to join to feature
+    psm.unquantified()    # feature_id IS NULL     — identified, not quantified
+    ```
+
+    **A `psm` -> `feature` join is therefore expected to be partial.** Join from
+    `psm.quantified()`, or convert with `--no-include-unassigned-psms` for a
+    quantified-only PSM view.
 
     The converse does not occur: a feature is never emitted without an
     identification, so there are no unidentified rows in the feature view.

--- a/qpx/cli/convert.py
+++ b/qpx/cli/convert.py
@@ -875,15 +875,18 @@ def convert_openms_cmd(**kwargs):
     help="PRIDE / ProteomeXchange accession (e.g. PXD001819)",
 )
 @click.option(
-    "--include-unassigned-psms",
-    is_flag=True,
-    default=False,
+    "--include-unassigned-psms/--no-include-unassigned-psms",
+    default=True,
+    show_default=True,
     help=(
-        "Also write identifications that are not linked to any consensus feature. "
-        "They are identified spectra but carry no quantification and their "
-        "feature_id is null, so a psm->feature join drops them anyway (41% of rows "
-        "on a real label-free dataset); they are omitted by default. Protein "
-        "inference always uses every identification either way."
+        "Write identifications that are not linked to any consensus feature. Kept "
+        "by default: they are real identifications (41% of PSM rows on a real "
+        "label-free dataset, with a better median PEP than the assigned ones, and "
+        "15% of their peptidoforms appear nowhere else). They are marked with a "
+        "psm_assignment=unassigned cv_param and have a null feature_id. Use "
+        "--no-include-unassigned-psms for a quantified-only PSM view. Features are "
+        "always identified regardless, and protein inference uses every "
+        "identification either way."
     ),
 )
 @click.option(

--- a/qpx/cli/convert.py
+++ b/qpx/cli/convert.py
@@ -879,13 +879,10 @@ def convert_openms_cmd(**kwargs):
     default=True,
     show_default=True,
     help=(
-        "Write identifications that are not linked to any consensus feature. Kept "
-        "by default: they are real identifications (41% of PSM rows on a real "
-        "label-free dataset, with a better median PEP than the assigned ones, and "
-        "15% of their peptidoforms appear nowhere else). They are marked with a "
-        "psm_assignment=unassigned cv_param and have a null feature_id. Use "
-        "--no-include-unassigned-psms for a quantified-only PSM view. Features are "
-        "always identified regardless, and protein inference uses every "
+        "Keep unassigned peptide identifications by default to preserve identification "
+        "evidence. Use --no-include-unassigned-psms to exclude them. Feature links "
+        "are only written when both feature and PSM views are exported; a null "
+        "feature_id means no recorded link. Protein inference uses every "
         "identification either way."
     ),
 )

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -389,22 +389,18 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         """Write the requested QPX views and return ``{structure: parquet path}``.
 
         ``include_unassigned_psms`` (default ``True``) controls whether
-        identifications that are not linked to any consensus feature reach
-        ``psm.parquet``.
+        unassigned PeptideIdentifications from the source reach ``psm.parquet``.
+        They are retained to preserve identification evidence; pass ``False``
+        to exclude them.
 
-        They are kept by default because they are real identifications: on a real
-        label-free dataset they are 41% of PSM rows, their median PEP is *better*
-        than the assigned ones, and 15% of their peptidoforms appear nowhere else
-        in the file. Dropping them would silently cost identification evidence.
-        A null ``feature_id`` is what marks them, and it means the PSM is **not
-        quantified** — not that it is unidentified. :meth:`PSM.quantified` and
-        :meth:`PSM.unquantified` expose that split directly.
+        ``feature_id`` records a link in the exported dataset, not quantification
+        status. It is only populated when both feature and PSM views are emitted;
+        PSM-only output leaves it null even for assigned identifications.
+        ``PSM.with_feature()`` and ``PSM.without_feature()`` filter these links.
 
-        Pass ``False`` for a quantified-only PSM view, where every row joins to a
-        feature. Note that features themselves are always identified — a
-        consensus feature with no peptide hit is never emitted — so this option
-        has no bearing on the feature view. Protein inference is unaffected
-        either way: it always sees every identification.
+        The feature view always omits consensus features without peptide hits.
+        Protein inference always uses every identification, regardless of this
+        option.
 
         ``structures`` selects which of feature/psm/pg/run/sample to emit. pg
         carries an interim unnormalized unique-peptide-sum intensity; ``pg_top``

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -146,7 +146,7 @@ def _stream_feature_psm(
     map_run,
     seen,
     batch,
-    include_unassigned_psms=False,
+    include_unassigned_psms=True,
     enzyme=None,
 ):
     """One ordered element/unassigned pass: write feature/psm in batches and
@@ -180,7 +180,7 @@ def _stream_feature_psm(
         else:  # unassigned peptide identification
             if pw is not None and include_unassigned_psms:
                 # Unassigned PSMs map to no feature -> feature_id stays null.
-                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen, enzyme=enzyme))
+                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen, enzyme=enzyme, assigned=False))
             if maps is not None:
                 # Protein inference always sees every identification, whether or
                 # not the PSM rows are emitted: dropping evidence would change the
@@ -207,7 +207,7 @@ def _convert_streaming(
     creator,
     pg_top,
     compression="zstd",
-    include_unassigned_psms=False,
+    include_unassigned_psms=True,
 ) -> dict:
     """Single-pass, low-memory feature/psm/pg from a streamed consensusXML.
 
@@ -384,18 +384,27 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         streaming: Optional[bool] = None,
         project_accession: Optional[str] = None,
         compression: str = "zstd",
-        include_unassigned_psms: bool = False,
+        include_unassigned_psms: bool = True,
     ) -> dict[str, Path]:
         """Write the requested QPX views and return ``{structure: parquet path}``.
 
-        ``include_unassigned_psms`` (default ``False``) controls whether
+        ``include_unassigned_psms`` (default ``True``) controls whether
         identifications that are not linked to any consensus feature reach
-        ``psm.parquet``. They are identified spectra, but they carry no
-        quantification and their ``feature_id`` is null, so a ``psm -> feature``
-        join drops them anyway — 41% of rows on a real label-free dataset. The
-        default therefore emits a quantified-only PSM view; pass ``True`` to keep
-        them. Protein inference is unaffected either way: it always sees every
-        identification, because dropping evidence would change the protein groups.
+        ``psm.parquet``.
+
+        They are kept by default because they are real identifications: on a real
+        label-free dataset they are 41% of PSM rows, their median PEP is *better*
+        than the assigned ones, and 15% of their peptidoforms appear nowhere else
+        in the file. Dropping them would silently cost identification evidence.
+        They are marked with a ``psm_assignment=unassigned`` cv_param so a
+        consumer can select or exclude them without inferring it from a null
+        ``feature_id``.
+
+        Pass ``False`` for a quantified-only PSM view, where every row joins to a
+        feature. Note that features themselves are always identified — a
+        consensus feature with no peptide hit is never emitted — so this option
+        has no bearing on the feature view. Protein inference is unaffected
+        either way: it always sees every identification.
 
         ``structures`` selects which of feature/psm/pg/run/sample to emit. pg
         carries an interim unnormalized unique-peptide-sum intensity; ``pg_top``
@@ -551,7 +560,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         creator,
         pg_top,
         compression="zstd",
-        include_unassigned_psms=False,
+        include_unassigned_psms=True,
     ) -> dict:
         """feature/psm/pg via the in-memory pyopenms map (loaded once, iterated cheaply)."""
         from qpx.converters.openms_consensus.feature_adapter import feature_map_info, resolve_enzyme
@@ -591,7 +600,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
                 psm_recs.extend(cf_psms)
             if want_psm and include_unassigned_psms:
                 for pid in cm.getUnassignedPeptideIdentifications():
-                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme))
+                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme, assigned=False))
             if want_feature:
                 written["feature"] = _write_view(
                     FeatureWriter,

--- a/qpx/converters/openms_consensus/converter.py
+++ b/qpx/converters/openms_consensus/converter.py
@@ -180,7 +180,7 @@ def _stream_feature_psm(
         else:  # unassigned peptide identification
             if pw is not None and include_unassigned_psms:
                 # Unassigned PSMs map to no feature -> feature_id stays null.
-                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen, enzyme=enzyme, assigned=False))
+                psm_buf.extend(psm_records_for_pid(obj, resolve_run, seen, enzyme=enzyme))
             if maps is not None:
                 # Protein inference always sees every identification, whether or
                 # not the PSM rows are emitted: dropping evidence would change the
@@ -396,9 +396,9 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
         label-free dataset they are 41% of PSM rows, their median PEP is *better*
         than the assigned ones, and 15% of their peptidoforms appear nowhere else
         in the file. Dropping them would silently cost identification evidence.
-        They are marked with a ``psm_assignment=unassigned`` cv_param so a
-        consumer can select or exclude them without inferring it from a null
-        ``feature_id``.
+        A null ``feature_id`` is what marks them, and it means the PSM is **not
+        quantified** — not that it is unidentified. :meth:`PSM.quantified` and
+        :meth:`PSM.unquantified` expose that split directly.
 
         Pass ``False`` for a quantified-only PSM view, where every row joins to a
         feature. Note that features themselves are always identified — a
@@ -600,7 +600,7 @@ class OpenMSConsensusConverter(BaseOrchestrator):  # pylint: disable=too-few-pub
                 psm_recs.extend(cf_psms)
             if want_psm and include_unassigned_psms:
                 for pid in cm.getUnassignedPeptideIdentifications():
-                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme, assigned=False))
+                    psm_recs.extend(psm_records_for_pid(pid, resolve_run, seen, enzyme=enzyme))
             if want_feature:
                 written["feature"] = _write_view(
                     FeatureWriter,

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -246,8 +246,15 @@ def _psm_additional_scores(primary, hits, score, score_type, score_is_qvalue, hi
     return additional_scores, site_scores
 
 
-def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme=None) -> list[dict]:
+def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme=None, assigned=True) -> list[dict]:
     """PSM records for one PeptideIdentification (deduped via the shared ``seen`` set).
+
+    ``assigned`` says whether this PeptideIdentification belongs to a consensus
+    feature. When it does not, the record is stamped with a
+    ``psm_assignment=unassigned`` cv_param: those rows are real identifications
+    that simply have no quantified feature, and the marker lets a consumer select
+    or exclude them explicitly instead of inferring it from a null ``feature_id``
+    (bigbio/qpx#299).
 
     ``cf_runs`` is the consensus feature's element-run set (passed for assigned
     PIDs); it lets :func:`_run_resolver` attribute a PID whose ``id_merge_index``
@@ -317,6 +324,7 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme
                 "rt": float(pid.getRT()) if pid.getRT() else None,
                 "calculated_mz": calc_mz,
                 "observed_mz": obs_mz,
+                "cv_params": (None if assigned else [{"cv_name": "psm_assignment", "cv_value": "unassigned"}]),
                 "mass_error_ppm": _mass_error_ppm(calc_mz, obs_mz),
                 "missed_cleavages": (count_missed_cleavages(seq_obj.toUnmodifiedString(), enzyme) if enzyme else None),
                 "posterior_error_probability": pep,

--- a/qpx/converters/openms_consensus/psm_adapter.py
+++ b/qpx/converters/openms_consensus/psm_adapter.py
@@ -246,15 +246,8 @@ def _psm_additional_scores(primary, hits, score, score_type, score_is_qvalue, hi
     return additional_scores, site_scores
 
 
-def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme=None, assigned=True) -> list[dict]:
+def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme=None) -> list[dict]:
     """PSM records for one PeptideIdentification (deduped via the shared ``seen`` set).
-
-    ``assigned`` says whether this PeptideIdentification belongs to a consensus
-    feature. When it does not, the record is stamped with a
-    ``psm_assignment=unassigned`` cv_param: those rows are real identifications
-    that simply have no quantified feature, and the marker lets a consumer select
-    or exclude them explicitly instead of inferring it from a null ``feature_id``
-    (bigbio/qpx#299).
 
     ``cf_runs`` is the consensus feature's element-run set (passed for assigned
     PIDs); it lets :func:`_run_resolver` attribute a PID whose ``id_merge_index``
@@ -324,7 +317,6 @@ def psm_records_for_pid(pid, resolve_run, seen: set[tuple], cf_runs=None, enzyme
                 "rt": float(pid.getRT()) if pid.getRT() else None,
                 "calculated_mz": calc_mz,
                 "observed_mz": obs_mz,
-                "cv_params": (None if assigned else [{"cv_name": "psm_assignment", "cv_value": "unassigned"}]),
                 "mass_error_ppm": _mass_error_ppm(calc_mz, obs_mz),
                 "missed_cleavages": (count_missed_cleavages(seq_obj.toUnmodifiedString(), enzyme) if enzyme else None),
                 "posterior_error_probability": pep,

--- a/qpx/core/data/psm.py
+++ b/qpx/core/data/psm.py
@@ -23,3 +23,28 @@ class PSM(BaseStructure):
     def targets_only(self) -> "PSM":
         """Filter to target PSMs only (exclude decoys)."""
         return self.filter("is_decoy = false")
+
+    def quantified(self) -> "PSM":
+        """Filter to PSMs that are linked to a quantified feature.
+
+        ``feature_id`` is null when the identification maps to no feature — in
+        OpenMS terms an *unassigned* PeptideIdentification, where the spectrum was
+        identified but no MS1 feature was detected or mapped at that RT and m/z.
+        Those rows are about **quantification**, not identification quality: they
+        carry a sequence, a score and a spectrum reference like any other PSM.
+
+        Use this before joining ``psm`` to ``feature``, which is otherwise a
+        partial join — on a representative label-free dataset 41% of PSM rows have
+        no feature (bigbio/qpx#299).
+        """
+        return self.filter("feature_id IS NOT NULL")
+
+    def unquantified(self) -> "PSM":
+        """Filter to identified PSMs that have no quantified feature.
+
+        The complement of :meth:`quantified`. These are identifications without
+        quantification, not failed identifications — their median posterior error
+        probability is typically better than that of quantified PSMs, and some of
+        their peptidoforms appear nowhere else in the file.
+        """
+        return self.filter("feature_id IS NULL")

--- a/qpx/core/data/psm.py
+++ b/qpx/core/data/psm.py
@@ -24,27 +24,14 @@ class PSM(BaseStructure):
         """Filter to target PSMs only (exclude decoys)."""
         return self.filter("is_decoy = false")
 
-    def quantified(self) -> "PSM":
-        """Filter to PSMs that are linked to a quantified feature.
-
-        ``feature_id`` is null when the identification maps to no feature — in
-        OpenMS terms an *unassigned* PeptideIdentification, where the spectrum was
-        identified but no MS1 feature was detected or mapped at that RT and m/z.
-        Those rows are about **quantification**, not identification quality: they
-        carry a sequence, a score and a spectrum reference like any other PSM.
-
-        Use this before joining ``psm`` to ``feature``, which is otherwise a
-        partial join — on a representative label-free dataset 41% of PSM rows have
-        no feature (bigbio/qpx#299).
-        """
+    def with_feature(self) -> "PSM":
+        """Filter to PSMs with a populated ``feature_id``."""
         return self.filter("feature_id IS NOT NULL")
 
-    def unquantified(self) -> "PSM":
-        """Filter to identified PSMs that have no quantified feature.
+    def without_feature(self) -> "PSM":
+        """Filter to PSMs without a populated ``feature_id``.
 
-        The complement of :meth:`quantified`. These are identifications without
-        quantification, not failed identifications — their median posterior error
-        probability is typically better than that of quantified PSMs, and some of
-        their peptidoforms appear nowhere else in the file.
+        A missing link does not establish whether the precursor was quantified.
+        OpenMS PSM-only exports also leave assigned PSMs' feature links null.
         """
         return self.filter("feature_id IS NULL")

--- a/tests/converters/test_openms_consensus_options.py
+++ b/tests/converters/test_openms_consensus_options.py
@@ -56,8 +56,13 @@ class TestSkipUnassignedPsms:
         return pq.read_table(str(out / "X.psm.parquet")).to_pylist()
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
-    def test_default_drops_unassigned(self, tmp_path, stream):
-        """The default PSM view is quantified-only."""
+    def test_default_keeps_unassigned_and_marks_them(self, tmp_path, stream):
+        """Unassigned PSMs are kept by default and are self-identifying.
+
+        They are real identifications with no quantified feature, so the artifact
+        keeps them; the cv_param means a consumer can select them explicitly
+        rather than inferring intent from a null feature_id.
+        """
         import pyarrow.parquet as pq
 
         from qpx.converters.openms_consensus import converter as conv
@@ -74,15 +79,22 @@ class TestSkipUnassignedPsms:
             project_accession="X",
         )
         rows = pq.read_table(str(out / "X.psm.parquet")).to_pylist()
-        assert "UNASSIGNEDK" not in {r["sequence"] for r in rows}
-        assert all(r["feature_id"] is not None for r in rows)
+        unassigned = [r for r in rows if r["sequence"] == "UNASSIGNEDK"]
+        assert unassigned, "an unassigned PSM must be kept by default"
+        for record in unassigned:
+            assert record["feature_id"] is None
+            assert record["cv_params"] == [{"cv_name": "psm_assignment", "cv_value": "unassigned"}]
+        for record in (r for r in rows if r["sequence"] != "UNASSIGNEDK"):
+            assert record["feature_id"] is not None, "assigned PSMs still link to a feature"
+            marks = [p for p in (record["cv_params"] or []) if p["cv_name"] == "psm_assignment"]
+            assert not marks, "assigned PSMs must not carry the unassigned marker"
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
-    def test_opt_in_keeps_unassigned(self, tmp_path, stream):
-        rows = self._convert(tmp_path, f"keep_{stream}", include=True, stream=stream)
-        seqs = {r["sequence"] for r in rows}
-        assert "UNASSIGNEDK" in seqs, "opt-in must restore them"
-        assert any(r["feature_id"] is None for r in rows)
+    def test_opt_out_drops_unassigned(self, tmp_path, stream):
+        """--no-include-unassigned-psms gives a quantified-only PSM view."""
+        rows = self._convert(tmp_path, f"drop_{stream}", include=False, stream=stream)
+        assert "UNASSIGNEDK" not in {r["sequence"] for r in rows}
+        assert rows and all(r["feature_id"] is not None for r in rows)
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
     def test_option_drops_unassigned_on_both_paths(self, tmp_path, stream):

--- a/tests/converters/test_openms_consensus_options.py
+++ b/tests/converters/test_openms_consensus_options.py
@@ -56,12 +56,11 @@ class TestSkipUnassignedPsms:
         return pq.read_table(str(out / "X.psm.parquet")).to_pylist()
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
-    def test_default_keeps_unassigned_and_marks_them(self, tmp_path, stream):
-        """Unassigned PSMs are kept by default and are self-identifying.
+    def test_default_keeps_psms_with_no_quantified_feature(self, tmp_path, stream):
+        """They are identifications without quantification, so the artifact keeps them.
 
-        They are real identifications with no quantified feature, so the artifact
-        keeps them; the cv_param means a consumer can select them explicitly
-        rather than inferring intent from a null feature_id.
+        A null ``feature_id`` is the marker; ``PSM.quantified()`` /
+        ``PSM.unquantified()`` are the supported way to split on it.
         """
         import pyarrow.parquet as pq
 
@@ -79,15 +78,13 @@ class TestSkipUnassignedPsms:
             project_accession="X",
         )
         rows = pq.read_table(str(out / "X.psm.parquet")).to_pylist()
-        unassigned = [r for r in rows if r["sequence"] == "UNASSIGNEDK"]
-        assert unassigned, "an unassigned PSM must be kept by default"
-        for record in unassigned:
-            assert record["feature_id"] is None
-            assert record["cv_params"] == [{"cv_name": "psm_assignment", "cv_value": "unassigned"}]
-        for record in (r for r in rows if r["sequence"] != "UNASSIGNEDK"):
-            assert record["feature_id"] is not None, "assigned PSMs still link to a feature"
-            marks = [p for p in (record["cv_params"] or []) if p["cv_name"] == "psm_assignment"]
-            assert not marks, "assigned PSMs must not carry the unassigned marker"
+        unquantified = [r for r in rows if r["sequence"] == "UNASSIGNEDK"]
+        assert unquantified, "a PSM with no quantified feature must be kept by default"
+        assert all(r["feature_id"] is None for r in unquantified)
+        assert all(r["sequence"] and r["posterior_error_probability"] is not None for r in unquantified), (
+            "they are identifications, so they carry a sequence and a score"
+        )
+        assert all(r["feature_id"] is not None for r in rows if r["sequence"] != "UNASSIGNEDK")
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
     def test_opt_out_drops_unassigned(self, tmp_path, stream):

--- a/tests/converters/test_openms_consensus_options.py
+++ b/tests/converters/test_openms_consensus_options.py
@@ -15,12 +15,7 @@ from tests.converters.test_openms_consensus import _TMT_CONSENSUSXML  # noqa: E4
 
 
 class TestSkipUnassignedPsms:
-    """`include_unassigned_psms=False` drops PSMs that link to no feature.
-
-    Unassigned identifications carry no quantification and their feature_id is
-    null, so a psm->feature join silently drops them anyway — 41% of rows on a
-    real label-free dataset (bigbio/qpx#299). The option makes that explicit.
-    """
+    """`include_unassigned_psms=False` excludes source unassigned identifications."""
 
     _XML_WITH_UNASSIGNED = _TMT_CONSENSUSXML.replace(
         "</consensusElementList>",
@@ -56,12 +51,8 @@ class TestSkipUnassignedPsms:
         return pq.read_table(str(out / "X.psm.parquet")).to_pylist()
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
-    def test_default_keeps_psms_with_no_quantified_feature(self, tmp_path, stream):
-        """They are identifications without quantification, so the artifact keeps them.
-
-        A null ``feature_id`` is the marker; ``PSM.quantified()`` /
-        ``PSM.unquantified()`` are the supported way to split on it.
-        """
+    def test_default_keeps_unassigned_psms(self, tmp_path, stream):
+        """Unassigned identifications are retained without a feature link."""
         import pyarrow.parquet as pq
 
         from qpx.converters.openms_consensus import converter as conv
@@ -78,28 +69,41 @@ class TestSkipUnassignedPsms:
             project_accession="X",
         )
         rows = pq.read_table(str(out / "X.psm.parquet")).to_pylist()
-        unquantified = [r for r in rows if r["sequence"] == "UNASSIGNEDK"]
-        assert unquantified, "a PSM with no quantified feature must be kept by default"
-        assert all(r["feature_id"] is None for r in unquantified)
-        assert all(r["sequence"] and r["posterior_error_probability"] is not None for r in unquantified), (
+        unassigned = [r for r in rows if r["sequence"] == "UNASSIGNEDK"]
+        assert unassigned, "an unassigned PSM must be kept by default"
+        assert all(r["feature_id"] is None for r in unassigned)
+        assert all(r["sequence"] and r["posterior_error_probability"] is not None for r in unassigned), (
             "they are identifications, so they carry a sequence and a score"
         )
         assert all(r["feature_id"] is not None for r in rows if r["sequence"] != "UNASSIGNEDK")
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
     def test_opt_out_drops_unassigned(self, tmp_path, stream):
-        """--no-include-unassigned-psms gives a quantified-only PSM view."""
+        """The opt-out excludes source unassigned identifications."""
         rows = self._convert(tmp_path, f"drop_{stream}", include=False, stream=stream)
         assert "UNASSIGNEDK" not in {r["sequence"] for r in rows}
         assert rows and all(r["feature_id"] is not None for r in rows)
 
     @pytest.mark.parametrize("stream", [False, True], ids=["memory", "streaming"])
-    def test_option_drops_unassigned_on_both_paths(self, tmp_path, stream):
-        rows = self._convert(tmp_path, f"drop_{stream}", include=False, stream=stream)
-        seqs = {r["sequence"] for r in rows}
-        assert "UNASSIGNEDK" not in seqs, "unassigned PSM was still written"
-        assert rows, "assigned PSMs must survive"
-        assert all(r["feature_id"] is not None for r in rows), "every remaining PSM links to a feature"
+    def test_psm_only_keeps_assigned_psms_without_feature_links(self, tmp_path, stream):
+        """An assigned source PSM can have no feature link in the exported view."""
+        from qpx.core.data import PSM
+        from qpx.core.engine import DuckDBEngine
+
+        path = tmp_path / "psm-only.consensusXML"
+        path.write_text(self._XML_WITH_UNASSIGNED)
+        written = OpenMSConsensusConverter().convert(
+            str(path),
+            str(tmp_path / "out"),
+            structures=("psm",),
+            streaming=stream,
+            include_unassigned_psms=False,
+        )
+        with DuckDBEngine(threads=24) as engine:
+            engine.register_parquet("psm", written["psm"])
+            psm = PSM(engine=engine, table_name="psm", file_path=written["psm"])
+            assert psm.with_feature().count() == 0
+            assert psm.without_feature().to_df()["sequence"].tolist() == ["PEPTIDEK"]
 
     def test_protein_inference_is_unaffected(self, tmp_path):
         """Dropping PSM rows must not change the protein groups."""

--- a/tests/unit/test_psm_api.py
+++ b/tests/unit/test_psm_api.py
@@ -1,0 +1,42 @@
+"""PSM.quantified() / PSM.unquantified() — the supported split on feature_id."""
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from qpx.core.data import PSM
+
+
+@pytest.fixture(name="psm_file")
+def _psm_file(tmp_path):
+    """A tiny psm.parquet with two quantified rows and one unquantified."""
+    from tests.conftest import make_psm_record
+
+    records = []
+    for i, feature_id in enumerate((111, 222, None)):
+        record = dict(make_psm_record())
+        record["psm_id"] = 900 + i
+        record["sequence"] = f"PEPTIDE{i}"
+        record["feature_id"] = feature_id
+        records.append(record)
+    schema = PSM._schema_class.get_arrow_schema()
+    table = pa.Table.from_pylist([{k: r.get(k) for k in schema.names} for r in records], schema=schema)
+    path = tmp_path / "x.psm.parquet"
+    pq.write_table(table, path)
+    return path
+
+
+def test_quantified_keeps_only_linked_rows(psm_file):
+    psm = PSM.from_file(psm_file)
+    assert psm.count() == 3
+    assert psm.quantified().count() == 2
+    assert psm.quantified().to_df()["feature_id"].notna().all()
+
+
+def test_unquantified_is_the_complement(psm_file):
+    psm = PSM.from_file(psm_file)
+    assert psm.unquantified().count() == 1
+    # pandas renders a null int64 as NaN, not None.
+    assert psm.unquantified().to_df()["feature_id"].isna().all()
+    assert psm.quantified().count() + psm.unquantified().count() == psm.count()

--- a/tests/unit/test_psm_api.py
+++ b/tests/unit/test_psm_api.py
@@ -1,4 +1,4 @@
-"""PSM.quantified() / PSM.unquantified() — the supported split on feature_id."""
+"""PSM.with_feature() / PSM.without_feature() filter recorded feature links."""
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -9,7 +9,7 @@ from qpx.core.data import PSM
 
 @pytest.fixture(name="psm_file")
 def _psm_file(tmp_path):
-    """A tiny psm.parquet with two quantified rows and one unquantified."""
+    """A tiny psm.parquet with two linked rows and one unlinked row."""
     from tests.conftest import make_psm_record
 
     records = []
@@ -19,23 +19,24 @@ def _psm_file(tmp_path):
         record["sequence"] = f"PEPTIDE{i}"
         record["feature_id"] = feature_id
         records.append(record)
-    schema = PSM._schema_class.get_arrow_schema()
+    schema = PSM.schema()
     table = pa.Table.from_pylist([{k: r.get(k) for k in schema.names} for r in records], schema=schema)
     path = tmp_path / "x.psm.parquet"
     pq.write_table(table, path)
     return path
 
 
-def test_quantified_keeps_only_linked_rows(psm_file):
-    psm = PSM.from_file(psm_file)
+def test_with_feature_keeps_only_linked_rows(psm_file):
+    """Filtering feature links leaves the original PSM view intact."""
+    psm = PSM.from_file(psm_file, threads=24)
+    assert psm.with_feature().count() == 2
+    assert psm.with_feature().to_df()["feature_id"].notna().all()
     assert psm.count() == 3
-    assert psm.quantified().count() == 2
-    assert psm.quantified().to_df()["feature_id"].notna().all()
 
 
-def test_unquantified_is_the_complement(psm_file):
-    psm = PSM.from_file(psm_file)
-    assert psm.unquantified().count() == 1
-    # pandas renders a null int64 as NaN, not None.
-    assert psm.unquantified().to_df()["feature_id"].isna().all()
-    assert psm.quantified().count() + psm.unquantified().count() == psm.count()
+def test_without_feature_is_the_complement(psm_file):
+    """Linked and unlinked filters partition all PSM rows."""
+    psm = PSM.from_file(psm_file, threads=24)
+    assert psm.without_feature().count() == 1
+    assert psm.without_feature().to_df()["feature_id"].isna().all()
+    assert psm.with_feature().count() + psm.without_feature().count() == psm.count()

--- a/tests/unit/test_psm_api.py
+++ b/tests/unit/test_psm_api.py
@@ -1,6 +1,5 @@
 """PSM.quantified() / PSM.unquantified() — the supported split on feature_id."""
 
-import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenMS consensus conversion now retains unassigned peptide identifications by default.
  * Added an option to exclude unassigned identifications when needed.
  * Renamed PSM filters to `with_feature()` and `without_feature()` to clarify that they filter recorded feature links.

* **Documentation**
  * Clarified feature-link behavior, including null links in PSM-only exports and partial joins.
  * Documented identification retention and feature-view handling.

* **Tests**
  * Added coverage for the renamed PSM filters and updated OpenMS conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->