### PR TITLE
fix(gene-map): keep gene names the FASTA cannot resolve

### DIFF
--- a/qpx/cli/transform.py
+++ b/qpx/cli/transform.py
@@ -189,6 +189,11 @@ def _annotate_dataset_views(
             continue
         name = f"{prefix}.{view}.parquet"
         write_view(qpx_dataset, staging / name)
+        share = mapping.last_mapped_share
+        if share is not None:
+            click.echo(f"  {name}: {share:.1f}% of rows matched a gene in the FASTA")
+            if share == 0.0:
+                click.echo(f"  WARNING: the FASTA resolved no genes for {view}; existing gene names were kept unchanged")
         written.append((staging / name, out_dir / name))
     return written
 

--- a/qpx/transforms/gene_mapping.py
+++ b/qpx/transforms/gene_mapping.py
@@ -37,6 +37,10 @@ logger = logging.getLogger(__name__)
 
 _GENE_NAME_RE = re.compile(r"\bGN=(\S+)")
 
+# "both" keys the map by accession AND entry name; it was previously reachable
+# only by passing an unrecognised value, which made a typo silently change mode.
+_MAP_BY_CHOICES = frozenset({"accession", "name", "both"})
+
 
 def _parse_fasta_header(header: str) -> tuple[str, str, Optional[str]]:
     """Split one FASTA header line into (accession, entry name, gene name).
@@ -92,15 +96,26 @@ def _parse_gene_names_from_fasta(
             accession, name, gene_name = _parse_fasta_header(line)
 
             if map_by == "accession":
-                gene_map[accession].add(gene_name)
+                keys = (accession,)
             elif map_by == "name":
-                gene_map[name].add(gene_name)
+                keys = (name,)
             else:
                 # Map by both accession and name for maximum matching
-                gene_map[accession].add(gene_name)
-                gene_map[name].add(gene_name)
+                keys = (accession, name)
+            for key in keys:
+                gene_map[key].add(gene_name)
 
-    logger.info("Parsed gene names for %d protein identifiers from %s", len(gene_map), fasta_path)
+    # Count identifiers that actually carry a gene, not every header parsed. The
+    # old count included GN-less entries, so a FASTA yielding no genes at all
+    # still reported "Parsed gene names for N" — the opposite of the truth, on
+    # the one line a caller would check before overwriting annotations.
+    with_gene = sum(1 for names in gene_map.values() if any(n is not None for n in names))
+    logger.info(
+        "Parsed gene names for %d/%d protein identifiers from %s",
+        with_gene,
+        len(gene_map),
+        fasta_path,
+    )
     return gene_map
 
 
@@ -219,10 +234,20 @@ class GeneMappingTransform:
         if not self._fasta_path.exists():
             raise FileNotFoundError(f"FASTA file not found: {fasta_path}")
 
+        if map_by not in _MAP_BY_CHOICES:
+            raise ValueError(f"map_by must be one of {sorted(_MAP_BY_CHOICES)}, got {map_by!r}")
         self._map_by = map_by
 
         # Lazily computed
         self._gene_map: Optional[dict[str, set[str]]] = None
+        # Share of rows the last annotate_dataframe call resolved from the FASTA,
+        # so callers can surface a zero-yield run instead of silently writing one.
+        self._last_mapped_share: Optional[float] = None
+
+    @property
+    def last_mapped_share(self) -> Optional[float]:
+        """Percentage of rows the most recent annotation resolved from the FASTA."""
+        return self._last_mapped_share
 
     @property
     def gene_map(self) -> dict[str, set[str]]:
@@ -263,24 +288,38 @@ class GeneMappingTransform:
         gene_map = self.gene_map
 
         # Map protein accessions to gene names
-        result["gg_names"] = result[protein_col].apply(
+        mapped = result[protein_col].apply(
             lambda accessions: _resolve_gene_names(
                 _normalize_protein_list(accessions),
                 gene_map,
             )
         )
 
+        # A FASTA the accession is absent from says nothing about that protein's
+        # gene — it is not evidence the gene is unknown. Overwriting regardless
+        # wiped every gg_names a converter had already written (DIA-NN reports
+        # carry them) whenever the FASTA lacked GN= fields, and --in-place made
+        # that unrecoverable. Only rows that actually resolved are replaced.
+        if "gg_names" in result.columns:
+            existing = result["gg_names"]
+            result["gg_names"] = [
+                new_names if new_names is not None else old_names for new_names, old_names in zip(mapped, existing, strict=True)
+            ]
+        else:
+            result["gg_names"] = mapped
+
         if "gg_accessions" not in result.columns:
             result["gg_accessions"] = None
 
-        n_mapped = result["gg_names"].notna().sum()
+        n_mapped = int(mapped.notna().sum())
         mapped_share = n_mapped / len(result) * 100 if len(result) else 0.0
         logger.info(
-            "Mapped gene names for %d/%d rows (%.1f%%)",
+            "Mapped gene names from FASTA for %d/%d rows (%.1f%%)",
             n_mapped,
             len(result),
             mapped_share,
         )
+        self._last_mapped_share = mapped_share
         return result
 
     def annotate_dataset_features(

--- a/tests/unit/test_gene_mapping.py
+++ b/tests/unit/test_gene_mapping.py
@@ -1,6 +1,8 @@
 """Regression tests for identity-preserving gene annotation writes."""
 
+import pandas as pd
 import pyarrow.parquet as pq
+import pytest
 
 from qpx import Dataset
 from qpx.transforms.gene_mapping import (
@@ -252,3 +254,69 @@ def test_annotate_dataframe_handles_an_empty_frame(tmp_path):
 
     assert len(annotated) == 0
     assert "gg_names" in annotated.columns
+
+
+def _write_fasta(tmp_path, text):
+    fasta = tmp_path / "db.fasta"
+    fasta.write_text(text)
+    return fasta
+
+
+def test_annotate_dataframe_keeps_existing_genes_the_fasta_cannot_resolve(tmp_path):
+    """A FASTA without GN= must not erase gene names a converter already wrote.
+
+    DIA-NN conversions carry gg_names from the DIA-NN report. Running gene-map
+    with a contaminants-only or GN-stripped FASTA used to overwrite every row
+    with None, which --in-place made unrecoverable.
+    """
+    fasta = _write_fasta(
+        tmp_path,
+        ">sp|P12345|PROT_HUMAN desc PE=1 SV=2\nMKV\n>sp|Q99999|OTHR_HUMAN desc\nMKV\n",
+    )
+    df = pd.DataFrame(
+        {
+            "pg_accessions": [["P12345"], ["Q99999"]],
+            "gg_names": [["BRCA1"], ["TP53"]],
+        }
+    )
+
+    annotated = GeneMappingTransform(fasta).annotate_dataframe(df)
+
+    assert annotated["gg_names"].tolist() == [["BRCA1"], ["TP53"]]
+
+
+def test_annotate_dataframe_overwrites_existing_genes_the_fasta_does_resolve(tmp_path):
+    """Preserving unresolved rows must not stop the FASTA from correcting resolved ones."""
+    fasta = _write_fasta(tmp_path, ">sp|P12345|PROT_HUMAN desc GN=NEWGENE PE=1\nMKV\n")
+    df = pd.DataFrame({"pg_accessions": [["P12345"]], "gg_names": [["STALE"]]})
+
+    annotated = GeneMappingTransform(fasta).annotate_dataframe(df)
+
+    assert annotated["gg_names"].tolist() == [["NEWGENE"]]
+
+
+def test_annotate_dataframe_reports_zero_share_for_a_fasta_without_genes(tmp_path):
+    fasta = _write_fasta(tmp_path, ">sp|P12345|PROT_HUMAN desc PE=1\nMKV\n")
+    transform = GeneMappingTransform(fasta)
+
+    transform.annotate_dataframe(pd.DataFrame({"pg_accessions": [["P12345"]]}))
+
+    assert transform.last_mapped_share == 0.0
+
+
+def test_parse_gene_names_log_counts_only_identifiers_carrying_a_gene(tmp_path, caplog):
+    fasta = _write_fasta(
+        tmp_path,
+        ">sp|P12345|A_HUMAN desc GN=BRCA1\nMKV\n>sp|Q99999|B_HUMAN desc\nMKV\n",
+    )
+    with caplog.at_level("INFO"):
+        GeneMappingTransform(fasta).gene_map
+
+    assert "Parsed gene names for 1/2 protein identifiers" in caplog.text
+
+
+def test_unrecognised_map_by_is_rejected(tmp_path):
+    fasta = _write_fasta(tmp_path, ">sp|P12345|A_HUMAN desc GN=BRCA1\nMKV\n")
+
+    with pytest.raises(ValueError, match="map_by must be one of"):
+        GeneMappingTransform(fasta, map_by="Accession")


### PR DESCRIPTION
Found while reviewing #313 before merging it into `main`.

## The bug

`annotate_dataframe` assigned `gg_names` unconditionally:

```python
result["gg_names"] = result[protein_col].apply(lambda a: _resolve_gene_names(...))
```

`_resolve_gene_names` returns `None` when nothing matches, so every row the FASTA did not resolve was overwritten with `None`.

This is not hypothetical. DIA-NN conversions already carry `gg_names` from the DIA-NN report. Reproduced against `dev` with a FASTA that has no `GN=` fields:

```
BEFORE gg_names: [['BRCA1'], ['TP53']]
AFTER  gg_names: [None, None]
```

Point `gene-map --dataset ... --in-place` at a contaminants-only, non-UniProt or GN-stripped FASTA and every gene name in the dataset is destroyed, with no backup and no prompt.

It was also inconsistent with `gg_accessions`, which the same function already preserves deliberately — the docstring explains that a FASTA carrying no genomic accessions is not evidence about them. The same reasoning applies to a gene name the FASTA cannot speak to.

## Why it was invisible

- The mapping rate was `logger.info`, and the CLI only raises the level under `--verbose`, so dataset mode printed just `pg.parquet: updated`. It is now echoed per view, with an explicit warning when nothing resolved.
- `Parsed gene names for N protein identifiers` counted every header, including GN-less ones, because the parser stores `None` in the gene set. A FASTA yielding no genes still reported a healthy `N` — the opposite of the truth, on the one line a caller would check before overwriting. Now reports `with_gene/total`:

```
INFO Parsed gene names for 1/2 protein identifiers from ...
```

## Also

Reject an unrecognised `map_by` instead of silently falling through to the undocumented both-keys mode, where a typo like `"Accession"` changed behaviour.

## Tests

Four new regression tests; all four fail on `dev` and pass here. A companion test asserts a resolvable FASTA still overwrites a stale gene, so preserving unresolved rows does not disable the transform's purpose.

Full `tests/unit` + `tests/cli` suite passes (272), pre-commit clean.

Suggest merging this before #313, since #313 is the release into `main` and that build is what the stuck MSV000085836 rerun will resume on.