### PR TITLE
Fix integration workflow CLI options and enhance gene mapping

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,8 +45,8 @@ jobs:
             --pg-matrix-path tests/examples/diann/small/diann_report.pg_matrix.tsv \
             --output-folder examples/output \
             --output-prefix diann \
-            --duckdb-max-memory 4GB \
-            --duckdb-threads 4 \
+            --max-memory 4GB \
+            --max-cpus 4 \
             --verbose
 
           echo "=== MaxQuant Examples ==="

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`qpxc transform gene-map --dataset`**: annotate a whole QPX dataset instead of one file. Both quantification views that carry protein accessions (pg and feature) are annotated, identity recipes are preserved so `pg_id`/`feature_id` do not change, and the dataset's MuData view is rebuilt when one is present — so a `.h5mu` never describes stale genes. Writes go through a staging directory, so `--in-place` never truncates a parquet that is still being read.
+- **`qpx.mudata.write_dataset_mudata()`**: the converters' best-effort `.h5mu` writer, extracted so transforms that rewrite parquet can refresh the view the same way.
 - **QuantMS MSstats converter**: `qpxc convert quantms-msstats` converts a QuantMS-generated `*_msstats_in.csv` plus its authoritative SDRF into QPX Feature, Sample, Run, Dataset, Ontology, and Provenance views. LFQ/TMT/iTRAQ labels are canonicalized, channel rows are collapsed per measured Feature, and unsupported PSM/PG views are not fabricated.
 - **Spectronaut converter**: `qpxc convert spectronaut` — full support for Spectronaut report TSV files, producing feature.parquet and pg.parquet with DuckDB-accelerated batch processing
 - **CPTAC CDAP converter**: `qpxc convert cdap` — convert CPTAC CDAP `.psm` study directories to QPX psm/feature/pg/dataset/ontology/provenance views

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`gene-map --dataset` copied only top-level files** — sharded / partitioned datasets kept their views in subdirectories, so an annotated copy came back incomplete. Subdirectories are now copied too, and a `--output-folder` that is the dataset itself or nested inside it is rejected instead of copying into its own destination.
+- **`gene-map` accepted `--in-place` together with `--output-folder`** — the destination silently won; it is now a usage error.
+- **`annotate_dataframe` divided by zero on an empty view** — the mapped-share log now reports 0.0%.
+
 - **Ontology PK uniqueness**: ontology writes collapse to one row per `(field_name, view)` (first-wins) when a field is both a discovered score and a mapped field.
 - **DIA-NN blank `anchor_protein`**: empty/whitespace first accession from `Protein.Group` is written as NULL; validators treat blank anchors as unset.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **`[mudata]` optional extra** — MuData export is included in the default install.
+- **`[transforms]` optional extra, with its `biopython` and `mygene` dependencies** — gene mapping now parses FASTA headers directly, so `qpxc transform gene-map` works in a bare install (and in the published container, which never carried the extra).
+- **MyGene.info lookup and the `--species` option of `qpxc transform gene-map`** — the transform no longer queries a network service. `gg_names` comes from the FASTA `GN=` field; `gg_accessions` is left as the converter wrote it instead of being overwritten from the API.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pip install .
 uv pip install "qpx @ git+https://github.com/bigbio/qpx.git"
 
 # With optional extras
-uv pip install "qpx[quantify,transforms,plotting] @ git+https://github.com/bigbio/qpx.git"
+uv pip install "qpx[quantify,plotting] @ git+https://github.com/bigbio/qpx.git"
 ```
 
 **From a local clone:**

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ pip install qpx                # includes MuData export (mudata, anndata, scipy)
 
 # Optional extras
 pip install "qpx[quantify]"    # protein quantification via mokume[directlfq]
-pip install "qpx[transforms]"  # gene mapping / BioPython helpers
 pip install "qpx[plotting]"    # plotting dependencies
 pip install "qpx[mzidentml]"   # mzIdentML conversion (lxml)
 pip install "qpx[pdc]"         # PDC/CPTAC download (pridepy)

--- a/docs/guide/transform.md
+++ b/docs/guide/transform.md
@@ -139,14 +139,13 @@ from qpx.cli.transform import transform_gene_map_cmd
 print(generate_example(transform_gene_map_cmd, "Map gene information to parquet file:"))
 ```
 
-#### With Species Parameter {#gene-map-example-species}
+#### Annotating a Feature File {#gene-map-example-feature}
 
 ```bash
 qpxc transform gene-map \
     --parquet-path ./output/feature.parquet \
     --fasta tests/examples/fasta/Homo-sapiens.fasta \
-    --output-folder ./output \
-    --species human
+    --output-folder ./output
 ```
 
 ### Output Files {#gene-map-output}
@@ -157,7 +156,8 @@ qpxc transform gene-map \
 
 ### Best Practices {#gene-map-best-practices}
 
-- Use species-specific FASTA files for accurate gene annotation
+- Use the same FASTA the search used, so every identified protein can be mapped
+- Gene names come from the `GN=` field of the FASTA headers; entries without it stay unmapped
 - Enable verbose mode for debugging
 
 ---

