### PR TITLE
ci: fix stale CLI options in the integration workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,8 +45,8 @@ jobs:
             --pg-matrix-path tests/examples/diann/small/diann_report.pg_matrix.tsv \
             --output-folder examples/output \
             --output-prefix diann \
-            --duckdb-max-memory 4GB \
-            --duckdb-threads 4 \
+            --max-memory 4GB \
+            --max-cpus 4 \
             --verbose
 
           echo "=== MaxQuant Examples ==="


### PR DESCRIPTION
The **Integration Tests** workflow has failed on every release since v1.1.0. Last green run was v1.0.2 in May.

```
v1.1.3  failure      v1.1.0  failure
v1.1.2  failure      v1.0.2  success   <- last green
v1.1.1  failure
```

## Cause

`5810dd9` (2026-05-17) renamed the CLI params to `--max-memory` / `--max-cpus`. This workflow was never updated and still passes the old names:

```
Error: No such option '--duckdb-max-memory'. Did you mean '--max-memory'?
```

This is a **stale workflow, not a code regression** — the failing step generates example outputs, and it dies at the *first* `qpxc` call, which means the MaxQuant step below it has not run since May either.

## Fix

`--duckdb-max-memory` -> `--max-memory`, `--duckdb-threads` -> `--max-cpus`.

Rather than fix only the reported error and move the failure downstream, I checked **every** option both invocations pass against the current CLI help. These two were the only stale ones, and the DIA-NN command completes locally once corrected.

## Why it matters beyond the badge

Four releases shipped with a red Integration Tests signal, so a genuine failure there would have been indistinguishable from this one. That is the real cost, not the cosmetics.
