### PR TITLE
fix(mudata): write empty strings for null gene names

### DIFF
--- a/qpx/mudata.py
+++ b/qpx/mudata.py
@@ -534,7 +534,14 @@ def _build_protein_adata(
     gene_df = gene_df.drop_duplicates(subset="anchor_protein", keep="first")
     gene_df = gene_df.set_index("anchor_protein").reindex(proteins)
 
-    var = pd.DataFrame({"gene_name": gene_df["gene_name"].values}, index=proteins)
+    # A missing gene must still serialise as a string. When every protein lacks a
+    # gene the column comes back float64 (all NaN) and h5py refuses to write var
+    # ("Can't implicitly convert non-string objects to strings"). That is the norm
+    # for TMT datasets whose consensusXML carries no GN= descriptions, so gg_names
+    # is NULL on every row. Same reason _load_run_obs fills its string columns.
+    gene_names = gene_df["gene_name"].fillna("").astype(str)
+
+    var = pd.DataFrame({"gene_name": gene_names.values}, index=proteins)
 
     return ad.AnnData(X=intensity_matrix, obs=obs, var=var)
 

--- a/tests/unit/test_mudata.py
+++ b/tests/unit/test_mudata.py
@@ -682,3 +682,44 @@ class TestArrowPivotEquivalence:
         assert list(arrow_index) == list(pandas_index)
         assert list(arrow_keys["run_file_name"]) == list(pandas_keys["run_file_name"])
         assert list(arrow_keys["intensity_label"]) == list(pandas_keys["intensity_label"])
+
+
+def test_protein_var_gene_names_serialise_when_every_gene_is_null(tmp_path):
+    """All-NULL gg_names must still write to h5mu.
+
+    TMT datasets whose consensusXML carries no GN= descriptions come back with
+    gg_names NULL on every row, so the gene_name column is inferred as float64
+    (all NaN) and h5py refuses it: "Can't implicitly convert non-string objects
+    to strings" (seen on MSV000085836, 4.89M protein rows).
+    """
+    with FeatureWriter(tmp_path / "g.feature.parquet") as writer:
+        writer.write_batch([make_feature_record(intensities=[{"label": "TMT126", "intensity": 10.0}])])
+
+    pg = make_pg_record(intensities=[{"label": "TMT126", "intensity": 100.0}])
+    pg["gg_names"] = None
+    with PgWriter(tmp_path / "g.pg.parquet") as writer:
+        writer.write_batch([pg])
+
+    run = make_run_record()
+    run["samples"] = [
+        {
+            "sample_accession": "g_TMT126",
+            "label": "TMT126",
+            "biological_replicate": 1,
+            "technical_replicate": 1,
+        }
+    ]
+    with RunWriter(tmp_path / "g.run.parquet") as writer:
+        writer.write_batch([run])
+
+    dataset = Dataset(tmp_path, file_prefix="g")
+    try:
+        mdata = build_mudata(dataset, intensity_label="TMT126", modalities=["proteins"])
+        gene_names = mdata.mod["proteins"].var["gene_name"]
+        assert list(gene_names) == [""]
+        assert all(isinstance(value, str) for value in gene_names)
+        mdata.write(str(tmp_path / "g.h5mu"))
+    finally:
+        dataset.close()
+
+    assert (tmp_path / "g.h5mu").exists()


### PR DESCRIPTION
## Problem

`mdata.write()` fails with `TypeError: Can't implicitly convert non-string objects to strings` (h5py, writing key `gene_name` of `/var`) whenever **every** protein lacks a gene name.

`_build_protein_adata` reads `pg.gg_names[1]`, which is NULL when a protein has no gene. With a few nulls the column stays `object` and writes fine; when all values are NULL pandas infers `float64` (all NaN) and h5py refuses it.

This is the norm for TMT datasets whose consensusXML carries no `GN=` protein descriptions. Hit in production on MSV000085836 (TMT10, 552 raw files): all 4,891,140 protein rows had NULL `gg_names`, so the quantms pipeline aborted at `QPX_OPENMSCONSENSUS` after ~80 min — on all three attempts, and after the parquet outputs had already been written correctly. Label-free runs were unaffected (e.g. PXD000396: genes on 111,195 of 111,235 rows).

## Fix

Fill missing gene names with `""` and coerce to `str`, mirroring what `_load_run_obs` already does for its string columns.

## Test

`test_protein_var_gene_names_serialise_when_every_gene_is_null` builds a pg bundle with `gg_names=None` and asserts the h5mu write succeeds. Verified it fails on `dev` with exactly the production error and passes with the fix. Full `tests/unit/test_mudata.py`: 23 passed.