--- a/docs/guide/transform.md
+++ b/docs/guide/transform.md
@@ -148,11 +148,26 @@ qpxc transform gene-map \
     --output-folder ./output
 ```
 
+#### Annotating a Whole Dataset {#gene-map-example-dataset}
+
+```bash
+qpxc transform gene-map \
+    --dataset ./qpx_output \
+    --fasta tests/examples/fasta/Homo-sapiens.fasta \
+    --in-place
+```
+
+Every quantification view that carries protein accessions (`pg` and `feature`) is
+annotated, and the dataset's MuData view is rebuilt when one is present, so the
+`.h5mu` never describes stale genes. Pass `--output-folder` instead of `--in-place`
+to write an annotated copy and leave the source dataset untouched.
+
 ### Output Files {#gene-map-output}
 
 - **Output**: Enhanced parquet file(s) with gene information
 - **Format**: Parquet file in output folder
 - **Added Fields**: Gene names and metadata from FASTA headers
+- **Dataset mode**: annotated `pg` + `feature` views, plus a rebuilt `.h5mu` when the dataset has one
 
 ### Best Practices {#gene-map-best-practices}
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -11,7 +11,6 @@ qpx defines a standardized Parquet-based format (QPX) for quantitative proteomic
 pip install qpx                    # Core (includes mudata, anndata, scipy)
 pip install qpx[all]               # All optional extras
 pip install qpx[mzidentml]         # mzIdentML (lxml)
-pip install qpx[transforms]        # Gene mapping (biopython, mygene)
 pip install qpx[plotting]          # Visualization
 pip install qpx[quantify]          # mokume[directlfq]>=0.1.0
 pip install qpx[pdc]               # PDC/CPTAC download (pridepy)

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,4 @@ dependencies:
   # Dev / test
   - scikit-learn
   # Optional (uncomment as needed)
-  # - biopython     # transforms: gene mapping
-  # - mygene        # transforms: gene mapping via MyGene.info API
   # - plotly        # plotting: interactive charts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ dependencies = [
 [project.optional-dependencies]
 mzidentml = ["lxml>=4.9.0"]
 pdc = ["pridepy>=0.0.15"]
-transforms = ["biopython", "mygene>=1.0.0"]
+# Gene mapping reads FASTA headers directly, so it needs no extra dependency.
 plotting = ["plotly>=5.0.0", "scikit-learn>=1.5.0"]
 quantify = ["mokume[directlfq]>=0.1.0"]
-all = ["lxml>=4.9.0", "biopython", "mygene>=1.0.0", "plotly>=5.0.0", "scikit-learn>=1.5.0", "mokume[directlfq]>=0.1.0"]
+all = ["lxml>=4.9.0", "plotly>=5.0.0", "scikit-learn>=1.5.0", "mokume[directlfq]>=0.1.0"]
 dev = [
     "pytest",
     "pytest-timeout",

--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -189,6 +189,11 @@ def _annotate_dataset_views(
             continue
         name = f"{prefix}.{view}.parquet"
         write_view(qpx_dataset, staging / name)
+        share = mapping.last_mapped_share
+        if share is not None:
+            click.echo(f"  {name}: {share:.1f}% of rows matched a gene in the FASTA")
+            if share == 0.0:
+                click.echo(f"  WARNING: the FASTA resolved no genes for {view}; existing gene names were kept unchanged")
         written.append((staging / name, out_dir / name))
     return written
 

--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -33,9 +33,20 @@ def transform():
 @transform.command("gene-map")
 @click.option(
     "--parquet-path",
-    help="QPX PSM or feature parquet file path",
-    required=True,
+    help="QPX PSM, feature or pg parquet file path (single-file mode)",
+    default=None,
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--dataset",
+    help="Path to a QPX dataset directory (annotates pg + feature, refreshes the h5mu)",
+    default=None,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option(
+    "--in-place",
+    help="Dataset mode: overwrite the dataset's files instead of writing to --output-folder",
+    is_flag=True,
 )
 @click.option(
     "--fasta",
@@ -46,40 +57,65 @@ def transform():
 @click.option(
     "--output-folder",
     help="Output directory for generated files",
-    required=True,
+    default=None,
     type=click.Path(file_okay=False, path_type=Path),
 )
 @click.option("--verbose", help="Enable verbose logging", is_flag=True)
 def transform_gene_map_cmd(
-    parquet_path: Path,
+    parquet_path: Optional[Path],
+    dataset: Optional[Path],
+    in_place: bool,
     fasta: Path,
-    output_folder: Path,
+    output_folder: Optional[Path],
     verbose: bool,
 ):
     """Map gene names from a FASTA file to QPX parquet data.
 
-    Enriches protein identifications in QPX PSM or feature files with
-    gene names read from the ``GN=`` field of the FASTA headers. The FASTA is
-    the only source: nothing is fetched over the network.
+    Enriches protein identifications with gene names read from the ``GN=`` field
+    of the FASTA headers. The FASTA is the only source: nothing is fetched over
+    the network.
+
+    Given ``--dataset``, every quantification view that carries protein
+    accessions (pg and feature) is annotated, and the dataset's MuData view is
+    rebuilt when one is present, so the ``.h5mu`` never describes stale genes.
 
     \b
-    Example:
+    Examples:
+        # A single parquet file
         qpxc transform gene-map \\
             --parquet-path ./output/psm.parquet \\
             --fasta proteins.fasta \\
             --output-folder ./output
+
+        # A whole QPX dataset, refreshing its h5mu in place
+        qpxc transform gene-map \\
+            --dataset ./qpx_output \\
+            --fasta proteins.fasta \\
+            --in-place
     """
     if verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    output_folder = Path(output_folder)
-    output_folder.mkdir(parents=True, exist_ok=True)
-
-    import pandas as pd
+    if (parquet_path is None) == (dataset is None):
+        raise click.UsageError("Specify exactly one of --parquet-path or --dataset")
+    if dataset is None and output_folder is None:
+        raise click.UsageError("--output-folder is required with --parquet-path")
+    if dataset is not None and not in_place and output_folder is None:
+        raise click.UsageError("Specify --in-place or --output-folder with --dataset")
 
     from qpx.transforms.gene_mapping import GeneMappingTransform
 
     mapping = GeneMappingTransform(fasta_path=str(fasta))
+
+    if dataset is not None:
+        _gene_map_dataset(mapping, dataset, in_place, output_folder)
+        return
+
+    import pandas as pd
+
+    output_folder = Path(output_folder)
+    output_folder.mkdir(parents=True, exist_ok=True)
+
     df = pd.read_parquet(str(parquet_path))
     protein_col = "pg_accessions" if "pg_accessions" in df.columns else "protein_accessions"
     annotated = mapping.annotate_dataframe(df, protein_col=protein_col)
@@ -87,6 +123,74 @@ def transform_gene_map_cmd(
     annotated.to_parquet(str(output_path), index=False)
 
     click.echo(f"Gene mapping complete. Output: {output_path}")
+
+
+def _gene_map_dataset(
+    mapping,
+    dataset: Path,
+    in_place: bool,
+    output_folder: Optional[Path],
+) -> None:
+    """Annotate a QPX dataset's pg + feature views and refresh its MuData view.
+
+    Views are written to a temporary directory first, so an in-place run never
+    truncates a parquet that is still being read.
+    """
+    import shutil
+
+    from qpx.dataset import Dataset
+    from qpx.mudata import write_dataset_mudata
+    from qpx.transforms.utils import discover_qpx_file_prefix
+
+    try:
+        prefix = discover_qpx_file_prefix(dataset)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    out_dir = dataset if in_place else Path(output_folder)
+    if out_dir != dataset:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for path in dataset.iterdir():
+            if path.is_file():
+                shutil.copy2(path, out_dir / path.name)
+
+    staging = out_dir / ".gene_map_tmp"
+    staging.mkdir(parents=True, exist_ok=True)
+    written: list[tuple[Path, Path]] = []
+
+    qpx_dataset = Dataset(str(dataset), file_prefix=prefix)
+    try:
+        views = (
+            ("pg", qpx_dataset.pg, mapping.write_annotated_pg),
+            ("feature", qpx_dataset.feature, mapping.write_annotated_features),
+        )
+        for view, structure, write_view in views:
+            if structure is None:
+                continue
+            name = f"{prefix}.{view}.parquet"
+            write_view(qpx_dataset, staging / name)
+            written.append((staging / name, out_dir / name))
+    finally:
+        qpx_dataset.close()
+
+    try:
+        for source, target in written:
+            source.replace(target)
+            click.echo(f"  {target.name}: gene names annotated")
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+    if not written:
+        raise click.ClickException(f"No pg or feature Parquet file found in {dataset}")
+
+    if (out_dir / f"{prefix}.h5mu").is_file():
+        refreshed = write_dataset_mudata(out_dir, prefix)
+        if refreshed is None:
+            click.echo("  h5mu: could not be rebuilt (see log); parquet views are annotated")
+        else:
+            click.echo(f"  {refreshed.name}: MuData view rebuilt")
+
+    click.echo(f"\nGene mapping complete. Output: {out_dir}")
 
 
 # ---------------------------------------------------------------------------

--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -49,31 +49,25 @@ def transform():
     required=True,
     type=click.Path(file_okay=False, path_type=Path),
 )
-@click.option(
-    "--species",
-    help="Species name for gene mapping",
-    default="human",
-)
 @click.option("--verbose", help="Enable verbose logging", is_flag=True)
 def transform_gene_map_cmd(
     parquet_path: Path,
     fasta: Path,
     output_folder: Path,
-    species: str,
     verbose: bool,
 ):
     """Map gene names from a FASTA file to QPX parquet data.
 
     Enriches protein identifications in QPX PSM or feature files with
-    gene-level metadata extracted from FASTA database headers.
+    gene names read from the ``GN=`` field of the FASTA headers. The FASTA is
+    the only source: nothing is fetched over the network.
 
     \b
     Example:
         qpxc transform gene-map \\
             --parquet-path ./output/psm.parquet \\
             --fasta proteins.fasta \\
-            --output-folder ./output \\
-            --species human
+            --output-folder ./output
     """
     if verbose:
         logging.getLogger().setLevel(logging.DEBUG)
@@ -85,7 +79,7 @@ def transform_gene_map_cmd(
 
     from qpx.transforms.gene_mapping import GeneMappingTransform
 
-    mapping = GeneMappingTransform(fasta_path=str(fasta), species=species)
+    mapping = GeneMappingTransform(fasta_path=str(fasta))
     df = pd.read_parquet(str(parquet_path))
     protein_col = "pg_accessions" if "pg_accessions" in df.columns else "protein_accessions"
     annotated = mapping.annotate_dataframe(df, protein_col=protein_col)

--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -43,6 +43,8 @@ def _validate_gene_map_inputs(
         raise click.UsageError("--output-folder is required with --parquet-path")
     if dataset is not None and not in_place and output_folder is None:
         raise click.UsageError("Specify --in-place or --output-folder with --dataset")
+    if dataset is not None and in_place and output_folder is not None:
+        raise click.UsageError("--in-place and --output-folder are mutually exclusive")
 
 
 @transform.command("gene-map")
@@ -93,6 +95,9 @@ def transform_gene_map_cmd(
     Given ``--dataset``, every quantification view that carries protein
     accessions (pg and feature) is annotated, and the dataset's MuData view is
     rebuilt when one is present, so the ``.h5mu`` never describes stale genes.
+    Dataset mode requires flat Parquet views sharing one file prefix;
+    partitioned pg/feature views are rejected before any files are changed.
+    An output folder must be empty and outside the source dataset.
 
     \b
     Examples:
@@ -136,13 +141,27 @@ def transform_gene_map_cmd(
 
 
 def _copy_dataset_files(dataset: Path, out_dir: Path) -> None:
-    """Copy a dataset's files to ``out_dir`` so annotation never mutates the source."""
+    """Copy the complete dataset, including directory-backed views."""
     import shutil
 
-    out_dir.mkdir(parents=True, exist_ok=True)
-    for path in dataset.iterdir():
-        if path.is_file():
-            shutil.copy2(path, out_dir / path.name)
+    if out_dir == dataset or dataset in out_dir.parents:
+        raise click.ClickException("--output-folder must be outside the source dataset; use --in-place to update it")
+    if out_dir.exists() and any(out_dir.iterdir()):
+        raise click.ClickException("--output-folder must be empty")
+    shutil.copytree(dataset, out_dir, dirs_exist_ok=True)
+
+
+def _gene_map_dataset_prefix(dataset: Path) -> str:
+    """Reject unsupported quantification layouts before copying or annotation."""
+    from qpx.transforms.utils import discover_qpx_file_prefix
+
+    for view in ("pg", "feature"):
+        if any((dataset / view).rglob("*.parquet")):
+            raise click.ClickException(f"Partitioned {view} data is not supported by gene-map; use flat Parquet views")
+    try:
+        return discover_qpx_file_prefix(dataset)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _annotate_dataset_views(
@@ -170,6 +189,33 @@ def _annotate_dataset_views(
     return written
 
 
+def _stage_dataset_integrity(qpx_dataset, prefix: str, staging: Path, out_dir: Path) -> tuple[Path, Path] | None:
+    """Update existing integrity records for the staged quantification files."""
+    from qpx.dataset import Dataset
+    from qpx.writers import DatasetWriter
+
+    if qpx_dataset.dataset_meta is None:
+        return None
+    metadata = qpx_dataset.dataset_meta.to_df()
+    if metadata.empty:
+        return None
+    record = metadata.iloc[0].to_dict()
+    fields = ("file_checksums", "file_row_counts", "file_sizes_bytes")
+    if not any(isinstance(record.get(field), dict) for field in fields):
+        return None
+
+    with Dataset(str(staging), file_prefix=prefix) as staged_dataset:
+        integrity = staged_dataset.compute_integrity()
+    for field in fields:
+        if isinstance(record.get(field), dict):
+            record[field].update(integrity[field])
+    record["packaged_at"] = integrity["packaged_at"]
+    name = f"{prefix}.dataset.parquet"
+    with DatasetWriter(staging / name) as writer:
+        writer.write_batch([record])
+    return staging / name, out_dir / name
+
+
 def _refresh_dataset_mudata(out_dir: Path, prefix: str) -> None:
     """Rebuild the dataset's MuData view, so a stale h5mu never outlives the parquet."""
     from qpx.mudata import write_dataset_mudata
@@ -195,38 +241,28 @@ def _gene_map_dataset(
     Views are written to a temporary directory first, so an in-place run never
     truncates a parquet that is still being read.
     """
-    import shutil
+    from tempfile import TemporaryDirectory
 
     from qpx.dataset import Dataset
-    from qpx.transforms.utils import discover_qpx_file_prefix
 
-    try:
-        prefix = discover_qpx_file_prefix(dataset)
-    except ValueError as exc:
-        raise click.ClickException(str(exc)) from exc
-
-    out_dir = dataset if in_place else Path(output_folder)
-    if out_dir != dataset:
+    dataset = dataset.resolve()
+    prefix = _gene_map_dataset_prefix(dataset)
+    out_dir = dataset if in_place else Path(output_folder).resolve()
+    if not in_place:
         _copy_dataset_files(dataset, out_dir)
 
-    staging = out_dir / ".gene_map_tmp"
-    staging.mkdir(parents=True, exist_ok=True)
-
-    qpx_dataset = Dataset(str(dataset), file_prefix=prefix)
-    try:
-        written = _annotate_dataset_views(mapping, qpx_dataset, prefix, staging, out_dir)
-    finally:
-        qpx_dataset.close()
-
-    try:
+    with TemporaryDirectory(prefix=".gene_map_tmp-", dir=out_dir) as temporary:
+        staging = Path(temporary)
+        with Dataset(str(dataset), file_prefix=prefix) as qpx_dataset:
+            written = _annotate_dataset_views(mapping, qpx_dataset, prefix, staging, out_dir)
+            if not written:
+                raise click.ClickException(f"No pg or feature Parquet file found in {dataset}")
+            metadata = _stage_dataset_integrity(qpx_dataset, prefix, staging, out_dir)
+            if metadata is not None:
+                written.append(metadata)
         for source, target in written:
             source.replace(target)
-            click.echo(f"  {target.name}: gene names annotated")
-    finally:
-        shutil.rmtree(staging, ignore_errors=True)
-
-    if not written:
-        raise click.ClickException(f"No pg or feature Parquet file found in {dataset}")
+            click.echo(f"  {target.name}: updated")
 
     _refresh_dataset_mudata(out_dir, prefix)
 

--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -43,6 +43,14 @@ def _validate_gene_map_inputs(
         raise click.UsageError("--output-folder is required with --parquet-path")
     if dataset is not None and not in_place and output_folder is None:
         raise click.UsageError("Specify --in-place or --output-folder with --dataset")
+    if dataset is not None and in_place and output_folder is not None:
+        raise click.UsageError("Specify either --in-place or --output-folder with --dataset, not both")
+    if dataset is not None and output_folder is not None:
+        source, destination = dataset.resolve(), output_folder.resolve()
+        if destination == source:
+            raise click.UsageError("--output-folder is the dataset itself; use --in-place")
+        if source in destination.parents:
+            raise click.UsageError("--output-folder must not be inside the dataset directory")
 
 
 @transform.command("gene-map")
@@ -141,8 +149,13 @@ def _copy_dataset_files(dataset: Path, out_dir: Path) -> None:
 
     out_dir.mkdir(parents=True, exist_ok=True)
     for path in dataset.iterdir():
-        if path.is_file():
-            shutil.copy2(path, out_dir / path.name)
+        target = out_dir / path.name
+        if path.is_dir():
+            # Sharded / partitioned datasets keep views in subdirectories; copying
+            # only the top-level files would hand back an incomplete dataset.
+            shutil.copytree(path, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(path, target)
 
 
 def _annotate_dataset_views(

--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -30,6 +30,21 @@ def transform():
 # ---------------------------------------------------------------------------
 
 
+def _validate_gene_map_inputs(
+    parquet_path: Optional[Path],
+    dataset: Optional[Path],
+    in_place: bool,
+    output_folder: Optional[Path],
+) -> None:
+    """Reject input/destination combinations gene-map cannot act on."""
+    if (parquet_path is None) == (dataset is None):
+        raise click.UsageError("Specify exactly one of --parquet-path or --dataset")
+    if dataset is None and output_folder is None:
+        raise click.UsageError("--output-folder is required with --parquet-path")
+    if dataset is not None and not in_place and output_folder is None:
+        raise click.UsageError("Specify --in-place or --output-folder with --dataset")
+
+
 @transform.command("gene-map")
 @click.option(
     "--parquet-path",
@@ -96,12 +111,7 @@ def transform_gene_map_cmd(
     if verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    if (parquet_path is None) == (dataset is None):
-        raise click.UsageError("Specify exactly one of --parquet-path or --dataset")
-    if dataset is None and output_folder is None:
-        raise click.UsageError("--output-folder is required with --parquet-path")
-    if dataset is not None and not in_place and output_folder is None:
-        raise click.UsageError("Specify --in-place or --output-folder with --dataset")
+    _validate_gene_map_inputs(parquet_path, dataset, in_place, output_folder)
 
     from qpx.transforms.gene_mapping import GeneMappingTransform
 
@@ -125,6 +135,55 @@ def transform_gene_map_cmd(
     click.echo(f"Gene mapping complete. Output: {output_path}")
 
 
+def _copy_dataset_files(dataset: Path, out_dir: Path) -> None:
+    """Copy a dataset's files to ``out_dir`` so annotation never mutates the source."""
+    import shutil
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for path in dataset.iterdir():
+        if path.is_file():
+            shutil.copy2(path, out_dir / path.name)
+
+
+def _annotate_dataset_views(
+    mapping,
+    qpx_dataset,
+    prefix: str,
+    staging: Path,
+    out_dir: Path,
+) -> list[tuple[Path, Path]]:
+    """Write gene-annotated pg + feature views into ``staging``.
+
+    Returns the ``(staged, destination)`` pairs to move into place.
+    """
+    written: list[tuple[Path, Path]] = []
+    views = (
+        ("pg", qpx_dataset.pg, mapping.write_annotated_pg),
+        ("feature", qpx_dataset.feature, mapping.write_annotated_features),
+    )
+    for view, structure, write_view in views:
+        if structure is None:
+            continue
+        name = f"{prefix}.{view}.parquet"
+        write_view(qpx_dataset, staging / name)
+        written.append((staging / name, out_dir / name))
+    return written
+
+
+def _refresh_dataset_mudata(out_dir: Path, prefix: str) -> None:
+    """Rebuild the dataset's MuData view, so a stale h5mu never outlives the parquet."""
+    from qpx.mudata import write_dataset_mudata
+
+    if not (out_dir / f"{prefix}.h5mu").is_file():
+        return
+
+    refreshed = write_dataset_mudata(out_dir, prefix)
+    if refreshed is None:
+        click.echo("  h5mu: could not be rebuilt (see log); parquet views are annotated")
+    else:
+        click.echo(f"  {refreshed.name}: MuData view rebuilt")
+
+
 def _gene_map_dataset(
     mapping,
     dataset: Path,
@@ -139,7 +198,6 @@ def _gene_map_dataset(
     import shutil
 
     from qpx.dataset import Dataset
-    from qpx.mudata import write_dataset_mudata
     from qpx.transforms.utils import discover_qpx_file_prefix
 
     try:
@@ -149,27 +207,14 @@ def _gene_map_dataset(
 
     out_dir = dataset if in_place else Path(output_folder)
     if out_dir != dataset:
-        out_dir.mkdir(parents=True, exist_ok=True)
-        for path in dataset.iterdir():
-            if path.is_file():
-                shutil.copy2(path, out_dir / path.name)
+        _copy_dataset_files(dataset, out_dir)
 
     staging = out_dir / ".gene_map_tmp"
     staging.mkdir(parents=True, exist_ok=True)
-    written: list[tuple[Path, Path]] = []
 
     qpx_dataset = Dataset(str(dataset), file_prefix=prefix)
     try:
-        views = (
-            ("pg", qpx_dataset.pg, mapping.write_annotated_pg),
-            ("feature", qpx_dataset.feature, mapping.write_annotated_features),
-        )
-        for view, structure, write_view in views:
-            if structure is None:
-                continue
-            name = f"{prefix}.{view}.parquet"
-            write_view(qpx_dataset, staging / name)
-            written.append((staging / name, out_dir / name))
+        written = _annotate_dataset_views(mapping, qpx_dataset, prefix, staging, out_dir)
     finally:
         qpx_dataset.close()
 
@@ -183,12 +228,7 @@ def _gene_map_dataset(
     if not written:
         raise click.ClickException(f"No pg or feature Parquet file found in {dataset}")
 
-    if (out_dir / f"{prefix}.h5mu").is_file():
-        refreshed = write_dataset_mudata(out_dir, prefix)
-        if refreshed is None:
-            click.echo("  h5mu: could not be rebuilt (see log); parquet views are annotated")
-        else:
-            click.echo(f"  {refreshed.name}: MuData view rebuilt")
+    _refresh_dataset_mudata(out_dir, prefix)
 
     click.echo(f"\nGene mapping complete. Output: {out_dir}")
 

--- a/qpx/converters/orchestrator.py
+++ b/qpx/converters/orchestrator.py
@@ -11,8 +11,6 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-import duckdb
-
 logger = logging.getLogger(__name__)
 
 
@@ -133,51 +131,10 @@ class BaseOrchestrator:
         which emits muData. Must run after the core + metadata parquet are
         written. Best-effort: expected dependency, database, validation, and I/O
         failures are logged and skipped rather than failing the run.
+
+        The implementation lives in ``qpx.mudata`` so the transform commands
+        that rewrite those parquet can refresh the view the same way.
         """
-        h5mu_path = output_folder / f"{prefix}.h5mu"
-        h5mu_tmp = h5mu_path.with_name(f"{h5mu_path.stem}.tmp{h5mu_path.suffix}")
-        try:
-            # Core parquet files have already been refreshed, so an older MuData
-            # view would be stale if this build fails.
-            h5mu_path.unlink(missing_ok=True)
+        from qpx.mudata import write_dataset_mudata
 
-            from qpx.dataset import Dataset
-            from qpx.mudata import build_mudata
-
-            dataset = Dataset(str(output_folder), file_prefix=prefix)
-            try:
-                required_modalities = {
-                    name
-                    for name, structure in (
-                        ("precursors", dataset.feature),
-                        ("proteins", dataset.pg),
-                    )
-                    if structure is not None
-                }
-                if not required_modalities:
-                    logger.info("Skipping muData for %s: no feature or pg quantification data", prefix)
-                    return None
-
-                modalities = required_modalities | {"expression", "differential"}
-                mdata = build_mudata(
-                    dataset,
-                    modalities=sorted(modalities),
-                    all_intensity_labels=True,
-                )
-                missing = required_modalities - set(mdata.mod)
-                if missing:
-                    raise ValueError(f"Missing required quantification modalities: {', '.join(sorted(missing))}")
-                mdata.write(str(h5mu_tmp))
-                h5mu_tmp.replace(h5mu_path)
-            finally:
-                dataset.close()
-        except (ImportError, OSError, RuntimeError, TypeError, ValueError, duckdb.Error) as exc:
-            logger.warning("Could not build muData for %s: %s", prefix, exc)
-            return None
-        finally:
-            try:
-                h5mu_tmp.unlink(missing_ok=True)
-            except OSError as exc:
-                logger.warning("Could not remove temporary muData file %s: %s", h5mu_tmp, exc)
-        logger.info("Wrote muData to %s", h5mu_path)
-        return h5mu_path
+        return write_dataset_mudata(output_folder, prefix)

--- a/qpx/mudata.py
+++ b/qpx/mudata.py
@@ -837,3 +837,68 @@ def build_mudata(
                 frame[str_cols] = frame[str_cols].fillna("")
 
     return mdata
+
+
+def write_dataset_mudata(
+    output_folder: Path | str,
+    prefix: str,
+    *,
+    all_intensity_labels: bool = True,
+) -> Path | None:
+    """Assemble and write the MuData (.h5mu) view of a QPX dataset on disk.
+
+    Shared by the converters (which refresh the view right after writing the
+    parquet) and by ``qpxc transform`` commands that rewrite those parquet, so a
+    stale h5mu never outlives the data it describes.
+
+    Best-effort: expected dependency, database, validation, and I/O failures are
+    logged and skipped rather than raised, because the parquet views — not the
+    h5mu — are the dataset's source of truth.
+    """
+    output_folder = Path(output_folder)
+    h5mu_path = output_folder / f"{prefix}.h5mu"
+    h5mu_tmp = h5mu_path.with_name(f"{h5mu_path.stem}.tmp{h5mu_path.suffix}")
+    try:
+        # Core parquet files have already been refreshed, so an older MuData
+        # view would be stale if this build fails.
+        h5mu_path.unlink(missing_ok=True)
+
+        from qpx.dataset import Dataset
+
+        dataset = Dataset(str(output_folder), file_prefix=prefix)
+        try:
+            required_modalities = {
+                name
+                for name, structure in (
+                    ("precursors", dataset.feature),
+                    ("proteins", dataset.pg),
+                )
+                if structure is not None
+            }
+            if not required_modalities:
+                logger.info("Skipping muData for %s: no feature or pg quantification data", prefix)
+                return None
+
+            modalities = required_modalities | {"expression", "differential"}
+            mdata = build_mudata(
+                dataset,
+                modalities=sorted(modalities),
+                all_intensity_labels=all_intensity_labels,
+            )
+            missing = required_modalities - set(mdata.mod)
+            if missing:
+                raise ValueError(f"Missing required quantification modalities: {', '.join(sorted(missing))}")
+            mdata.write(str(h5mu_tmp))
+            h5mu_tmp.replace(h5mu_path)
+        finally:
+            dataset.close()
+    except (ImportError, OSError, RuntimeError, TypeError, ValueError, duckdb.Error) as exc:
+        logger.warning("Could not build muData for %s: %s", prefix, exc)
+        return None
+    finally:
+        try:
+            h5mu_tmp.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning("Could not remove temporary muData file %s: %s", h5mu_tmp, exc)
+    logger.info("Wrote muData to %s", h5mu_path)
+    return h5mu_path

--- a/qpx/mudata.py
+++ b/qpx/mudata.py
@@ -534,7 +534,14 @@ def _build_protein_adata(
     gene_df = gene_df.drop_duplicates(subset="anchor_protein", keep="first")
     gene_df = gene_df.set_index("anchor_protein").reindex(proteins)
 
-    var = pd.DataFrame({"gene_name": gene_df["gene_name"].values}, index=proteins)
+    # A missing gene must still serialise as a string. When every protein lacks a
+    # gene the column comes back float64 (all NaN) and h5py refuses to write var
+    # ("Can't implicitly convert non-string objects to strings"). That is the norm
+    # for TMT datasets whose consensusXML carries no GN= descriptions, so gg_names
+    # is NULL on every row. Same reason _load_run_obs fills its string columns.
+    gene_names = gene_df["gene_name"].fillna("").astype(str)
+
+    var = pd.DataFrame({"gene_name": gene_names.values}, index=proteins)
 
     return ad.AnnData(X=intensity_matrix, obs=obs, var=var)
 

--- a/qpx/transforms/gene_mapping.py
+++ b/qpx/transforms/gene_mapping.py
@@ -337,3 +337,62 @@ class GeneMappingTransform:
 
         logger.info(f"Wrote gene-annotated features to {output_path}")
         return output_path
+
+    def annotate_dataset_pg(
+        self,
+        dataset,
+    ) -> pd.DataFrame:
+        """
+        Annotate a Dataset's protein-group data with gene names.
+
+        Args:
+            dataset: A qpx.Dataset with pg data.
+
+        Returns:
+            Annotated PG DataFrame with gg_names.
+        """
+        if dataset.pg is None:
+            raise ValueError("Dataset does not contain protein group data.")
+
+        pg_df = dataset.pg.to_df()
+        return self.annotate_dataframe(
+            pg_df,
+            protein_col="pg_accessions",
+        )
+
+    def write_annotated_pg(
+        self,
+        dataset,
+        output_path: Union[str, Path],
+    ) -> Path:
+        """
+        Write gene-annotated protein-group data to a new Parquet file.
+
+        Uses the PgWriter to produce a schema-validated output file, preserving
+        the source file's identity recipe so pg_id values do not change.
+
+        Args:
+            dataset: A qpx.Dataset with pg data.
+            output_path: Path for the output .pg.parquet file.
+
+        Returns:
+            Path to the written file.
+        """
+        from qpx.writers.pg import PgWriter
+
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        annotated_df = self.annotate_dataset_pg(dataset)
+
+        source_composite = dataset.pg.file_metadata.get("identity_composite")
+        identity_composite = tuple(source_composite.split(",")) if source_composite else None
+        with PgWriter(
+            output_path,
+            override_provided_ids=False,
+            identity_composite=identity_composite,
+        ) as writer:
+            writer.write_dataframe(annotated_df)
+
+        logger.info(f"Wrote gene-annotated protein groups to {output_path}")
+        return output_path

--- a/qpx/transforms/gene_mapping.py
+++ b/qpx/transforms/gene_mapping.py
@@ -274,11 +274,12 @@ class GeneMappingTransform:
             result["gg_accessions"] = None
 
         n_mapped = result["gg_names"].notna().sum()
+        mapped_share = n_mapped / len(result) * 100 if len(result) else 0.0
         logger.info(
             "Mapped gene names for %d/%d rows (%.1f%%)",
             n_mapped,
             len(result),
-            n_mapped / len(result) * 100,
+            mapped_share,
         )
         return result
 

--- a/qpx/transforms/gene_mapping.py
+++ b/qpx/transforms/gene_mapping.py
@@ -100,7 +100,7 @@ def _parse_gene_names_from_fasta(
                 gene_map[accession].add(gene_name)
                 gene_map[name].add(gene_name)
 
-    logger.info(f"Parsed gene names for {len(gene_map)} protein identifiers from {fasta_path}")
+    logger.info("Parsed gene names for %d protein identifiers from %s", len(gene_map), fasta_path)
     return gene_map
 
 
@@ -274,7 +274,12 @@ class GeneMappingTransform:
             result["gg_accessions"] = None
 
         n_mapped = result["gg_names"].notna().sum()
-        logger.info(f"Mapped gene names for {n_mapped}/{len(result)} rows ({n_mapped / len(result) * 100:.1f}%)")
+        logger.info(
+            "Mapped gene names for %d/%d rows (%.1f%%)",
+            n_mapped,
+            len(result),
+            n_mapped / len(result) * 100,
+        )
         return result
 
     def annotate_dataset_features(
@@ -335,7 +340,7 @@ class GeneMappingTransform:
         ) as writer:
             writer.write_dataframe(annotated_df)
 
-        logger.info(f"Wrote gene-annotated features to {output_path}")
+        logger.info("Wrote gene-annotated features to %s", output_path)
         return output_path
 
     def annotate_dataset_pg(
@@ -394,5 +399,5 @@ class GeneMappingTransform:
         ) as writer:
             writer.write_dataframe(annotated_df)
 
-        logger.info(f"Wrote gene-annotated protein groups to {output_path}")
+        logger.info("Wrote gene-annotated protein groups to %s", output_path)
         return output_path

--- a/qpx/transforms/gene_mapping.py
+++ b/qpx/transforms/gene_mapping.py
@@ -37,6 +37,10 @@ logger = logging.getLogger(__name__)
 
 _GENE_NAME_RE = re.compile(r"\bGN=(\S+)")
 
+# "both" keys the map by accession AND entry name; it was previously reachable
+# only by passing an unrecognised value, which made a typo silently change mode.
+_MAP_BY_CHOICES = frozenset({"accession", "name", "both"})
+
 
 def _parse_fasta_header(header: str) -> tuple[str, str, Optional[str]]:
     """Split one FASTA header line into (accession, entry name, gene name).
@@ -92,15 +96,26 @@ def _parse_gene_names_from_fasta(
             accession, name, gene_name = _parse_fasta_header(line)
 
             if map_by == "accession":
-                gene_map[accession].add(gene_name)
+                keys = (accession,)
             elif map_by == "name":
-                gene_map[name].add(gene_name)
+                keys = (name,)
             else:
                 # Map by both accession and name for maximum matching
-                gene_map[accession].add(gene_name)
-                gene_map[name].add(gene_name)
+                keys = (accession, name)
+            for key in keys:
+                gene_map[key].add(gene_name)
 
-    logger.info("Parsed gene names for %d protein identifiers from %s", len(gene_map), fasta_path)
+    # Count identifiers that actually carry a gene, not every header parsed. The
+    # old count included GN-less entries, so a FASTA yielding no genes at all
+    # still reported "Parsed gene names for N" — the opposite of the truth, on
+    # the one line a caller would check before overwriting annotations.
+    with_gene = sum(1 for names in gene_map.values() if any(n is not None for n in names))
+    logger.info(
+        "Parsed gene names for %d/%d protein identifiers from %s",
+        with_gene,
+        len(gene_map),
+        fasta_path,
+    )
     return gene_map
 
 
@@ -219,10 +234,20 @@ class GeneMappingTransform:
         if not self._fasta_path.exists():
             raise FileNotFoundError(f"FASTA file not found: {fasta_path}")
 
+        if map_by not in _MAP_BY_CHOICES:
+            raise ValueError(f"map_by must be one of {sorted(_MAP_BY_CHOICES)}, got {map_by!r}")
         self._map_by = map_by
 
         # Lazily computed
         self._gene_map: Optional[dict[str, set[str]]] = None
+        # Share of rows the last annotate_dataframe call resolved from the FASTA,
+        # so callers can surface a zero-yield run instead of silently writing one.
+        self._last_mapped_share: Optional[float] = None
+
+    @property
+    def last_mapped_share(self) -> Optional[float]:
+        """Percentage of rows the most recent annotation resolved from the FASTA."""
+        return self._last_mapped_share
 
     @property
     def gene_map(self) -> dict[str, set[str]]:
@@ -263,24 +288,38 @@ class GeneMappingTransform:
         gene_map = self.gene_map
 
         # Map protein accessions to gene names
-        result["gg_names"] = result[protein_col].apply(
+        mapped = result[protein_col].apply(
             lambda accessions: _resolve_gene_names(
                 _normalize_protein_list(accessions),
                 gene_map,
             )
         )
 
+        # A FASTA the accession is absent from says nothing about that protein's
+        # gene — it is not evidence the gene is unknown. Overwriting regardless
+        # wiped every gg_names a converter had already written (DIA-NN reports
+        # carry them) whenever the FASTA lacked GN= fields, and --in-place made
+        # that unrecoverable. Only rows that actually resolved are replaced.
+        if "gg_names" in result.columns:
+            existing = result["gg_names"]
+            result["gg_names"] = [
+                new_names if new_names is not None else old_names for new_names, old_names in zip(mapped, existing, strict=True)
+            ]
+        else:
+            result["gg_names"] = mapped
+
         if "gg_accessions" not in result.columns:
             result["gg_accessions"] = None
 
-        n_mapped = result["gg_names"].notna().sum()
+        n_mapped = int(mapped.notna().sum())
         mapped_share = n_mapped / len(result) * 100 if len(result) else 0.0
         logger.info(
-            "Mapped gene names for %d/%d rows (%.1f%%)",
+            "Mapped gene names from FASTA for %d/%d rows (%.1f%%)",
             n_mapped,
             len(result),
             mapped_share,
         )
+        self._last_mapped_share = mapped_share
         return result
 
     def annotate_dataset_features(

--- a/qpx/transforms/gene_mapping.py
+++ b/qpx/transforms/gene_mapping.py
@@ -1,8 +1,8 @@
 """Gene mapping transform — FASTA protein-to-gene annotation.
 
-This transform maps protein accessions to gene names and gene accessions using
-information parsed from UniProt FASTA headers and optionally from the MyGene.info
-API for genomic accessions.
+This transform maps protein accessions to gene names using the ``GN=`` field of
+UniProt FASTA headers. The FASTA supplied by the caller is the only source: no
+network service is queried, and no optional dependency is required.
 
 The FASTA header format expected (UniProt):
     >sp|P12345|PROT_HUMAN Some description GN=BRCA1 PE=1 SV=2
@@ -24,6 +24,7 @@ Usage:
 
 from __future__ import annotations
 
+import gzip
 import logging
 import re
 from collections import defaultdict
@@ -34,6 +35,31 @@ import pandas as pd
 
 logger = logging.getLogger(__name__)
 
+_GENE_NAME_RE = re.compile(r"\bGN=(\S+)")
+
+
+def _parse_fasta_header(header: str) -> tuple[str, str, Optional[str]]:
+    """Split one FASTA header line into (accession, entry name, gene name).
+
+    Handles the UniProt ``>db|ACCESSION|NAME description`` form, the two-field
+    ``>db|ACCESSION`` form, and a bare ``>IDENTIFIER``. The gene name is the
+    ``GN=`` field when present, else None.
+    """
+    header = header[1:] if header.startswith(">") else header
+    header = header.strip()
+    identifier = header.split(None, 1)[0] if header else ""
+    parts = identifier.split("|")
+
+    if len(parts) >= 3:
+        accession, name = parts[1], parts[2]
+    elif len(parts) == 2:
+        accession = name = parts[1]
+    else:
+        accession = name = identifier
+
+    match = _GENE_NAME_RE.search(header)
+    return accession, name, match.group(1) if match else None
+
 
 def _parse_gene_names_from_fasta(
     fasta_path: str,
@@ -42,10 +68,12 @@ def _parse_gene_names_from_fasta(
     """
     Parse FASTA file and build a protein -> gene name mapping.
 
-    Extracts gene names from the 'GN=' field in UniProt FASTA headers.
+    Extracts gene names from the 'GN=' field in UniProt FASTA headers. Only
+    header lines are read (sequences are skipped), and ``.gz`` files are opened
+    transparently.
 
     Args:
-        fasta_path: Path to the FASTA file.
+        fasta_path: Path to the FASTA file (optionally gzip-compressed).
         map_by: How to key the mapping:
             - "accession": use UniProt accession (e.g., P12345)
             - "name": use UniProt entry name (e.g., PROT_HUMAN)
@@ -53,39 +81,24 @@ def _parse_gene_names_from_fasta(
     Returns:
         Dict mapping protein identifier to set of gene names.
     """
-    try:
-        from Bio import SeqIO
-    except ImportError:
-        raise ImportError("Biopython is required for FASTA parsing. Install it with: pip install qpx[transforms]")
-
     gene_map: dict[str, set[str]] = defaultdict(set)
 
-    for record in SeqIO.parse(fasta_path, "fasta"):
-        # Parse the FASTA header: >db|ACCESSION|NAME description
-        parts = record.id.split("|")
+    opener = gzip.open if str(fasta_path).endswith(".gz") else open
+    with opener(fasta_path, "rt", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if not line.startswith(">"):
+                continue
 
-        if len(parts) >= 3:
-            accession = parts[1]
-            name = parts[2]
-        elif len(parts) == 2:
-            accession = parts[1]
-            name = parts[1]
-        else:
-            accession = record.id
-            name = record.id
+            accession, name, gene_name = _parse_fasta_header(line)
 
-        # Extract gene name from description using GN= field
-        gene_list = re.findall(r"GN=(\S+)", record.description)
-        gene_name = gene_list[0] if gene_list else None
-
-        if map_by == "accession":
-            gene_map[accession].add(gene_name)
-        elif map_by == "name":
-            gene_map[name].add(gene_name)
-        else:
-            # Map by both accession and name for maximum matching
-            gene_map[accession].add(gene_name)
-            gene_map[name].add(gene_name)
+            if map_by == "accession":
+                gene_map[accession].add(gene_name)
+            elif map_by == "name":
+                gene_map[name].add(gene_name)
+            else:
+                # Map by both accession and name for maximum matching
+                gene_map[accession].add(gene_name)
+                gene_map[name].add(gene_name)
 
     logger.info(f"Parsed gene names for {len(gene_map)} protein identifiers from {fasta_path}")
     return gene_map
@@ -166,91 +179,13 @@ def _resolve_gene_names(
     return gene_names if gene_names else None
 
 
-def _fetch_gene_accessions_from_api(
-    gene_names: list[str],
-    species: str = "human",
-) -> dict[str, str]:
-    """
-    Fetch genomic accessions for gene symbols from MyGene.info API.
-
-    Args:
-        gene_names: List of gene symbols to look up.
-        species: Species name for the query (default: "human").
-
-    Returns:
-        Dict mapping gene symbol to comma-separated genomic accession string.
-    """
-    if not gene_names:
-        return {}
-
-    try:
-        import mygene
-    except ImportError:
-        logger.warning(
-            "mygene package not installed. Gene accession lookup will be skipped. Install it with: pip install qpx[transforms]"
-        )
-        return {}
-
-    mg = mygene.MyGeneInfo()
-
-    try:
-        results = mg.querymany(
-            gene_names,
-            scopes="symbol",
-            species=species,
-            fields="accession",
-        )
-    except Exception as e:
-        logger.warning(f"MyGene.info API call failed: {e}")
-        return {}
-
-    accession_map: dict[str, str] = {}
-    for result in results:
-        query = result.get("query", "")
-        accession_info = result.get("accession", {})
-        if isinstance(accession_info, dict) and "genomic" in accession_info:
-            genomic = accession_info["genomic"]
-            if isinstance(genomic, list):
-                accession_map[query] = ",".join(genomic)
-            elif isinstance(genomic, str):
-                accession_map[query] = genomic
-
-    logger.info(f"Fetched genomic accessions for {len(accession_map)}/{len(gene_names)} genes")
-    return accession_map
-
-
-def _map_gene_accessions(
-    gene_names: Optional[list[str]],
-    accession_map: dict[str, str],
-) -> Optional[list[str]]:
-    """
-    Map gene names to their genomic accessions.
-
-    Args:
-        gene_names: List of gene names.
-        accession_map: Gene-to-accession mapping from _fetch_gene_accessions_from_api.
-
-    Returns:
-        List of genomic accessions, or None if no mappings found.
-    """
-    if gene_names is None:
-        return None
-
-    accessions = []
-    for gene in gene_names:
-        if gene in accession_map and accession_map[gene]:
-            accessions.append(accession_map[gene])
-
-    return accessions if accessions else None
-
-
 class GeneMappingTransform:
     """
-    Map protein accessions to gene names and gene accessions from FASTA.
+    Map protein accessions to gene names from a FASTA database.
 
     This transform reads UniProt FASTA headers to extract gene symbols (GN= field)
-    and optionally queries MyGene.info for genomic accessions. It annotates
-    QPX Feature or PG data structures with gg_names and gg_accessions columns.
+    and annotates QPX Feature or PG data structures with a gg_names column. The
+    FASTA is the only source of truth, so annotation is offline and reproducible.
 
     Usage:
         mapping = GeneMappingTransform(fasta_path="proteins.fasta")
@@ -258,7 +193,7 @@ class GeneMappingTransform:
         # Get the raw gene map
         gene_map = mapping.gene_map
 
-        # Annotate a DataFrame (adds gg_names and gg_accessions columns)
+        # Annotate a DataFrame (adds a gg_names column)
         annotated_df = mapping.annotate_dataframe(df, protein_col="pg_accessions")
 
         # Annotate a Dataset's features
@@ -272,29 +207,22 @@ class GeneMappingTransform:
         self,
         fasta_path: Union[str, Path],
         map_by: str = "accession",
-        species: str = "human",
-        fetch_accessions: bool = True,
     ):
         """
         Initialize the gene mapping transform.
 
         Args:
-            fasta_path: Path to the UniProt FASTA file.
+            fasta_path: Path to the UniProt FASTA file (optionally gzip-compressed).
             map_by: Mapping strategy ("accession" or "name").
-            species: Species for MyGene.info lookup (default: "human").
-            fetch_accessions: Whether to fetch genomic accessions from MyGene.info.
         """
         self._fasta_path = Path(fasta_path)
         if not self._fasta_path.exists():
             raise FileNotFoundError(f"FASTA file not found: {fasta_path}")
 
         self._map_by = map_by
-        self._species = species
-        self._fetch_accessions = fetch_accessions
 
         # Lazily computed
         self._gene_map: Optional[dict[str, set[str]]] = None
-        self._accession_map: Optional[dict[str, str]] = None
 
     @property
     def gene_map(self) -> dict[str, set[str]]:
@@ -306,45 +234,27 @@ class GeneMappingTransform:
             )
         return self._gene_map
 
-    @property
-    def accession_map(self) -> dict[str, str]:
-        """Gene-to-genomic accession mapping (lazy-loaded from MyGene.info)."""
-        if self._accession_map is None:
-            if self._fetch_accessions:
-                # Collect all unique gene names
-                all_genes = set()
-                for genes in self.gene_map.values():
-                    for gene in genes:
-                        if gene is not None:
-                            all_genes.add(gene)
-                self._accession_map = _fetch_gene_accessions_from_api(
-                    sorted(all_genes),
-                    species=self._species,
-                )
-            else:
-                self._accession_map = {}
-        return self._accession_map
-
     def annotate_dataframe(
         self,
         df: pd.DataFrame,
         protein_col: str = "pg_accessions",
-        include_accessions: bool = True,
     ) -> pd.DataFrame:
         """
-        Add gg_names and gg_accessions columns to a DataFrame.
+        Add a gg_names column to a DataFrame.
 
         The protein_col should contain either:
         - A list of protein accessions (e.g., from QPX pg_accessions column)
         - A single protein accession string
 
+        A FASTA carries no genomic accessions, so ``gg_accessions`` is left
+        exactly as the converter wrote it (and created as NULL when absent).
+
         Args:
             df: Input DataFrame with protein identifiers.
             protein_col: Column name containing protein accessions.
-            include_accessions: Whether to include gg_accessions from MyGene.info.
 
         Returns:
-            DataFrame with added gg_names and gg_accessions columns.
+            DataFrame with an added gg_names column.
         """
         if protein_col not in df.columns:
             raise ValueError(f"Column '{protein_col}' not found in DataFrame.")
@@ -360,11 +270,7 @@ class GeneMappingTransform:
             )
         )
 
-        # Map gene names to genomic accessions
-        if include_accessions:
-            acc_map = self.accession_map
-            result["gg_accessions"] = result["gg_names"].apply(lambda names: _map_gene_accessions(names, acc_map))
-        else:
+        if "gg_accessions" not in result.columns:
             result["gg_accessions"] = None
 
         n_mapped = result["gg_names"].notna().sum()
@@ -374,20 +280,18 @@ class GeneMappingTransform:
     def annotate_dataset_features(
         self,
         dataset,
-        include_accessions: bool = True,
     ) -> pd.DataFrame:
         """
-        Annotate a Dataset's Feature data with gene names and accessions.
+        Annotate a Dataset's Feature data with gene names.
 
         Materializes the Feature data as a DataFrame, adds gene annotations,
         and returns the annotated DataFrame.
 
         Args:
             dataset: A qpx.Dataset with feature data.
-            include_accessions: Whether to include gg_accessions from MyGene.info.
 
         Returns:
-            Annotated Feature DataFrame with gg_names and gg_accessions.
+            Annotated Feature DataFrame with gg_names.
         """
         if dataset.feature is None:
             raise ValueError("Dataset does not contain feature data.")
@@ -396,14 +300,12 @@ class GeneMappingTransform:
         return self.annotate_dataframe(
             feature_df,
             protein_col="pg_accessions",
-            include_accessions=include_accessions,
         )
 
     def write_annotated_features(
         self,
         dataset,
         output_path: Union[str, Path],
-        include_accessions: bool = True,
     ) -> Path:
         """
         Write gene-annotated Feature data to a new Parquet file.
@@ -413,7 +315,6 @@ class GeneMappingTransform:
         Args:
             dataset: A qpx.Dataset with feature data.
             output_path: Path for the output .feature.parquet file.
-            include_accessions: Whether to include gg_accessions from MyGene.info.
 
         Returns:
             Path to the written file.
@@ -423,10 +324,7 @@ class GeneMappingTransform:
         output_path = Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        annotated_df = self.annotate_dataset_features(
-            dataset,
-            include_accessions=include_accessions,
-        )
+        annotated_df = self.annotate_dataset_features(dataset)
 
         source_composite = dataset.feature.file_metadata.get("identity_composite")
         identity_composite = tuple(source_composite.split(",")) if source_composite else None

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -83,7 +83,48 @@ class TestTransformGeneMapCLI:
     def test_genemap_help_renders(self):
         runner = CliRunner()
         result = runner.invoke(qpx_main, ["transform", "gene-map", "--help"])
-        _assert_help(result, "--fasta")
+        _assert_help(result, "--parquet-path", "--dataset", "--in-place", "--fasta")
+
+    def test_gene_map_requires_exactly_one_input_mode(self, tmp_path):
+        fasta = tmp_path / "db.fasta"
+        fasta.write_text(">sp|P12345|A_HUMAN a GN=BRCA1\nMKV\n")
+        runner = CliRunner()
+
+        neither = runner.invoke(qpx_main, ["transform", "gene-map", "--fasta", str(fasta)])
+        assert neither.exit_code != 0
+        assert "exactly one of --parquet-path or --dataset" in neither.output
+
+        parquet = tmp_path / "openms.pg.parquet"
+        parquet.touch()
+        both = runner.invoke(
+            qpx_main,
+            [
+                "transform",
+                "gene-map",
+                "--fasta",
+                str(fasta),
+                "--parquet-path",
+                str(parquet),
+                "--dataset",
+                str(tmp_path),
+            ],
+        )
+        assert both.exit_code != 0
+        assert "exactly one of --parquet-path or --dataset" in both.output
+
+    def test_gene_map_dataset_requires_a_destination(self, tmp_path):
+        fasta = tmp_path / "db.fasta"
+        fasta.write_text(">sp|P12345|A_HUMAN a GN=BRCA1\nMKV\n")
+        (tmp_path / "openms.pg.parquet").touch()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            qpx_main,
+            ["transform", "gene-map", "--fasta", str(fasta), "--dataset", str(tmp_path)],
+        )
+
+        assert result.exit_code != 0
+        assert "--in-place or --output-folder" in result.output
 
 
 class TestTransformQuantifyCLI:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -112,6 +112,29 @@ class TestTransformGeneMapCLI:
         assert both.exit_code != 0
         assert "exactly one of --parquet-path or --dataset" in both.output
 
+    def test_gene_map_dataset_rejects_conflicting_destinations(self, tmp_path):
+        """--in-place and --output-folder together, or a destination inside the source."""
+        fasta = tmp_path / "db.fasta"
+        fasta.write_text(">sp|P12345|A_HUMAN a GN=BRCA1\nMKV\n")
+        data = tmp_path / "qpx_output"
+        data.mkdir()
+        (data / "openms.pg.parquet").touch()
+        runner = CliRunner()
+
+        base = ["transform", "gene-map", "--fasta", str(fasta), "--dataset", str(data)]
+
+        both = runner.invoke(qpx_main, base + ["--in-place", "--output-folder", str(tmp_path / "out")])
+        assert both.exit_code != 0
+        assert "not both" in both.output
+
+        same = runner.invoke(qpx_main, base + ["--output-folder", str(data)])
+        assert same.exit_code != 0
+        assert "use --in-place" in same.output
+
+        nested = runner.invoke(qpx_main, base + ["--output-folder", str(data / "annotated")])
+        assert nested.exit_code != 0
+        assert "must not be inside the dataset" in nested.output
+
     def test_gene_map_dataset_requires_a_destination(self, tmp_path):
         fasta = tmp_path / "db.fasta"
         fasta.write_text(">sp|P12345|A_HUMAN a GN=BRCA1\nMKV\n")

--- a/tests/unit/test_gene_mapping.py
+++ b/tests/unit/test_gene_mapping.py
@@ -1,6 +1,8 @@
 """Regression tests for identity-preserving gene annotation writes."""
 
+import pandas as pd
 import pyarrow.parquet as pq
+import pytest
 
 from qpx import Dataset
 from qpx.transforms.gene_mapping import (
@@ -252,3 +254,69 @@ def test_annotate_dataframe_handles_an_empty_frame(tmp_path):
 
     assert len(annotated) == 0
     assert "gg_names" in annotated.columns
+
+
+def _write_fasta(tmp_path, text):
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(text)
+    return fasta
+
+
+def test_annotate_dataframe_keeps_existing_genes_the_fasta_cannot_resolve(tmp_path):
+    """A FASTA without GN= must not erase gene names a converter already wrote.
+
+    DIA-NN conversions carry gg_names from the DIA-NN report. Running gene-map
+    with a contaminants-only or GN-stripped FASTA used to overwrite every row
+    with None, which --in-place made unrecoverable.
+    """
+    fasta = _write_fasta(
+        tmp_path,
+        ">sp|P12345|PROT_HUMAN desc PE=1 SV=2\nMKV\n>sp|Q99999|OTHR_HUMAN desc\nMKV\n",
+    )
+    df = pd.DataFrame(
+        {
+            "pg_accessions": [["P12345"], ["Q99999"]],
+            "gg_names": [["BRCA1"], ["TP53"]],
+        }
+    )
+
+    annotated = GeneMappingTransform(fasta).annotate_dataframe(df)
+
+    assert annotated["gg_names"].tolist() == [["BRCA1"], ["TP53"]]
+
+
+def test_annotate_dataframe_overwrites_existing_genes_the_fasta_does_resolve(tmp_path):
+    """Preserving unresolved rows must not stop the FASTA from correcting resolved ones."""
+    fasta = _write_fasta(tmp_path, ">sp|P12345|PROT_HUMAN desc GN=NEWGENE PE=1\nMKV\n")
+    df = pd.DataFrame({"pg_accessions": [["P12345"]], "gg_names": [["STALE"]]})
+
+    annotated = GeneMappingTransform(fasta).annotate_dataframe(df)
+
+    assert annotated["gg_names"].tolist() == [["NEWGENE"]]
+
+
+def test_annotate_dataframe_reports_zero_share_for_a_fasta_without_genes(tmp_path):
+    fasta = _write_fasta(tmp_path, ">sp|P12345|PROT_HUMAN desc PE=1\nMKV\n")
+    transform = GeneMappingTransform(fasta)
+
+    transform.annotate_dataframe(pd.DataFrame({"pg_accessions": [["P12345"]]}))
+
+    assert transform.last_mapped_share == 0.0
+
+
+def test_parse_gene_names_log_counts_only_identifiers_carrying_a_gene(tmp_path, caplog):
+    fasta = _write_fasta(
+        tmp_path,
+        ">sp|P12345|A_HUMAN desc GN=BRCA1\nMKV\n>sp|Q99999|B_HUMAN desc\nMKV\n",
+    )
+    with caplog.at_level("INFO"):
+        GeneMappingTransform(fasta).gene_map
+
+    assert "Parsed gene names for 1/2 protein identifiers" in caplog.text
+
+
+def test_unrecognised_map_by_is_rejected(tmp_path):
+    fasta = _write_fasta(tmp_path, ">sp|P12345|A_HUMAN desc GN=BRCA1\nMKV\n")
+
+    with pytest.raises(ValueError, match="map_by must be one of"):
+        GeneMappingTransform(fasta, map_by="Accession")

--- a/tests/unit/test_gene_mapping.py
+++ b/tests/unit/test_gene_mapping.py
@@ -203,3 +203,52 @@ def test_gene_map_dataset_to_output_folder_leaves_source_untouched(tmp_path):
     assert pq.read_table(out_dir / "openms.pg.parquet").column("gg_names").to_pylist()[0] == ["BRCA1"]
     assert pq.read_table(dataset_dir / "openms.pg.parquet").column("gg_names").to_pylist()[0] == ["GENE1"]
     assert (out_dir / "openms.run.parquet").is_file()
+
+
+def test_gene_map_dataset_copy_preserves_subdirectories(tmp_path):
+    """Sharded / partitioned datasets keep views in subdirectories; the copy must keep them."""
+    from click.testing import CliRunner
+
+    from qpx.cli.main import qpx_main
+
+    dataset_dir = tmp_path / "qpx_output"
+    dataset_dir.mkdir()
+    _write_gene_bundle(dataset_dir, "openms")
+    shard = dataset_dir / "psm_shards"
+    shard.mkdir()
+    (shard / "part-0.parquet").write_bytes(b"shard-payload")
+
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(">sp|P12345|A_HUMAN a OS=Homo sapiens GN=BRCA1 PE=1 SV=2\nMKV\n")
+    out_dir = tmp_path / "annotated"
+
+    result = CliRunner().invoke(
+        qpx_main,
+        [
+            "transform",
+            "gene-map",
+            "--dataset",
+            str(dataset_dir),
+            "--fasta",
+            str(fasta),
+            "--output-folder",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (out_dir / "psm_shards" / "part-0.parquet").read_bytes() == b"shard-payload"
+
+
+def test_annotate_dataframe_handles_an_empty_frame(tmp_path):
+    """An empty view must not divide by zero when logging the mapped share."""
+    import pandas as pd
+
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(">sp|P12345|A_HUMAN a OS=Homo sapiens GN=BRCA1 PE=1 SV=2\nMKV\n")
+    empty = pd.DataFrame({"pg_accessions": []})
+
+    annotated = GeneMappingTransform(fasta).annotate_dataframe(empty)
+
+    assert len(annotated) == 0
+    assert "gg_names" in annotated.columns

--- a/tests/unit/test_gene_mapping.py
+++ b/tests/unit/test_gene_mapping.py
@@ -106,3 +106,100 @@ def test_annotate_dataframe_maps_genes_and_keeps_existing_accessions(tmp_path):
 
     assert annotated["gg_names"].tolist() == [["BRCA1", "TP53"], None]
     assert annotated["gg_accessions"].tolist() == [["NC_000017.11"], None]
+
+
+def _write_gene_bundle(directory, prefix, label="TMT126"):
+    """Write a minimal pg/feature/run dataset whose genes come from the converter."""
+    from qpx.writers import PgWriter, RunWriter
+    from tests.conftest import make_pg_record, make_run_record
+
+    intensities = [{"label": label, "intensity": 100.0}]
+    with FeatureWriter(directory / f"{prefix}.feature.parquet") as writer:
+        writer.write_batch([make_feature_record(intensities=intensities)])
+    with PgWriter(directory / f"{prefix}.pg.parquet") as writer:
+        writer.write_batch([make_pg_record(intensities=intensities)])
+
+    run = make_run_record()
+    run["samples"] = [
+        {
+            "sample_accession": f"{prefix}_{label}",
+            "label": label,
+            "biological_replicate": 1,
+            "technical_replicate": 1,
+        }
+    ]
+    with RunWriter(directory / f"{prefix}.run.parquet") as writer:
+        writer.write_batch([run])
+
+
+def test_gene_map_dataset_annotates_pg_and_refreshes_mudata(tmp_path):
+    """--dataset rewrites the quantification views and rebuilds a stale h5mu."""
+    import mudata as mu
+    from click.testing import CliRunner
+
+    from qpx.cli.main import qpx_main
+    from qpx.mudata import write_dataset_mudata
+
+    dataset_dir = tmp_path / "qpx_output"
+    dataset_dir.mkdir()
+    _write_gene_bundle(dataset_dir, "openms")
+
+    # The converter's own view: genes as the converter wrote them.
+    assert write_dataset_mudata(dataset_dir, "openms") is not None
+    before = mu.read_h5mu(str(dataset_dir / "openms.h5mu"))
+    assert list(before.mod["proteins"].var["gene_name"]) == ["GENE1"]
+    pg_ids_before = pq.read_table(dataset_dir / "openms.pg.parquet").column("pg_id").to_pylist()
+
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(
+        ">sp|P12345|A_HUMAN a OS=Homo sapiens GN=BRCA1 PE=1 SV=2\nMKV\n"
+        ">sp|P12346|B_HUMAN b OS=Homo sapiens GN=TP53 PE=1 SV=2\nMKV\n"
+    )
+
+    result = CliRunner().invoke(
+        qpx_main,
+        ["transform", "gene-map", "--dataset", str(dataset_dir), "--fasta", str(fasta), "--in-place"],
+    )
+
+    assert result.exit_code == 0, result.output
+    pg_table = pq.read_table(dataset_dir / "openms.pg.parquet")
+    assert pg_table.column("gg_names").to_pylist()[0] == ["BRCA1", "TP53"]
+    assert pg_table.column("pg_id").to_pylist() == pg_ids_before
+    assert not (dataset_dir / ".gene_map_tmp").exists()
+
+    after = mu.read_h5mu(str(dataset_dir / "openms.h5mu"))
+    assert list(after.mod["proteins"].var["gene_name"]) == ["BRCA1"]
+
+
+def test_gene_map_dataset_to_output_folder_leaves_source_untouched(tmp_path):
+    """Without --in-place the source dataset is copied, not modified."""
+    from click.testing import CliRunner
+
+    from qpx.cli.main import qpx_main
+
+    dataset_dir = tmp_path / "qpx_output"
+    dataset_dir.mkdir()
+    _write_gene_bundle(dataset_dir, "openms")
+
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(">sp|P12345|A_HUMAN a OS=Homo sapiens GN=BRCA1 PE=1 SV=2\nMKV\n")
+    out_dir = tmp_path / "annotated"
+
+    result = CliRunner().invoke(
+        qpx_main,
+        [
+            "transform",
+            "gene-map",
+            "--dataset",
+            str(dataset_dir),
+            "--fasta",
+            str(fasta),
+            "--output-folder",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert pq.read_table(out_dir / "openms.pg.parquet").column("gg_names").to_pylist()[0] == ["BRCA1"]
+    assert pq.read_table(dataset_dir / "openms.pg.parquet").column("gg_names").to_pylist()[0] == ["GENE1"]
+    assert (out_dir / "openms.run.parquet").is_file()

--- a/tests/unit/test_gene_mapping.py
+++ b/tests/unit/test_gene_mapping.py
@@ -3,7 +3,11 @@
 import pyarrow.parquet as pq
 
 from qpx import Dataset
-from qpx.transforms.gene_mapping import GeneMappingTransform
+from qpx.transforms.gene_mapping import (
+    GeneMappingTransform,
+    _parse_fasta_header,
+    _parse_gene_names_from_fasta,
+)
 from qpx.writers.feature import FeatureWriter
 from tests.conftest import make_feature_record
 
@@ -32,7 +36,7 @@ def test_write_annotated_features_preserves_source_identity(tmp_path, monkeypatc
     dataset = Dataset(source_dir, structures=["feature"])
     fasta = tmp_path / "empty.fasta"
     fasta.touch()
-    transform = GeneMappingTransform(fasta, fetch_accessions=False)
+    transform = GeneMappingTransform(fasta)
     source_frame = dataset.feature.to_df()
     monkeypatch.setattr(transform, "annotate_dataset_features", lambda *_args, **_kwargs: source_frame)
 
@@ -43,3 +47,62 @@ def test_write_annotated_features_preserves_source_identity(tmp_path, monkeypatc
     output = pq.read_table(output_path)
     assert output.column("feature_id").to_pylist() == source.column("feature_id").to_pylist()
     assert output.schema.metadata[b"identity_composite"] == b",".join(field.encode() for field in composite)
+
+
+def test_parse_gene_names_reads_headers_without_biopython(tmp_path):
+    """Gene names come from the FASTA headers alone — no optional dependency."""
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(
+        ">sp|P12345|BRCA1_HUMAN Breast cancer type 1 OS=Homo sapiens GN=BRCA1 PE=1 SV=2\n"
+        "MKVLAA\nGGWSTR\n"
+        ">tr|Q99999|Q99999_HUMAN Uncharacterized protein OS=Homo sapiens PE=4 SV=1\n"
+        "MKV\n"
+        ">CONTAM_TRYP_PIG Trypsin\n"
+        "MKV\n"
+    )
+
+    gene_map = _parse_gene_names_from_fasta(str(fasta))
+
+    assert gene_map["P12345"] == {"BRCA1"}
+    assert gene_map["Q99999"] == {None}
+    assert gene_map["CONTAM_TRYP_PIG"] == {None}
+
+
+def test_parse_gene_names_reads_gzipped_fasta(tmp_path):
+    """A gzip-compressed FASTA is opened transparently."""
+    import gzip
+
+    fasta = tmp_path / "db.fasta.gz"
+    with gzip.open(fasta, "wt") as handle:
+        handle.write(">sp|P12345|PROT_HUMAN Some protein OS=Homo sapiens GN=TP53 PE=1 SV=2\nMKV\n")
+
+    assert _parse_gene_names_from_fasta(str(fasta))["P12345"] == {"TP53"}
+
+
+def test_parse_fasta_header_handles_each_identifier_shape():
+    """UniProt three-field, two-field and bare identifiers all resolve."""
+    assert _parse_fasta_header(">sp|P12345|PROT_HUMAN d GN=BRCA1 PE=1") == ("P12345", "PROT_HUMAN", "BRCA1")
+    assert _parse_fasta_header(">sp|P12345 description") == ("P12345", "P12345", None)
+    assert _parse_fasta_header(">CONTAM_ALBU Albumin GN=ALB") == ("CONTAM_ALBU", "CONTAM_ALBU", "ALB")
+
+
+def test_annotate_dataframe_maps_genes_and_keeps_existing_accessions(tmp_path):
+    """gg_names is filled from the FASTA; gg_accessions written by a converter survives."""
+    import pandas as pd
+
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(
+        ">sp|P12345|A_HUMAN a OS=Homo sapiens GN=BRCA1 PE=1 SV=2\nMKV\n"
+        ">sp|P12346|B_HUMAN b OS=Homo sapiens GN=TP53 PE=1 SV=2\nMKV\n"
+    )
+    df = pd.DataFrame(
+        {
+            "pg_accessions": [["P12345", "P12346"], ["P00000"]],
+            "gg_accessions": [["NC_000017.11"], None],
+        }
+    )
+
+    annotated = GeneMappingTransform(fasta).annotate_dataframe(df)
+
+    assert annotated["gg_names"].tolist() == [["BRCA1", "TP53"], None]
+    assert annotated["gg_accessions"].tolist() == [["NC_000017.11"], None]

--- a/tests/unit/test_mudata.py
+++ b/tests/unit/test_mudata.py
@@ -682,3 +682,44 @@ class TestArrowPivotEquivalence:
         assert list(arrow_index) == list(pandas_index)
         assert list(arrow_keys["run_file_name"]) == list(pandas_keys["run_file_name"])
         assert list(arrow_keys["intensity_label"]) == list(pandas_keys["intensity_label"])
+
+
+def test_protein_var_gene_names_serialise_when_every_gene_is_null(tmp_path):
+    """All-NULL gg_names must still write to h5mu.
+
+    TMT datasets whose consensusXML carries no GN= descriptions come back with
+    gg_names NULL on every row, so the gene_name column is inferred as float64
+    (all NaN) and h5py refuses it: "Can't implicitly convert non-string objects
+    to strings" (seen on MSV000085836, 4.89M protein rows).
+    """
+    with FeatureWriter(tmp_path / "g.feature.parquet") as writer:
+        writer.write_batch([make_feature_record(intensities=[{"label": "TMT126", "intensity": 10.0}])])
+
+    pg = make_pg_record(intensities=[{"label": "TMT126", "intensity": 100.0}])
+    pg["gg_names"] = None
+    with PgWriter(tmp_path / "g.pg.parquet") as writer:
+        writer.write_batch([pg])
+
+    run = make_run_record()
+    run["samples"] = [
+        {
+            "sample_accession": "g_TMT126",
+            "label": "TMT126",
+            "biological_replicate": 1,
+            "technical_replicate": 1,
+        }
+    ]
+    with RunWriter(tmp_path / "g.run.parquet") as writer:
+        writer.write_batch([run])
+
+    dataset = Dataset(tmp_path, file_prefix="g")
+    try:
+        mdata = build_mudata(dataset, intensity_label="TMT126", modalities=["proteins"])
+        gene_names = mdata.mod["proteins"].var["gene_name"]
+        assert list(gene_names) == [""]
+        assert all(isinstance(value, str) for value in gene_names)
+        mdata.write(str(tmp_path / "g.h5mu"))
+    finally:
+        dataset.close()
+
+    assert (tmp_path / "g.h5mu").exists()


### PR DESCRIPTION
This pull request makes significant improvements to the gene mapping transform and its integration with QPX datasets. The main changes are the removal of optional dependencies and network lookups for gene mapping, a new dataset-wide annotation mode, and improved reliability when updating MuData views. Documentation and packaging are also updated to reflect these changes.

**Gene mapping transform improvements:**

* The gene mapping transform now reads gene names directly from the `GN=` field in the provided FASTA file, eliminating the need for the `biopython` and `mygene` dependencies and removing all network lookups [[1]](diffhunk://#diff-320588d8f26f27eac92b98713dd6fda51de13d42d06066797b1be4ddc1f760e4L3-R5) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR18-R19) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L37-R40).
* The CLI for `qpxc transform gene-map` is extended with a `--dataset` option to annotate all relevant views in a QPX dataset, updating both `pg` and `feature` files and refreshing the MuData (`.h5mu`) view safely, with all writes staged to avoid truncation of files in use [[1]](diffhunk://#diff-4cba6b9fd56f5c7501b3f7799cd87c6a2e3793cb46a4395e26870c83342940b9R33-R65) [[2]](diffhunk://#diff-4cba6b9fd56f5c7501b3f7799cd87c6a2e3793cb46a4395e26870c83342940b9L49-L88) [[3]](diffhunk://#diff-4cba6b9fd56f5c7501b3f7799cd87c6a2e3793cb46a4395e26870c83342940b9R138-R235) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR28-R29).

**MuData view handling:**

* The logic for rebuilding the MuData (`.h5mu`) view is extracted into a new function `write_dataset_mudata`, which is now used both by converters and by transform commands, ensuring that MuData is always consistent with the underlying Parquet files [[1]](diffhunk://#diff-fe8260eef28062606967a8ed981b486b34bfe782de37231fbb468494a67deedcR847-R911) [[2]](diffhunk://#diff-4e83306615966ac583b821deedf9706289cef99477771659f9359b515afd98a6R134-R140).

**Dependency and packaging cleanup:**

* The `[transforms]` optional extra and its dependencies (`biopython`, `mygene`) are removed from all packaging and environment files since gene mapping no longer requires them [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L37-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55) [[3]](diffhunk://#diff-01ba4c5fb78fba91121577b4b9db5c2eaa3b47ecdafe316ab1d2cc045f460a5cL14) [[4]](diffhunk://#diff-9efd195f4e9bfb79ccd456a1d8370fafcc4bcb0b00ea3799222667d2ae818533L22-L23).

**Documentation updates:**

* The documentation and CLI help are updated to reflect the new gene mapping behavior, removal of the `--species` option, and the new dataset annotation mode [[1]](diffhunk://#diff-c8772ae71c9f09a71c8cac3cb29c4c30895289a1bbc15d97d684452e79f52331L142-R148) [[2]](diffhunk://#diff-c8772ae71c9f09a71c8cac3cb29c4c30895289a1bbc15d97d684452e79f52331L160-R160) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR28-R29).

**Other improvements:**

* The gene mapping logic is simplified and clarified, and the handling of missing gene names is improved to ensure compatibility with downstream tools.

**References:** [[1]](diffhunk://#diff-320588d8f26f27eac92b98713dd6fda51de13d42d06066797b1be4ddc1f760e4L3-R5) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR18-R19) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L37-R40) [[4]](diffhunk://#diff-4cba6b9fd56f5c7501b3f7799cd87c6a2e3793cb46a4395e26870c83342940b9R33-R65) [[5]](diffhunk://#diff-fe8260eef28062606967a8ed981b486b34bfe782de37231fbb468494a67deedcR847-R911)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `gene-map` can annotate complete datasets, including protein-group and feature data.
  * Added in-place updates and separate output-folder options.
  * Gene names are read directly from plain or compressed FASTA headers.

* **Changes**
  * Removed the `--species` option and external gene-lookup behavior.
  * The optional transforms installation extras are no longer available.
  * Updated documentation and installation guidance.

* **Bug Fixes**
  * Improved dataset copying, metadata handling, and MuData rebuilding.
  * Added validation for conflicting or unsafe output paths.
  * Fixed empty-dataset reporting and serialization when gene names are missing.
  * Updated integration tests for current DIA-NN options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->