### PR TITLE
fix(gene-map): copy dataset subdirectories and guard the destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`gene-map --dataset` copied only top-level files** — sharded / partitioned datasets kept their views in subdirectories, so an annotated copy came back incomplete. Subdirectories are now copied too, and a `--output-folder` that is the dataset itself or nested inside it is rejected instead of copying into its own destination.
+- **`gene-map` accepted `--in-place` together with `--output-folder`** — the destination silently won; it is now a usage error.
+- **`annotate_dataframe` divided by zero on an empty view** — the mapped-share log now reports 0.0%.
+
 - **Ontology PK uniqueness**: ontology writes collapse to one row per `(field_name, view)` (first-wins) when a field is both a discovered score and a mapped field.
 - **DIA-NN blank `anchor_protein`**: empty/whitespace first accession from `Protein.Group` is written as NULL; validators treat blank anchors as unset.
 

--- a/docs/guide/transform.md
+++ b/docs/guide/transform.md
@@ -148,11 +148,26 @@ qpxc transform gene-map \
     --output-folder ./output
 ```
 
+#### Annotating a Whole Dataset {#gene-map-example-dataset}
+
+```bash
+qpxc transform gene-map \
+    --dataset ./qpx_output \
+    --fasta tests/examples/fasta/Homo-sapiens.fasta \
+    --in-place
+```
+
+Every quantification view that carries protein accessions (`pg` and `feature`) is
+annotated, and the dataset's MuData view is rebuilt when one is present, so the
+`.h5mu` never describes stale genes. Pass `--output-folder` instead of `--in-place`
+to write an annotated copy and leave the source dataset untouched.
+
 ### Output Files {#gene-map-output}
 
 - **Output**: Enhanced parquet file(s) with gene information
 - **Format**: Parquet file in output folder
 - **Added Fields**: Gene names and metadata from FASTA headers
+- **Dataset mode**: annotated `pg` + `feature` views, plus a rebuilt `.h5mu` when the dataset has one
 
 ### Best Practices {#gene-map-best-practices}
 

--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -43,6 +43,14 @@ def _validate_gene_map_inputs(
         raise click.UsageError("--output-folder is required with --parquet-path")
     if dataset is not None and not in_place and output_folder is None:
         raise click.UsageError("Specify --in-place or --output-folder with --dataset")
+    if dataset is not None and in_place and output_folder is not None:
+        raise click.UsageError("Specify either --in-place or --output-folder with --dataset, not both")
+    if dataset is not None and output_folder is not None:
+        source, destination = dataset.resolve(), output_folder.resolve()
+        if destination == source:
+            raise click.UsageError("--output-folder is the dataset itself; use --in-place")
+        if source in destination.parents:
+            raise click.UsageError("--output-folder must not be inside the dataset directory")
 
 
 @transform.command("gene-map")
@@ -141,8 +149,13 @@ def _copy_dataset_files(dataset: Path, out_dir: Path) -> None:
 
     out_dir.mkdir(parents=True, exist_ok=True)
     for path in dataset.iterdir():
-        if path.is_file():
-            shutil.copy2(path, out_dir / path.name)
+        target = out_dir / path.name
+        if path.is_dir():
+            # Sharded / partitioned datasets keep views in subdirectories; copying
+            # only the top-level files would hand back an incomplete dataset.
+            shutil.copytree(path, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(path, target)
 
 
 def _annotate_dataset_views(

--- a/qpx/transforms/gene_mapping.py
+++ b/qpx/transforms/gene_mapping.py
@@ -274,11 +274,12 @@ class GeneMappingTransform:
             result["gg_accessions"] = None
 
         n_mapped = result["gg_names"].notna().sum()
+        mapped_share = n_mapped / len(result) * 100 if len(result) else 0.0
         logger.info(
             "Mapped gene names for %d/%d rows (%.1f%%)",
             n_mapped,
             len(result),
-            n_mapped / len(result) * 100,
+            mapped_share,
         )
         return result
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -112,6 +112,29 @@ class TestTransformGeneMapCLI:
         assert both.exit_code != 0
         assert "exactly one of --parquet-path or --dataset" in both.output
 
+    def test_gene_map_dataset_rejects_conflicting_destinations(self, tmp_path):
+        """--in-place and --output-folder together, or a destination inside the source."""
+        fasta = tmp_path / "db.fasta"
+        fasta.write_text(">sp|P12345|A_HUMAN a GN=BRCA1\nMKV\n")
+        data = tmp_path / "qpx_output"
+        data.mkdir()
+        (data / "openms.pg.parquet").touch()
+        runner = CliRunner()
+
+        base = ["transform", "gene-map", "--fasta", str(fasta), "--dataset", str(data)]
+
+        both = runner.invoke(qpx_main, base + ["--in-place", "--output-folder", str(tmp_path / "out")])
+        assert both.exit_code != 0
+        assert "not both" in both.output
+
+        same = runner.invoke(qpx_main, base + ["--output-folder", str(data)])
+        assert same.exit_code != 0
+        assert "use --in-place" in same.output
+
+        nested = runner.invoke(qpx_main, base + ["--output-folder", str(data / "annotated")])
+        assert nested.exit_code != 0
+        assert "must not be inside the dataset" in nested.output
+
     def test_gene_map_dataset_requires_a_destination(self, tmp_path):
         fasta = tmp_path / "db.fasta"
         fasta.write_text(">sp|P12345|A_HUMAN a GN=BRCA1\nMKV\n")

--- a/tests/unit/test_gene_mapping.py
+++ b/tests/unit/test_gene_mapping.py
@@ -203,3 +203,52 @@ def test_gene_map_dataset_to_output_folder_leaves_source_untouched(tmp_path):
     assert pq.read_table(out_dir / "openms.pg.parquet").column("gg_names").to_pylist()[0] == ["BRCA1"]
     assert pq.read_table(dataset_dir / "openms.pg.parquet").column("gg_names").to_pylist()[0] == ["GENE1"]
     assert (out_dir / "openms.run.parquet").is_file()
+
+
+def test_gene_map_dataset_copy_preserves_subdirectories(tmp_path):
+    """Sharded / partitioned datasets keep views in subdirectories; the copy must keep them."""
+    from click.testing import CliRunner
+
+    from qpx.cli.main import qpx_main
+
+    dataset_dir = tmp_path / "qpx_output"
+    dataset_dir.mkdir()
+    _write_gene_bundle(dataset_dir, "openms")
+    shard = dataset_dir / "psm_shards"
+    shard.mkdir()
+    (shard / "part-0.parquet").write_bytes(b"shard-payload")
+
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(">sp|P12345|A_HUMAN a OS=Homo sapiens GN=BRCA1 PE=1 SV=2\nMKV\n")
+    out_dir = tmp_path / "annotated"
+
+    result = CliRunner().invoke(
+        qpx_main,
+        [
+            "transform",
+            "gene-map",
+            "--dataset",
+            str(dataset_dir),
+            "--fasta",
+            str(fasta),
+            "--output-folder",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (out_dir / "psm_shards" / "part-0.parquet").read_bytes() == b"shard-payload"
+
+
+def test_annotate_dataframe_handles_an_empty_frame(tmp_path):
+    """An empty view must not divide by zero when logging the mapped share."""
+    import pandas as pd
+
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(">sp|P12345|A_HUMAN a OS=Homo sapiens GN=BRCA1 PE=1 SV=2\nMKV\n")
+    empty = pd.DataFrame({"pg_accessions": []})
+
+    annotated = GeneMappingTransform(fasta).annotate_dataframe(empty)
+
+    assert len(annotated) == 0
+    assert "gg_names" in annotated.columns


### PR DESCRIPTION
Addresses the three CodeRabbit findings on #313.

## Fixes

1. **Subdirectories were dropped.** `_copy_dataset_files` copied only top-level files, so a sharded / partitioned dataset annotated with `--output-folder` came back **missing the views kept in subdirectories** — silent data loss. Now copied with `copytree(..., dirs_exist_ok=True)`.
2. **Unsafe destinations.** `--output-folder` pointing at the dataset itself, or nested inside it, was accepted — the latter making the copy walk into its own destination. Both are now usage errors, as is passing `--in-place` **and** `--output-folder` together (the destination was previously ignored without a word).
3. **Division by zero.** `annotate_dataframe` computed `n_mapped / len(result)` for the mapped-share log, raising `ZeroDivisionError` on an empty view. Reports `0.0%` instead.

## Also

Documents `--dataset` in the transform guide — the new mode and its h5mu refresh had no example, only the single-file ones.

## Tests

Three new regression tests: subdirectory contents survive the copy, each rejected destination combination raises, and an empty frame annotates cleanly. Full suite: 267 passed.